### PR TITLE
"require 'rational'" has been deprecated. So require rational only when the Rational module has not already been loaded

### DIFF
--- a/lib/tzinfo/time_or_datetime.rb
+++ b/lib/tzinfo/time_or_datetime.rb
@@ -22,7 +22,7 @@
 
 
 require 'date'
-require 'rational'
+require 'rational' unless defined?(Rational)
 require 'time'
 
 module TZInfo


### PR DESCRIPTION
This eliminates a Ruby warning in recent versions of Ruby.

see: e0278964938ea346b2bf5237857e8656c2ca754d
