### PR TITLE
Update to Minitest 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,8 @@ gemspec
 
 group :test do
   gem 'rake'
-  
+  gem 'minitest', '>= 5.0.0'
+
   platforms :rbx do
     gem 'rubysl-test-unit', '~> 2.0'
   end

--- a/test/tc_country.rb
+++ b/test/tc_country.rb
@@ -25,7 +25,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 
 include TZInfo
 
-class TCCountry < Test::Unit::TestCase
+class TCCountry < Minitest::Test
   def setup
     @orig_data_source = DataSource.get
     Country.send :init_countries

--- a/test/tc_country_index_definition.rb
+++ b/test/tc_country_index_definition.rb
@@ -25,7 +25,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 
 include TZInfo
 
-class TCCountryIndexDefinition < Test::Unit::TestCase
+class TCCountryIndexDefinition < Minitest::Test
 
   module CountriesTest1     
     include CountryIndexDefinition

--- a/test/tc_country_info.rb
+++ b/test/tc_country_info.rb
@@ -25,7 +25,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 
 include TZInfo
 
-class TCCountryInfo < Test::Unit::TestCase
+class TCCountryInfo < Minitest::Test
   
   def test_code
     ci = CountryInfo.new('ZZ', 'Zzz') {|c| }

--- a/test/tc_country_timezone.rb
+++ b/test/tc_country_timezone.rb
@@ -25,7 +25,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 
 include TZInfo
 
-class TCCountryTimezone < Test::Unit::TestCase
+class TCCountryTimezone < Minitest::Test
   def test_identifier
     ct = CountryTimezone.new('Europe/London', 2059, 40, -5, 16)    
     assert_equal('Europe/London', ct.identifier)

--- a/test/tc_data_source.rb
+++ b/test/tc_data_source.rb
@@ -26,7 +26,7 @@ require 'tmpdir'
 
 include TZInfo
 
-class TCDataSource < Test::Unit::TestCase
+class TCDataSource < Minitest::Test
   class InitDataSource < DataSource
   end
   

--- a/test/tc_data_timezone.rb
+++ b/test/tc_data_timezone.rb
@@ -25,7 +25,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 
 include TZInfo
 
-class TCDataTimezone < Test::Unit::TestCase
+class TCDataTimezone < Minitest::Test
   
   class TestTimezoneInfo < TimezoneInfo
     attr_reader :utc

--- a/test/tc_data_timezone_info.rb
+++ b/test/tc_data_timezone_info.rb
@@ -25,7 +25,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 
 include TZInfo
 
-class TCDataTimezoneInfo < Test::Unit::TestCase
+class TCDataTimezoneInfo < Minitest::Test
   
   def test_identifier
     ti = DataTimezoneInfo.new('Test/Zone')

--- a/test/tc_info_timezone.rb
+++ b/test/tc_info_timezone.rb
@@ -25,7 +25,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 
 include TZInfo
 
-class TCInfoTimezone < Test::Unit::TestCase
+class TCInfoTimezone < Minitest::Test
   
   class TestInfoTimezone < InfoTimezone
     attr_reader :setup_info

--- a/test/tc_linked_timezone.rb
+++ b/test/tc_linked_timezone.rb
@@ -25,7 +25,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 
 include TZInfo
 
-class TCLinkedTimezone < Test::Unit::TestCase
+class TCLinkedTimezone < Minitest::Test
   
   class TestTimezone < Timezone
     attr_reader :utc_period

--- a/test/tc_linked_timezone_info.rb
+++ b/test/tc_linked_timezone_info.rb
@@ -25,7 +25,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 
 include TZInfo
 
-class TCLinkedTimezoneInfo < Test::Unit::TestCase
+class TCLinkedTimezoneInfo < Minitest::Test
   
   def test_identifier
     lti = LinkedTimezoneInfo.new('Test/Zone', 'Test/Linked')

--- a/test/tc_offset_rationals.rb
+++ b/test/tc_offset_rationals.rb
@@ -25,7 +25,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 
 include TZInfo
 
-class TCOffsetRationals < Test::Unit::TestCase
+class TCOffsetRationals < Minitest::Test
   def test_rational_for_offset
     [0,1,2,3,4,-1,-2,-3,-4,30*60,-30*60,61*60,-61*60,14*60*60,-14*60*60,20*60*60,-20*60*60].each {|seconds|
       assert_equal(Rational(seconds, 86400), OffsetRationals.rational_for_offset(seconds))      

--- a/test/tc_ruby_core_support.rb
+++ b/test/tc_ruby_core_support.rb
@@ -27,7 +27,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 
 include TZInfo
 
-class TCRubyCoreSupport < Test::Unit::TestCase
+class TCRubyCoreSupport < Minitest::Test
   def test_rational_new!
     assert_equal(Rational(3,4), RubyCoreSupport.rational_new!(3,4))
   end

--- a/test/tc_ruby_country_info.rb
+++ b/test/tc_ruby_country_info.rb
@@ -25,7 +25,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 
 include TZInfo
 
-class TCRubyCountryInfo < Test::Unit::TestCase
+class TCRubyCountryInfo < Minitest::Test
   
   def test_code
     ci = RubyCountryInfo.new('ZZ', 'Zzz') {|c| }

--- a/test/tc_ruby_data_source.rb
+++ b/test/tc_ruby_data_source.rb
@@ -25,7 +25,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 
 include TZInfo
 
-class TCRubyDataSource < Test::Unit::TestCase
+class TCRubyDataSource < Minitest::Test
   def setup
     @data_source = RubyDataSource.new
   end

--- a/test/tc_time_or_datetime.rb
+++ b/test/tc_time_or_datetime.rb
@@ -26,7 +26,7 @@ require 'rational' unless defined?(Rational)
 
 include TZInfo
 
-class TCTimeOrDateTime < Test::Unit::TestCase
+class TCTimeOrDateTime < Minitest::Test
   def test_initialize_time
     assert_nothing_raised do
       TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 721000))

--- a/test/tc_timezone.rb
+++ b/test/tc_timezone.rb
@@ -25,7 +25,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 
 include TZInfo
 
-class TCTimezone < Test::Unit::TestCase
+class TCTimezone < Minitest::Test
 
   class BlockCalled < StandardError
   end

--- a/test/tc_timezone_definition.rb
+++ b/test/tc_timezone_definition.rb
@@ -25,7 +25,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 
 include TZInfo
 
-class TCTimezoneDefinition < Test::Unit::TestCase
+class TCTimezoneDefinition < Minitest::Test
 
   module DataTest
     include TimezoneDefinition

--- a/test/tc_timezone_index_definition.rb
+++ b/test/tc_timezone_index_definition.rb
@@ -25,7 +25,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 
 include TZInfo
 
-class TCTimezoneIndexDefinition < Test::Unit::TestCase
+class TCTimezoneIndexDefinition < Minitest::Test
   
   module TimezonesTest1
     include TimezoneIndexDefinition

--- a/test/tc_timezone_info.rb
+++ b/test/tc_timezone_info.rb
@@ -25,7 +25,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 
 include TZInfo
 
-class TCTimezoneInfo < Test::Unit::TestCase
+class TCTimezoneInfo < Minitest::Test
   
   def test_identifier
     ti = TimezoneInfo.new('Test/Zone')

--- a/test/tc_timezone_london.rb
+++ b/test/tc_timezone_london.rb
@@ -25,7 +25,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 
 include TZInfo
 
-class TCTimezoneLondon < Test::Unit::TestCase
+class TCTimezoneLondon < Minitest::Test
   def test_2004
     #Europe/London  Sun Mar 28 00:59:59 2004 UTC = Sun Mar 28 00:59:59 2004 GMT isdst=0 gmtoff=0
     #Europe/London  Sun Mar 28 01:00:00 2004 UTC = Sun Mar 28 02:00:00 2004 BST isdst=1 gmtoff=3600

--- a/test/tc_timezone_melbourne.rb
+++ b/test/tc_timezone_melbourne.rb
@@ -25,7 +25,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 
 include TZInfo
 
-class TCTimezoneMelbourne < Test::Unit::TestCase
+class TCTimezoneMelbourne < Minitest::Test
   def test_2004
     #Australia/Melbourne  Sat Mar 27 15:59:59 2004 UTC = Sun Mar 28 02:59:59 2004 EST isdst=1 gmtoff=39600
     #Australia/Melbourne  Sat Mar 27 16:00:00 2004 UTC = Sun Mar 28 02:00:00 2004 EST isdst=0 gmtoff=36000

--- a/test/tc_timezone_new_york.rb
+++ b/test/tc_timezone_new_york.rb
@@ -25,7 +25,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 
 include TZInfo
 
-class TCTimezoneNewYork < Test::Unit::TestCase
+class TCTimezoneNewYork < Minitest::Test
   def test_2004
     #America/New_York  Sun Apr  4 06:59:59 2004 UTC = Sun Apr  4 01:59:59 2004 EST isdst=0 gmtoff=-18000
     #America/New_York  Sun Apr  4 07:00:00 2004 UTC = Sun Apr  4 03:00:00 2004 EDT isdst=1 gmtoff=-14400

--- a/test/tc_timezone_offset.rb
+++ b/test/tc_timezone_offset.rb
@@ -25,7 +25,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 
 include TZInfo
 
-class TCTimezoneOffset < Test::Unit::TestCase
+class TCTimezoneOffset < Minitest::Test
   
   def test_utc_offset
     o1 = TimezoneOffset.new(18000, 0, :TEST)

--- a/test/tc_timezone_period.rb
+++ b/test/tc_timezone_period.rb
@@ -25,7 +25,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 
 include TZInfo
 
-class TCTimezonePeriod < Test::Unit::TestCase
+class TCTimezonePeriod < Minitest::Test
   
   class TestTimezoneTransition < TimezoneTransition
     def initialize(offset, previous_offset, at)

--- a/test/tc_timezone_proxy.rb
+++ b/test/tc_timezone_proxy.rb
@@ -25,7 +25,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 
 include TZInfo
 
-class TCTimezoneProxy < Test::Unit::TestCase
+class TCTimezoneProxy < Minitest::Test
   def test_not_exist
     proxy = TimezoneProxy.new('Nothing/Special')
     assert_equal('Nothing/Special', proxy.identifier)

--- a/test/tc_timezone_transition.rb
+++ b/test/tc_timezone_transition.rb
@@ -26,7 +26,7 @@ require 'date'
 
 include TZInfo
 
-class TCTimezoneTransition < Test::Unit::TestCase
+class TCTimezoneTransition < Minitest::Test
   
   class TestTimezoneTransition < TimezoneTransition
     def initialize(offset, previous_offset, at)

--- a/test/tc_timezone_transition_definition.rb
+++ b/test/tc_timezone_transition_definition.rb
@@ -26,7 +26,7 @@ require 'date'
 
 include TZInfo
 
-class TCTimezoneTransitionDefinition < Test::Unit::TestCase
+class TCTimezoneTransitionDefinition < Minitest::Test
   def test_initialize_timestamp_only
     assert_nothing_raised do
       TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),

--- a/test/tc_timezone_utc.rb
+++ b/test/tc_timezone_utc.rb
@@ -25,7 +25,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 
 include TZInfo
 
-class TCTimezoneUTC < Test::Unit::TestCase
+class TCTimezoneUTC < Minitest::Test
   def test_2004        
     tz = Timezone.get('UTC')
     

--- a/test/tc_transition_data_timezone_info.rb
+++ b/test/tc_transition_data_timezone_info.rb
@@ -25,7 +25,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 
 include TZInfo
 
-class TCTransitionDataTimezoneInfo < Test::Unit::TestCase
+class TCTransitionDataTimezoneInfo < Minitest::Test
   
   def test_identifier
     dti = TransitionDataTimezoneInfo.new('Test/Zone')

--- a/test/tc_zoneinfo_country_info.rb
+++ b/test/tc_zoneinfo_country_info.rb
@@ -25,7 +25,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 
 include TZInfo
 
-class TCZoneinfoCountryInfo < Test::Unit::TestCase
+class TCZoneinfoCountryInfo < Minitest::Test
   
   def test_code
     ci = ZoneinfoCountryInfo.new('ZZ', 'Zzz', []) {|c| }

--- a/test/tc_zoneinfo_data_source.rb
+++ b/test/tc_zoneinfo_data_source.rb
@@ -28,7 +28,7 @@ require 'tmpdir'
 
 include TZInfo
 
-class TCZoneinfoDataSource < Test::Unit::TestCase
+class TCZoneinfoDataSource < Minitest::Test
   ZONEINFO_DIR = File.join(File.expand_path(File.dirname(__FILE__)), 'zoneinfo').untaint
   
   def setup

--- a/test/tc_zoneinfo_timezone_info.rb
+++ b/test/tc_zoneinfo_timezone_info.rb
@@ -28,7 +28,7 @@ require 'tempfile'
 
 include TZInfo
 
-class TCZoneinfoTimezoneInfo < Test::Unit::TestCase
+class TCZoneinfoTimezoneInfo < Minitest::Test
 
   begin
     Time.at(-2147483649)
@@ -54,14 +54,14 @@ class TCZoneinfoTimezoneInfo < Test::Unit::TestCase
     assert_equal(dst, period.dst?)
     
     if start_at
-      assert_not_nil(period.utc_start_time)
+      refute_nil(period.utc_start_time)
       assert_equal(start_at, period.utc_start_time)
     else
       assert_nil(period.utc_start_time)
     end
     
     if end_at
-      assert_not_nil(period.utc_end_time)
+      refute_nil(period.utc_end_time)
       assert_equal(end_at, period.utc_end_time)
     else
       assert_nil(period.utc_end_time)

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -32,7 +32,7 @@ $:.unshift(TZINFO_LIB_DIR) unless $:.include?(TZINFO_LIB_DIR)
 # Add it to the load path.
 $:.unshift(TZINFO_TEST_DATA_DIR) unless $:.include?(TZINFO_TEST_DATA_DIR)
 
-require 'test/unit'
+require 'minitest/autorun'
 require 'tzinfo'
 require 'fileutils'
 require 'rbconfig'
@@ -134,7 +134,30 @@ module Kernel
       assert_equal(expected_lines, actual_lines)
     end
   end
+
+  def build_message(user_message, template_message, *args)
+    user_message ||= ''
+    user_message += ' ' unless user_message.empty?
+    msg = template_message.split(/<\?>/).zip(args.map { |o| o.inspect })
+    user_message + msg.join
+  end
+
+  def assert_nothing_raised _ = :ignored
+    yield
+  rescue => e
+    raise Minitest::Assertion, exception_details(e, "Exception raised:")
+  end
+
+  def assert_not_same(expected, actual, message="")
+    msg = message(msg) { build_message(message, "<?>with id <?> expected to not be equal\\? to<?>with id <?>.", expected, expected.__id__, actual, actual.__id__) }
+    assert(!actual.equal?(expected), msg)
+  end
+
+  def assert_block(*msgs)
+    assert yield, *msgs
+  end
 end
+
 
 # JRuby 1.7.5 to 1.7.9 consider DateTime instances that differ by less than 
 # 1 millisecond to be equivalent (https://github.com/jruby/jruby/issues/1311).


### PR DESCRIPTION
Hi,

this is the first attempt to update the test suite to Minitest 5. We are going to upgrade Ruby on Rails in Fedora 21 and RoR 4.1 uses the new Minitest so we upgraded it as well. We would love to see gems to use the new Minitest not to carry patches or sticking with the old one.

What this PR changes?
- `require 'test/unit'` to `require 'minitest/autorun'`
- `Test::Unit::TestCase` to `Minitest::Test`
- `assert_not_nil` to `refute_nil`
- adds requirement of Minitest 5 to `.gemspec`
- adds  `assert_nothing_raised`, `assert_not_same`, and `assert_block` to other custom asserts extending `Kernel` in `test/test_utils.rb`. This is kind of backport from older Minitest and we can probably change the tests not to use those at all in future.

Please consider.
