### PR TITLE
Allow offsets and transitions to be retrieved from Timezone

### DIFF
--- a/lib/tzinfo/data_timezone.rb
+++ b/lib/tzinfo/data_timezone.rb
@@ -24,7 +24,17 @@ module TZInfo
 
   # A Timezone based on a DataTimezoneInfo.
   class DataTimezone < InfoTimezone #:nodoc:
-    
+
+    # Returns array of all TimezoneOffsetInfo for this Timezone.
+    def all_offsets
+      info.offsets.values
+    end
+
+    # Returns array of all TimezoneTransitionInfo for this Timezone.
+    def all_transitions
+      info.transitions.freeze
+    end
+
     # Returns the TimezonePeriod for the given UTC time. utc can either be
     # a DateTime, Time or integer timestamp (Time.to_i). Any timezone 
     # information in utc is ignored (it is treated as a UTC time).        

--- a/lib/tzinfo/data_timezone_info.rb
+++ b/lib/tzinfo/data_timezone_info.rb
@@ -23,7 +23,17 @@
 module TZInfo
   # Represents a defined timezone containing transition data.
   class DataTimezoneInfo < TimezoneInfo  
-  
+
+    # Returns hash with offset_id as key and instances of TimezoneOffsetInfo as values.
+    def offsets
+      raise NotImplementedError, 'Subclasses must override offsets'
+    end
+
+    # Returns array of all Transitions (instances of TimezoneTransitionInfo) for this Timezone.
+    def transitions
+      raise NotImplementedError, 'Subclasses must override transitions'
+    end
+
     # Returns the TimezonePeriod for the given UTC time.
     def period_for_utc(utc)
       raise NotImplementedError, 'Subclasses must override period_for_utc'

--- a/lib/tzinfo/linked_timezone.rb
+++ b/lib/tzinfo/linked_timezone.rb
@@ -23,6 +23,17 @@
 module TZInfo
 
   class LinkedTimezone < InfoTimezone #:nodoc:
+
+    # Returns array of all TimezoneOffsetInfo for this Timezone.
+    def all_offsets
+      @linked_timezone.all_offsets
+    end
+
+    # Returns array of all TimezoneTransitionInfo for this Timezone.
+    def all_transitions
+      @linked_timezone.all_transitions
+    end
+
     # Returns the TimezonePeriod for the given UTC time. utc can either be
     # a DateTime, Time or integer timestamp (Time.to_i). Any timezone 
     # information in utc is ignored (it is treated as a UTC time).        

--- a/lib/tzinfo/timezone.rb
+++ b/lib/tzinfo/timezone.rb
@@ -276,7 +276,17 @@ module TZInfo
         result
       end
     end
-    
+
+    # Returns array of all TimezoneOffsetInfo for this Timezone.
+    def all_offsets
+      raise UnknownTimezone, 'TZInfo::Timezone constructed directly'
+    end
+
+    # Returns array of all TimezoneTransitionInfo for this Timezone.
+    def all_transitions
+      raise UnknownTimezone, 'TZInfo::Timezone constructed directly'
+    end
+
     # Returns the TimezonePeriod for the given UTC time. utc can either be
     # a DateTime, Time or integer timestamp (Time.to_i). Any timezone 
     # information in utc is ignored (it is treated as a UTC time).        

--- a/lib/tzinfo/timezone_offset_info.rb
+++ b/lib/tzinfo/timezone_offset_info.rb
@@ -22,7 +22,7 @@
 
 module TZInfo
   # Represents an offset defined in a Timezone data file.
-  class TimezoneOffsetInfo #:nodoc:
+  class TimezoneOffsetInfo
     # The base offset of the timezone from UTC in seconds.
     attr_reader :utc_offset
     

--- a/lib/tzinfo/timezone_proxy.rb
+++ b/lib/tzinfo/timezone_proxy.rb
@@ -44,7 +44,17 @@ module TZInfo
     def identifier
       @real_timezone ? @real_timezone.identifier : @identifier
     end
-    
+
+    # Returns array of all TimezoneOffsetInfo for this Timezone.
+    def all_offsets
+      real_timezone.all_offsets
+    end
+
+    # Returns array of all TimezoneTransitionInfo for this Timezone.
+    def all_transitions
+      real_timezone.all_transitions
+    end
+
     # Returns the TimezonePeriod for the given UTC time. utc can either be
     # a DateTime, Time or integer timestamp (Time.to_i). Any timezone 
     # information in utc is ignored (it is treated as a UTC time).        

--- a/lib/tzinfo/timezone_transition_info.rb
+++ b/lib/tzinfo/timezone_transition_info.rb
@@ -25,7 +25,7 @@ require 'date'
 module TZInfo
   # Represents an transition from one timezone offset to another at a particular
   # date and time.
-  class TimezoneTransitionInfo #:nodoc:
+  class TimezoneTransitionInfo
     # The offset this transition changes to (a TimezoneOffsetInfo instance).
     attr_reader :offset
     

--- a/lib/tzinfo/transition_data_timezone_info.rb
+++ b/lib/tzinfo/transition_data_timezone_info.rb
@@ -29,7 +29,12 @@ module TZInfo
   # Represents a data timezone defined by a set of offsets and a set 
   # of transitions
   class TransitionDataTimezoneInfo < DataTimezoneInfo #:nodoc:
-            
+    # Hash with offset_id as key and instances of TimezoneOffsetInfo as values.
+    attr_reader :offsets
+
+    # Array of all Transitions (instances of TimezoneTransitionInfo) for this Timezone.
+    attr_reader :transitions
+
     # Constructs a new TransitionDataTimezoneInfo with its identifier.
     def initialize(identifier)   
       super(identifier)


### PR DESCRIPTION
There wasn't any way to get all offsets nor transitions so I added these methods.

Now it's possible to do so
`TZInfo::Timezone.get("Europe/Paris").all_offsets` which will return array of `TimezoneOffsetInfo`'s
