### PR TITLE
use File.exist? instead of File.exists?

### DIFF
--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -47,7 +47,7 @@ module TestUtils
     ZONEINFO_SYMLINKS.each do |file, target|
       path = File.join(TZINFO_TEST_ZONEINFO_DIR, file)
       
-      File.delete(path) if File.exists?(path)
+      File.delete(path) if File.exist?(path)
     
       begin
         FileUtils.ln_s(target, path)


### PR DESCRIPTION
Ruby 2.1.0 warned follow message:

```
/path/to/tzinfo/test/test_utils.rb:50: warning: File.exists? is a deprecated name, use File.exist? instead
```

I fixed it.
