### PR TITLE
Eliminate "warning: assigned but unused variable - info"

### DIFF
--- a/lib/tzinfo/ruby_data_source.rb
+++ b/lib/tzinfo/ruby_data_source.rb
@@ -60,7 +60,7 @@ module TZInfo
           m = m.const_get(part)
         }
         
-        info = m.get
+        m.get
       rescue LoadError, NameError => e
         raise InvalidTimezoneIdentifier, e.message
       end


### PR DESCRIPTION
Simply eliminates a Ruby warning.
