### PR TITLE
Add TZInfo::Version

### DIFF
--- a/lib/tzinfo/version.rb
+++ b/lib/tzinfo/version.rb
@@ -1,0 +1,3 @@
+module TZInfo
+  Version = '1.2.2'
+end

--- a/tzinfo.gemspec
+++ b/tzinfo.gemspec
@@ -1,19 +1,20 @@
+require './lib/tzinfo/version'
 Gem::Specification.new do |s|
   s.name = 'tzinfo'
-  s.version = '1.2.2'
+  s.version = TZInfo::Version
   s.summary = 'Daylight savings aware timezone library'
   s.description = 'TZInfo provides daylight savings aware transformations between times in different time zones.'
   s.author = 'Philip Ross'
   s.email = 'phil.ross@gmail.com'
   s.homepage = 'http://tzinfo.github.io'
-  s.license = 'MIT' 
+  s.license = 'MIT'
   s.files = %w(CHANGES.md LICENSE Rakefile README.md tzinfo.gemspec .yardopts) +
             Dir['lib/**/*.rb'].delete_if {|f| f.include?('.svn')} +
             Dir['test/**/*.rb'].delete_if {|f| f.include?('.svn')} +
             Dir['test/zoneinfo/**/*'].delete_if {|f| f.include?('.svn') || File.symlink?(f)}
   s.platform = Gem::Platform::RUBY
   s.require_path = 'lib'
-  s.rdoc_options << '--title' << 'TZInfo' << 
+  s.rdoc_options << '--title' << 'TZInfo' <<
                     '--main' << 'README.md'
   s.extra_rdoc_files = ['README.md', 'CHANGES.md', 'LICENSE']
   s.required_ruby_version = '>= 1.8.7'


### PR DESCRIPTION
Please see [the discussion](https://github.com/tzinfo/tzinfo/issues/28) for more information.
Tested it locally and version is a proper constant.

```
1.9.3-p194 :001 > require 'tzinfo'
 => true
1.9.3-p194 :002 > TZInfo
 => TZInfo
1.9.3-p194 :003 > TZInfo::Version
 => "1.2.2"
```

P.S. removed some trailing space.
