### PR TITLE
Remove threadsafe gem dependency

### DIFF
--- a/lib/tzinfo/country.rb
+++ b/lib/tzinfo/country.rb
@@ -4,8 +4,8 @@ module TZInfo
   # Raised by Country#get if the code given is not valid.
   class InvalidCountryCode < StandardError
   end
-  
-  # The Country class represents an ISO 3166-1 country. It can be used to 
+
+  # The Country class represents an ISO 3166-1 country. It can be used to
   # obtain a list of Timezones for a country. For example:
   #
   #  us = Country.get('US')
@@ -13,51 +13,51 @@ module TZInfo
   #  us.zones
   #  us.zone_info
   #
-  # The Country class is thread-safe. It is safe to use class and instance 
+  # The Country class is thread-safe. It is safe to use class and instance
   # methods of Country in concurrently executing threads. Instances of Country
   # can be shared across thread boundaries.
   #
-  # Country information available through TZInfo is intended as an aid for 
-  # users, to help them select time zone data appropriate for their practical 
-  # needs. It is not intended to take or endorse any position on legal or 
+  # Country information available through TZInfo is intended as an aid for
+  # users, to help them select time zone data appropriate for their practical
+  # needs. It is not intended to take or endorse any position on legal or
   # territorial claims.
   class Country
     include Comparable
-    
+
     # Defined countries.
     #
     # @!visibility private
     @@countries = nil
-    
+
     # Whether the countries index has been loaded yet.
     #
     # @!visibility private
     @@index_loaded = false
-    
-    # Gets a Country by its ISO 3166-1 alpha-2 code. Raises an 
+
+    # Gets a Country by its ISO 3166-1 alpha-2 code. Raises an
     # InvalidCountryCode exception if it couldn't be found.
     def self.get(identifier)
       instance = @@countries[identifier]
-      
+
       unless instance
-        # Thread-safety: It is possible that multiple equivalent Country 
-        # instances could be created here in concurrently executing threads. 
-        # The consequences of this are that the data may be loaded more than 
+        # Thread-safety: It is possible that multiple equivalent Country
+        # instances could be created here in concurrently executing threads.
+        # The consequences of this are that the data may be loaded more than
         # once (depending on the data source) and memoized calculations could
         # be discarded. The performance benefit of ensuring that only a single
         # instance is created is unlikely to be worth the overhead of only
         # allowing one Country to be loaded at a time.
-        info = data_source.load_country_info(identifier)  
+        info = data_source.load_country_info(identifier)
         instance = Country.new(info)
         @@countries[identifier] = instance
-      end      
-      
-      instance        
+      end
+
+      instance
     end
-    
-    # If identifier is a CountryInfo object, initializes the Country instance, 
+
+    # If identifier is a CountryInfo object, initializes the Country instance,
     # otherwise calls get(identifier).
-    def self.new(identifier)      
+    def self.new(identifier)
       if identifier.kind_of?(CountryInfo)
         instance = super()
         instance.send :setup, identifier
@@ -66,37 +66,37 @@ module TZInfo
         get(identifier)
       end
     end
-    
+
     # Returns an Array of all the valid country codes.
     def self.all_codes
       data_source.country_codes
     end
-    
+
     # Returns an Array of all the defined Countries.
     def self.all
       data_source.country_codes.collect {|code| get(code)}
-    end       
-    
+    end
+
     # The ISO 3166-1 alpha-2 country code.
     def code
       @info.code
     end
-    
+
     # The name of the country.
     def name
       @info.name
     end
-    
+
     # Alias for name.
     def to_s
       name
     end
-    
+
     # Returns internal object state as a programmer-readable string.
     def inspect
       "#<#{self.class}: #{@info.code}>"
     end
-    
+
     # Returns a frozen array of all the zone identifiers for the country. These
     # are in an order that
     #
@@ -111,7 +111,7 @@ module TZInfo
       @info.zone_identifiers
     end
     alias zone_names zone_identifiers
-    
+
     # An array of all the Timezones for this country. Returns TimezoneProxy
     # objects to avoid the overhead of loading Timezone definitions until
     # a conversion is actually required. The Timezones are returned in an order
@@ -126,12 +126,12 @@ module TZInfo
     # after those relating to this country.
     def zones
       zone_identifiers.collect {|id|
-        Timezone.get_proxy(id)        
+        Timezone.get_proxy(id)
       }
     end
-    
+
     # Returns a frozen array of all the timezones for the for the country as
-    # CountryTimezone instances (containing extra information about each zone). 
+    # CountryTimezone instances (containing extra information about each zone).
     # These are in an order that
     #
     # 1. makes some geographical sense, and
@@ -144,7 +144,7 @@ module TZInfo
     def zone_info
       @info.zones
     end
-        
+
     # Compare two Countries based on their code. Returns -1 if c is less
     # than self, 0 if c is equal to self and +1 if c is greater than self.
     #
@@ -153,33 +153,33 @@ module TZInfo
       return nil unless c.is_a?(Country)
       code <=> c.code
     end
-    
+
     # Returns true if and only if the code of c is equal to the code of this
     # Country.
     def eql?(c)
       self == c
     end
-    
+
     # Returns a hash value for this Country.
     def hash
       code.hash
     end
-    
+
     # Dumps this Country for marshalling.
     def _dump(limit)
       code
     end
-    
+
     # Loads a marshalled Country.
     def self._load(data)
       Country.get(data)
     end
-    
+
     private
       # Called by Country.new to initialize a new Country instance. The info
       # parameter is a CountryInfo that defines the country.
       def setup(info)
-        @info = info        
+        @info = info
       end
 
       # Initializes @@countries.
@@ -187,10 +187,10 @@ module TZInfo
         @@countries = ThreadSafe::Cache.new
       end
       init_countries
-      
+
       # Returns the current DataSource
       def self.data_source
         DataSource.get
       end
-  end 
+  end
 end

--- a/lib/tzinfo/country_index_definition.rb
+++ b/lib/tzinfo/country_index_definition.rb
@@ -9,7 +9,7 @@ module TZInfo
       base.extend(ClassMethods)
       base.instance_eval { @countries = {} }
     end
-    
+
     # Class methods for inclusion.
     #
     # @private
@@ -18,9 +18,9 @@ module TZInfo
       # block will be evaluated to obtain all the timezones for the country.
       # Calls Country.country_defined with the definition of each country.
       def country(code, name, &block)
-        @countries[code] = RubyCountryInfo.new(code, name, &block)      
+        @countries[code] = RubyCountryInfo.new(code, name, &block)
       end
-      
+
       # Returns a frozen hash of all the countries that have been defined in
       # the index.
       def countries

--- a/lib/tzinfo/country_info.rb
+++ b/lib/tzinfo/country_info.rb
@@ -1,30 +1,30 @@
-module TZInfo  
+module TZInfo
   # Represents a country and references to its timezones as returned by a
   # DataSource.
   class CountryInfo
     # The ISO 3166 country code.
     attr_reader :code
-    
+
     # The name of the country.
     attr_reader :name
-    
+
     # Constructs a new CountryInfo with an ISO 3166 country code and name
     def initialize(code, name)
       @code = code
       @name = name
     end
-    
+
     # Returns internal object state as a programmer-readable string.
     def inspect
       "#<#{self.class}: #@code>"
     end
-    
+
     # Returns a frozen array of all the zone identifiers for the country.
     # The identifiers are ordered by importance according to the DataSource.
     def zone_identifiers
       raise_not_implemented('zone_identifiers')
     end
-    
+
     # Returns a frozen array of all the timezones for the for the country as
     # CountryTimezone instances.
     #

--- a/lib/tzinfo/country_timezone.rb
+++ b/lib/tzinfo/country_timezone.rb
@@ -4,24 +4,24 @@ module TZInfo
   # multiple countries).
   class CountryTimezone
     # The zone identifier.
-    attr_reader :identifier      
-    
-    # A description of this timezone in relation to the country, e.g. 
+    attr_reader :identifier
+
+    # A description of this timezone in relation to the country, e.g.
     # "Eastern Time". This is usually nil for countries having only a single
     # Timezone.
     attr_reader :description
-    
+
     class << self
       # Creates a new CountryTimezone with a timezone identifier, latitude,
       # longitude and description. The latitude and longitude are specified as
-      # rationals - a numerator and denominator. For performance reasons, the 
+      # rationals - a numerator and denominator. For performance reasons, the
       # numerators and denominators must be specified in their lowest form.
       #
       # For use internally within TZInfo.
       #
       # @!visibility private
       alias :new! :new
-      
+
       # Creates a new CountryTimezone with a timezone identifier, latitude,
       # longitude and description. The latitude and longitude must be specified
       # as instances of Rational.
@@ -29,20 +29,20 @@ module TZInfo
       # CountryTimezone instances should normally only be constructed when
       # creating new DataSource implementations.
       def new(identifier, latitude, longitude, description = nil)
-        super(identifier, latitude, nil, longitude, nil, description)      
+        super(identifier, latitude, nil, longitude, nil, description)
       end
     end
-    
+
     # Creates a new CountryTimezone with a timezone identifier, latitude,
     # longitude and description. The latitude and longitude are specified as
-    # rationals - a numerator and denominator. For performance reasons, the 
+    # rationals - a numerator and denominator. For performance reasons, the
     # numerators and denominators must be specified in their lowest form.
     #
     # @!visibility private
-    def initialize(identifier, latitude_numerator, latitude_denominator, 
+    def initialize(identifier, latitude_numerator, latitude_denominator,
                    longitude_numerator, longitude_denominator, description = nil) #:nodoc:
       @identifier = identifier
-      
+
       if latitude_numerator.kind_of?(Rational)
         @latitude = latitude_numerator
       else
@@ -50,7 +50,7 @@ module TZInfo
         @latitude_numerator = latitude_numerator
         @latitude_denominator = latitude_denominator
       end
-      
+
       if longitude_numerator.kind_of?(Rational)
         @longitude = longitude_numerator
       else
@@ -58,63 +58,63 @@ module TZInfo
         @longitude_numerator = longitude_numerator
         @longitude_denominator = longitude_denominator
       end
-        
+
       @description = description
     end
-    
+
     # The Timezone (actually a TimezoneProxy for performance reasons).
     def timezone
       Timezone.get_proxy(@identifier)
     end
-    
+
     # if description is not nil, this method returns description; otherwise it
     # returns timezone.friendly_identifier(true).
     def description_or_friendly_identifier
       description || timezone.friendly_identifier(true)
     end
-    
+
     # The latitude of this timezone in degrees as a Rational.
     def latitude
-      # Thread-safety: It is possible that the value of @latitude may be 
-      # calculated multiple times in concurrently executing threads. It is not 
-      # worth the overhead of locking to ensure that @latitude is only 
+      # Thread-safety: It is possible that the value of @latitude may be
+      # calculated multiple times in concurrently executing threads. It is not
+      # worth the overhead of locking to ensure that @latitude is only
       # calculated once.
       @latitude ||= RubyCoreSupport.rational_new!(@latitude_numerator, @latitude_denominator)
     end
-    
+
     # The longitude of this timezone in degrees as a Rational.
     def longitude
-      # Thread-safety: It is possible that the value of @longitude may be 
-      # calculated multiple times in concurrently executing threads. It is not 
-      # worth the overhead of locking to ensure that @longitude is only 
+      # Thread-safety: It is possible that the value of @longitude may be
+      # calculated multiple times in concurrently executing threads. It is not
+      # worth the overhead of locking to ensure that @longitude is only
       # calculated once.
       @longitude ||= RubyCoreSupport.rational_new!(@longitude_numerator, @longitude_denominator)
     end
-    
+
     # Returns true if and only if the given CountryTimezone is equal to the
     # current CountryTimezone (has the same identifer, latitude, longitude
     # and description).
     def ==(ct)
       ct.kind_of?(CountryTimezone) &&
         identifier == ct.identifier  && latitude == ct.latitude &&
-        longitude == ct.longitude   && description == ct.description         
+        longitude == ct.longitude   && description == ct.description
     end
-            
+
     # Returns true if and only if the given CountryTimezone is equal to the
     # current CountryTimezone (has the same identifer, latitude, longitude
     # and description).
     def eql?(ct)
       self == ct
     end
-    
-    # Returns a hash of this CountryTimezone. 
+
+    # Returns a hash of this CountryTimezone.
     def hash
-      @identifier.hash ^ 
+      @identifier.hash ^
         (@latitude ? @latitude.numerator.hash ^ @latitude.denominator.hash : @latitude_numerator.hash ^ @latitude_denominator.hash) ^
         (@longitude ? @longitude.numerator.hash ^ @longitude.denominator.hash : @longitude_numerator.hash ^ @longitude_denominator.hash) ^
         @description.hash
     end
-    
+
     # Returns internal object state as a programmer-readable string.
     def inspect
       "#<#{self.class}: #@identifier>"

--- a/lib/tzinfo/data_source.rb
+++ b/lib/tzinfo/data_source.rb
@@ -1,13 +1,13 @@
 require 'thread'
 
 module TZInfo
-  # InvalidDataSource is raised if the DataSource is used doesn't implement one 
+  # InvalidDataSource is raised if the DataSource is used doesn't implement one
   # of the required methods.
   class InvalidDataSource < StandardError
   end
-  
-  # DataSourceNotFound is raised if no data source could be found (i.e. 
-  # if 'tzinfo/data' cannot be found on the load path and no valid zoneinfo 
+
+  # DataSourceNotFound is raised if no data source could be found (i.e.
+  # if 'tzinfo/data' cannot be found on the load path and no valid zoneinfo
   # directory can be found on the system).
   class DataSourceNotFound < StandardError
   end
@@ -18,37 +18,37 @@ module TZInfo
   class DataSource
     # The currently selected data source.
     @@instance = nil
-    
+
     # Mutex used to ensure the default data source is only created once.
     @@default_mutex = Mutex.new
-        
+
     # Returns the currently selected DataSource instance.
     def self.get
       # If a DataSource hasn't been manually set when the first request is
       # made to obtain a DataSource, then a Default data source is created.
-      
+
       # This is done at the first request rather than when TZInfo is loaded to
-      # avoid unnecessary (or in some cases potentially harmful) attempts to 
+      # avoid unnecessary (or in some cases potentially harmful) attempts to
       # find a suitable DataSource.
-      
+
       # A Mutex is used to ensure that only a single default instance is
-      # created (having two different DataSources in use simultaneously could 
+      # created (having two different DataSources in use simultaneously could
       # cause unexpected results).
-      
+
       unless @@instance
         @@default_mutex.synchronize do
           set(create_default_data_source) unless @@instance
         end
-      end      
-      
+      end
+
       @@instance
     end
-    
+
     # Sets the currently selected data source for Timezone and Country data.
     #
     # This should usually be set to one of the two standard data source types:
     #
-    # * +:ruby+ - read data from the Ruby modules included in the TZInfo::Data 
+    # * +:ruby+ - read data from the Ruby modules included in the TZInfo::Data
     #   library (tzinfo-data gem).
     # * +:zoneinfo+ - read data from the zoneinfo files included with most
     #   Unix-like operating sytems (e.g. in /usr/share/zoneinfo).
@@ -62,7 +62,7 @@ module TZInfo
     #   TZInfo::DataSource.set(:zoneinfo, zoneinfo_dir, iso3166_tab_file)
     #
     # \DataSource.set(:zoneinfo) will automatically search for the zoneinfo
-    # directory by checking the paths specified in 
+    # directory by checking the paths specified in
     # ZoneinfoDataSource.search_paths. ZoneinfoDirectoryNotFound will be raised
     # if no valid zoneinfo directory could be found.
     #
@@ -85,7 +85,7 @@ module TZInfo
     # * \load_country_info
     # * \country_codes
     #
-    # To have TZInfo use the custom data source, call \DataSource.set 
+    # To have TZInfo use the custom data source, call \DataSource.set
     # as follows:
     #
     #   TZInfo::DataSource.set(CustomDataSource.new)
@@ -93,9 +93,9 @@ module TZInfo
     # To avoid inconsistent data, \DataSource.set should be called before
     # accessing any Timezone or Country data.
     #
-    # If \DataSource.set is not called, TZInfo will by default use TZInfo::Data 
-    # as the data source. If TZInfo::Data is not available (i.e. if require 
-    # 'tzinfo/data' fails), then TZInfo will search for a zoneinfo directory 
+    # If \DataSource.set is not called, TZInfo will by default use TZInfo::Data
+    # as the data source. If TZInfo::Data is not available (i.e. if require
+    # 'tzinfo/data' fails), then TZInfo will search for a zoneinfo directory
     # instead (using the search path specified by
     # TZInfo::ZoneinfoDataSource::DEFAULT_SEARCH_PATH).
     def self.set(data_source_or_type, *args)
@@ -109,73 +109,73 @@ module TZInfo
         raise ArgumentError, 'data_source_or_type must be a DataSource instance or a data source type (:ruby)'
       end
     end
-    
+
     # Returns a TimezoneInfo instance for a given identifier. The TimezoneInfo
     # instance should derive from either DataTimzoneInfo for timezones that
     # define their own data or LinkedTimezoneInfo for links or aliases to
     # other timezones.
     #
-    # Raises InvalidTimezoneIdentifier if the timezone is not found or the 
+    # Raises InvalidTimezoneIdentifier if the timezone is not found or the
     # identifier is invalid.
     def load_timezone_info(identifier)
       raise_invalid_data_source('load_timezone_info')
     end
-    
+
     # Returns an array of all the available timezone identifiers.
     def timezone_identifiers
       raise_invalid_data_source('timezone_identifiers')
     end
-    
+
     # Returns an array of all the available timezone identifiers for
     # data timezones (i.e. those that actually contain definitions).
     def data_timezone_identifiers
       raise_invalid_data_source('data_timezone_identifiers')
     end
-    
+
     # Returns an array of all the available timezone identifiers that
     # are links to other timezones.
     def linked_timezone_identifiers
       raise_invalid_data_source('linked_timezone_identifiers')
     end
-    
+
     # Returns a CountryInfo instance for the given ISO 3166-1 alpha-2
     # country code. Raises InvalidCountryCode if the country could not be found
     # or the code is invalid.
     def load_country_info(code)
       raise_invalid_data_source('load_country_info')
     end
-    
+
     # Returns an array of all the available ISO 3166-1 alpha-2
     # country codes.
     def country_codes
       raise_invalid_data_source('country_codes')
     end
-    
+
     # Returns the name of this DataSource.
     def to_s
       "Default DataSource"
     end
-    
+
     # Returns internal object state as a programmer-readable string.
     def inspect
       "#<#{self.class}>"
     end
-    
+
     private
-    
+
     # Creates a DataSource instance for use as the default. Used if
     # no preference has been specified manually.
     def self.create_default_data_source
       has_tzinfo_data = false
-      
+
       begin
         require 'tzinfo/data'
         has_tzinfo_data = true
       rescue LoadError
       end
-    
+
       return RubyDataSource.new if has_tzinfo_data
-      
+
       begin
         return ZoneinfoDataSource.new
       rescue ZoneinfoDirectoryNotFound

--- a/lib/tzinfo/data_timezone.rb
+++ b/lib/tzinfo/data_timezone.rb
@@ -4,42 +4,42 @@ module TZInfo
   #
   # @private
   class DataTimezone < InfoTimezone #:nodoc:
-    
+
     # Returns the TimezonePeriod for the given UTC time. utc can either be
-    # a DateTime, Time or integer timestamp (Time.to_i). Any timezone 
-    # information in utc is ignored (it is treated as a UTC time).        
+    # a DateTime, Time or integer timestamp (Time.to_i). Any timezone
+    # information in utc is ignored (it is treated as a UTC time).
     #
     # If no TimezonePeriod could be found, PeriodNotFound is raised.
     def period_for_utc(utc)
       info.period_for_utc(utc)
     end
-    
+
     # Returns the set of TimezonePeriod instances that are valid for the given
-    # local time as an array. If you just want a single period, use 
+    # local time as an array. If you just want a single period, use
     # period_for_local instead and specify how abiguities should be resolved.
     # Raises PeriodNotFound if no periods are found for the given time.
     def periods_for_local(local)
       info.periods_for_local(local)
     end
-    
+
     # Returns an Array of TimezoneTransition instances representing the times
     # where the UTC offset of the timezone changes.
     #
-    # Transitions are returned up to a given date and time up to a given date 
+    # Transitions are returned up to a given date and time up to a given date
     # and time, specified in UTC (utc_to).
     #
     # A from date and time may also be supplied using the utc_from parameter
-    # (also specified in UTC). If utc_from is not nil, only transitions from 
+    # (also specified in UTC). If utc_from is not nil, only transitions from
     # that date and time onwards will be returned.
     #
     # Comparisons with utc_to are exclusive. Comparisons with utc_from are
     # inclusive. If a transition falls precisely on utc_to, it will be excluded.
     # If a transition falls on utc_from, it will be included.
     #
-    # Transitions returned are ordered by when they occur, from earliest to 
+    # Transitions returned are ordered by when they occur, from earliest to
     # latest.
     #
-    # utc_to and utc_from can be specified using either DateTime, Time or 
+    # utc_to and utc_from can be specified using either DateTime, Time or
     # integer timestamps (Time.to_i).
     #
     # If utc_from is specified and utc_to is not greater than utc_from, then
@@ -47,7 +47,7 @@ module TZInfo
     def transitions_up_to(utc_to, utc_from = nil)
       info.transitions_up_to(utc_to, utc_from)
     end
-    
+
     # Returns the canonical zone for this Timezone.
     #
     # For a DataTimezone, this is always self.

--- a/lib/tzinfo/data_timezone_info.rb
+++ b/lib/tzinfo/data_timezone_info.rb
@@ -1,37 +1,37 @@
 module TZInfo
   # Represents a defined timezone containing transition data.
-  class DataTimezoneInfo < TimezoneInfo  
-  
+  class DataTimezoneInfo < TimezoneInfo
+
     # Returns the TimezonePeriod for the given UTC time.
     def period_for_utc(utc)
       raise_not_implemented('period_for_utc')
     end
-    
-    # Returns the set of TimezonePeriods for the given local time as an array.    
+
+    # Returns the set of TimezonePeriods for the given local time as an array.
     # Results returned are ordered by increasing UTC start date.
     # Returns an empty array if no periods are found for the given time.
     def periods_for_local(local)
       raise_not_implemented('periods_for_local')
     end
-    
+
     # Returns an Array of TimezoneTransition instances representing the times
     # where the UTC offset of the timezone changes.
     #
-    # Transitions are returned up to a given date and time up to a given date 
+    # Transitions are returned up to a given date and time up to a given date
     # and time, specified in UTC (utc_to).
     #
     # A from date and time may also be supplied using the utc_from parameter
-    # (also specified in UTC). If utc_from is not nil, only transitions from 
+    # (also specified in UTC). If utc_from is not nil, only transitions from
     # that date and time onwards will be returned.
     #
     # Comparisons with utc_to are exclusive. Comparisons with utc_from are
     # inclusive. If a transition falls precisely on utc_to, it will be excluded.
     # If a transition falls on utc_from, it will be included.
     #
-    # Transitions returned are ordered by when they occur, from earliest to 
+    # Transitions returned are ordered by when they occur, from earliest to
     # latest.
     #
-    # utc_to and utc_from can be specified using either DateTime, Time or 
+    # utc_to and utc_from can be specified using either DateTime, Time or
     # integer timestamps (Time.to_i).
     #
     # If utc_from is specified and utc_to is not greater than utc_from, then
@@ -39,7 +39,7 @@ module TZInfo
     def transitions_up_to(utc_to, utc_from = nil)
       raise_not_implemented('transitions_up_to')
     end
-    
+
     # Constructs a Timezone instance for the timezone represented by this
     # DataTimezoneInfo.
     def create_timezone

--- a/lib/tzinfo/info_timezone.rb
+++ b/lib/tzinfo/info_timezone.rb
@@ -4,27 +4,27 @@ module TZInfo
   #
   # @private
   class InfoTimezone < Timezone #:nodoc:
-    
+
     # Constructs a new InfoTimezone with a TimezoneInfo instance.
-    def self.new(info)      
+    def self.new(info)
       tz = super()
       tz.send(:setup, info)
       tz
     end
-    
+
     # The identifier of the timezone, e.g. "Europe/Paris".
     def identifier
       @info.identifier
     end
-    
+
     protected
       # The TimezoneInfo for this Timezone.
       def info
         @info
       end
-          
+
       def setup(info)
         @info = info
       end
-  end    
+  end
 end

--- a/lib/tzinfo/linked_timezone.rb
+++ b/lib/tzinfo/linked_timezone.rb
@@ -5,40 +5,40 @@ module TZInfo
   # @private
   class LinkedTimezone < InfoTimezone #:nodoc:
     # Returns the TimezonePeriod for the given UTC time. utc can either be
-    # a DateTime, Time or integer timestamp (Time.to_i). Any timezone 
-    # information in utc is ignored (it is treated as a UTC time).        
+    # a DateTime, Time or integer timestamp (Time.to_i). Any timezone
+    # information in utc is ignored (it is treated as a UTC time).
     #
     # If no TimezonePeriod could be found, PeriodNotFound is raised.
     def period_for_utc(utc)
       @linked_timezone.period_for_utc(utc)
     end
-    
+
     # Returns the set of TimezonePeriod instances that are valid for the given
-    # local time as an array. If you just want a single period, use 
+    # local time as an array. If you just want a single period, use
     # period_for_local instead and specify how abiguities should be resolved.
     # Raises PeriodNotFound if no periods are found for the given time.
     def periods_for_local(local)
       @linked_timezone.periods_for_local(local)
     end
-    
+
     # Returns an Array of TimezoneTransition instances representing the times
     # where the UTC offset of the timezone changes.
     #
-    # Transitions are returned up to a given date and time up to a given date 
+    # Transitions are returned up to a given date and time up to a given date
     # and time, specified in UTC (utc_to).
     #
     # A from date and time may also be supplied using the utc_from parameter
-    # (also specified in UTC). If utc_from is not nil, only transitions from 
+    # (also specified in UTC). If utc_from is not nil, only transitions from
     # that date and time onwards will be returned.
     #
     # Comparisons with utc_to are exclusive. Comparisons with utc_from are
     # inclusive. If a transition falls precisely on utc_to, it will be excluded.
     # If a transition falls on utc_from, it will be included.
     #
-    # Transitions returned are ordered by when they occur, from earliest to 
+    # Transitions returned are ordered by when they occur, from earliest to
     # latest.
     #
-    # utc_to and utc_from can be specified using either DateTime, Time or 
+    # utc_to and utc_from can be specified using either DateTime, Time or
     # integer timestamps (Time.to_i).
     #
     # If utc_from is specified and utc_to is not greater than utc_from, then
@@ -46,14 +46,14 @@ module TZInfo
     def transitions_up_to(utc_to, utc_from = nil)
       @linked_timezone.transitions_up_to(utc_to, utc_from)
     end
-    
+
     # Returns the canonical zone for this Timezone.
     #
     # For a LinkedTimezone, this is the canonical zone of the link target.
     def canonical_zone
       @linked_timezone.canonical_zone
     end
-    
+
     protected
       def setup(info)
         super(info)

--- a/lib/tzinfo/linked_timezone_info.rb
+++ b/lib/tzinfo/linked_timezone_info.rb
@@ -1,22 +1,22 @@
 module TZInfo
   # Represents a timezone that is defined as a link or alias to another zone.
   class LinkedTimezoneInfo < TimezoneInfo
-        
+
     # The zone that provides the data (that this zone is an alias for).
     attr_reader :link_to_identifier
-    
+
     # Constructs a new LinkedTimezoneInfo with an identifier and the identifier
     # of the zone linked to.
     def initialize(identifier, link_to_identifier)
       super(identifier)
-      @link_to_identifier = link_to_identifier      
+      @link_to_identifier = link_to_identifier
     end
-    
+
     # Returns internal object state as a programmer-readable string.
     def inspect
       "#<#{self.class}: #@identifier,#@link_to_identifier>"
     end
-    
+
     # Constructs a Timezone instance for the timezone represented by this
     # DataTimezoneInfo.
     def create_timezone

--- a/lib/tzinfo/offset_rationals.rb
+++ b/lib/tzinfo/offset_rationals.rb
@@ -1,7 +1,7 @@
 require 'rational' unless defined?(Rational)
 
 module TZInfo
-  
+
   # Provides a method for getting Rationals for a timezone offset in seconds.
   # Pre-reduced rationals are returned for all the half-hour intervals between
   # -14 and +14 hours to avoid having to call gcd at runtime.
@@ -9,7 +9,7 @@ module TZInfo
   # @private
   module OffsetRationals #:nodoc:
     @@rational_cache = {
-      -50400 => RubyCoreSupport.rational_new!(-7,12), 
+      -50400 => RubyCoreSupport.rational_new!(-7,12),
       -48600 => RubyCoreSupport.rational_new!(-9,16),
       -46800 => RubyCoreSupport.rational_new!(-13,24),
       -45000 => RubyCoreSupport.rational_new!(-25,48),
@@ -66,11 +66,11 @@ module TZInfo
        46800 => RubyCoreSupport.rational_new!(13,24),
        48600 => RubyCoreSupport.rational_new!(9,16),
        50400 => RubyCoreSupport.rational_new!(7,12)}.freeze
-    
-    # Returns a Rational expressing the fraction of a day that offset in 
-    # seconds represents (i.e. equivalent to Rational(offset, 86400)). 
+
+    # Returns a Rational expressing the fraction of a day that offset in
+    # seconds represents (i.e. equivalent to Rational(offset, 86400)).
     def rational_for_offset(offset)
-      @@rational_cache[offset] || Rational(offset, 86400)      
+      @@rational_cache[offset] || Rational(offset, 86400)
     end
     module_function :rational_for_offset
   end

--- a/lib/tzinfo/ruby_core_support.rb
+++ b/lib/tzinfo/ruby_core_support.rb
@@ -2,14 +2,14 @@ require 'date'
 require 'rational' unless defined?(Rational)
 
 module TZInfo
-  
+
   # Methods to support different versions of Ruby.
   #
   # @private
   module RubyCoreSupport #:nodoc:
-  
+
     # Use Rational.new! for performance reasons in Ruby 1.8.
-    # This has been removed from 1.9, but Rational performs better.        
+    # This has been removed from 1.9, but Rational performs better.
     if Rational.respond_to? :new!
       def self.rational_new!(numerator, denominator = 1)
         Rational.new!(numerator, denominator)
@@ -19,7 +19,7 @@ module TZInfo
         Rational(numerator, denominator)
       end
     end
-    
+
     # Ruby 1.8.6 introduced new! and deprecated new0.
     # Ruby 1.9.0 removed new0.
     # Ruby trunk revision 31668 removed the new! method.
@@ -40,11 +40,11 @@ module TZInfo
       def self.datetime_new!(ajd = 0, of = 0, sg = Date::ITALY)
         # Convert from an Astronomical Julian Day number to a civil Julian Day number.
         jd = ajd + of + HALF_DAYS_IN_DAY
-        
+
         # Ruby trunk revision 31862 changed the behaviour of DateTime.jd so that it will no
         # longer accept a fractional civil Julian Day number if further arguments are specified.
         # Calculate the hours, minutes and seconds to pass to jd.
-        
+
         jd_i = jd.to_i
         jd_i -= 1 if jd < 0
         hours = (jd - jd_i) * 24
@@ -52,11 +52,11 @@ module TZInfo
         minutes = (hours - hours_i) * 60
         minutes_i = minutes.to_i
         seconds = (minutes - minutes_i) * 60
-        
+
         DateTime.jd(jd_i, hours_i, minutes_i, seconds, of, sg)
       end
     end
-    
+
     # DateTime in Ruby 1.8.6 doesn't consider times within the 60th second to be
     # valid. When attempting to specify such a DateTime, subtract the fractional
     # part and then add it back later
@@ -72,15 +72,15 @@ module TZInfo
     else
       def self.datetime_new(y=-4712, m=1, d=1, h=0, min=0, s=0, of=0, sg=Date::ITALY)
         DateTime.new(y, m, d, h, min, s, of, sg)
-      end    
-    end    
-    
+      end
+    end
+
     # Returns true if Time on the runtime platform supports Times defined
     # by negative 32-bit timestamps, otherwise false.
     begin
       Time.at(-1)
       Time.at(-2147483648)
-      
+
       def self.time_supports_negative
         true
       end
@@ -89,13 +89,13 @@ module TZInfo
         false
       end
     end
-    
+
     # Returns true if Time on the runtime platform supports Times defined by
     # 64-bit timestamps, otherwise false.
     begin
       Time.at(-2147483649)
       Time.at(2147483648)
-      
+
       def self.time_supports_64bit
         true
       end
@@ -104,7 +104,7 @@ module TZInfo
         false
       end
     end
-    
+
     # Return the result of Time#nsec if it exists, otherwise return the
     # result of Time#usec * 1000.
     if Time.method_defined?(:nsec)
@@ -116,7 +116,7 @@ module TZInfo
         time.usec * 1000
       end
     end
-    
+
     # Call String#force_encoding if this version of Ruby has encoding support
     # otherwise treat as a no-op.
     if String.method_defined?(:force_encoding)
@@ -128,8 +128,8 @@ module TZInfo
         str
       end
     end
-    
-    
+
+
     # Wrapper for File.open that supports passing hash options for specifying
     # encodings on Ruby 1.9+. The options are ignored on earlier versions of
     # Ruby.

--- a/lib/tzinfo/ruby_country_info.rb
+++ b/lib/tzinfo/ruby_country_info.rb
@@ -1,10 +1,10 @@
-module TZInfo  
+module TZInfo
   # Represents information about a country returned by RubyDataSource.
   #
   # @private
   class RubyCountryInfo < CountryInfo #:nodoc:
-    # Constructs a new CountryInfo with an ISO 3166 country code, name and 
-    # block. The block will be evaluated to obtain the timezones for the 
+    # Constructs a new CountryInfo with an ISO 3166 country code, name and
+    # block. The block will be evaluated to obtain the timezones for the
     # country when the zones are first needed.
     def initialize(code, name, &block)
       super(code, name)
@@ -12,58 +12,58 @@ module TZInfo
       @zones = nil
       @zone_identifiers = nil
     end
-    
+
     # Returns a frozen array of all the zone identifiers for the country. These
     # are in the order they were added using the timezone method.
     def zone_identifiers
-      # Thread-safety: It is possible that the value of @zone_identifiers may be 
-      # calculated multiple times in concurrently executing threads. It is not 
-      # worth the overhead of locking to ensure that @zone_identifiers is only 
+      # Thread-safety: It is possible that the value of @zone_identifiers may be
+      # calculated multiple times in concurrently executing threads. It is not
+      # worth the overhead of locking to ensure that @zone_identifiers is only
       # calculated once.
-    
+
       unless @zone_identifiers
         @zone_identifiers = zones.collect {|zone| zone.identifier}.freeze
       end
-      
+
       @zone_identifiers
     end
-    
+
     # Returns a frozen array of all the timezones for the for the country as
-    # CountryTimezone instances. These are in the order they were added using 
+    # CountryTimezone instances. These are in the order they were added using
     # the timezone method.
     def zones
-      # Thread-safety: It is possible that the value of @zones may be 
-      # calculated multiple times in concurrently executing threads. It is not 
-      # worth the overhead of locking to ensure that @zones is only 
+      # Thread-safety: It is possible that the value of @zones may be
+      # calculated multiple times in concurrently executing threads. It is not
+      # worth the overhead of locking to ensure that @zones is only
       # calculated once.
-    
+
       unless @zones
         zones = Zones.new
         @block.call(zones) if @block
         @block = nil
         @zones = zones.list.freeze
       end
-      
+
       @zones
     end
-    
+
     # An instance of the Zones class is passed to the block used to define
     # timezones.
     #
     # @private
     class Zones #:nodoc:
       attr_reader :list
-    
+
       def initialize
         @list = []
       end
-    
+
       # Called by the index data to define a timezone for the country.
-      def timezone(identifier, latitude_numerator, latitude_denominator, 
-                   longitude_numerator, longitude_denominator, description = nil)          
-        @list << CountryTimezone.new!(identifier, latitude_numerator, 
+      def timezone(identifier, latitude_numerator, latitude_denominator,
+                   longitude_numerator, longitude_denominator, description = nil)
+        @list << CountryTimezone.new!(identifier, latitude_numerator,
           latitude_denominator, longitude_numerator, longitude_denominator,
-          description)     
+          description)
       end
     end
   end

--- a/lib/tzinfo/ruby_data_source.rb
+++ b/lib/tzinfo/ruby_data_source.rb
@@ -8,61 +8,61 @@ module TZInfo
   class RubyDataSource < DataSource
     # Base path for require.
     REQUIRE_PATH = File.join('tzinfo', 'data', 'definitions')
-    
+
     # Whether the timezone index has been loaded yet.
     @@timezone_index_loaded = false
-    
+
     # Whether the country index has been loaded yet.
     @@country_index_loaded = false
-  
-    # Returns a TimezoneInfo instance for a given identifier. 
-    # Raises InvalidTimezoneIdentifier if the timezone is not found or the 
+
+    # Returns a TimezoneInfo instance for a given identifier.
+    # Raises InvalidTimezoneIdentifier if the timezone is not found or the
     # identifier is invalid.
     def load_timezone_info(identifier)
       raise InvalidTimezoneIdentifier, 'Invalid identifier' if identifier !~ /^[A-Za-z0-9\+\-_]+(\/[A-Za-z0-9\+\-_]+)*$/
-      
+
       identifier = identifier.gsub(/-/, '__m__').gsub(/\+/, '__p__')
-      
+
       # Untaint identifier after it has been reassigned to a new string. We
-      # don't want to modify the original identifier. identifier may also be 
+      # don't want to modify the original identifier. identifier may also be
       # frozen and therefore cannot be untainted.
       identifier.untaint
-      
+
       identifier = identifier.split('/')
       begin
         require_definition(identifier)
-        
+
         m = Data::Definitions
         identifier.each {|part|
           m = m.const_get(part)
         }
-        
+
         m.get
       rescue LoadError, NameError => e
         raise InvalidTimezoneIdentifier, e.message
       end
     end
-    
+
     # Returns an array of all the available timezone identifiers.
     def timezone_identifiers
       load_timezone_index
       Data::Indexes::Timezones.timezones
     end
-    
+
     # Returns an array of all the available timezone identifiers for
     # data timezones (i.e. those that actually contain definitions).
     def data_timezone_identifiers
       load_timezone_index
       Data::Indexes::Timezones.data_timezones
     end
-    
+
     # Returns an array of all the available timezone identifiers that
     # are links to other timezones.
     def linked_timezone_identifiers
       load_timezone_index
       Data::Indexes::Timezones.linked_timezones
     end
-    
+
     # Returns a CountryInfo instance for the given ISO 3166-1 alpha-2
     # country code. Raises InvalidCountryCode if the country could not be found
     # or the code is invalid.
@@ -72,59 +72,59 @@ module TZInfo
       raise InvalidCountryCode, 'Invalid country code' unless info
       info
     end
-    
+
     # Returns an array of all the available ISO 3166-1 alpha-2
     # country codes.
     def country_codes
       load_country_index
       Data::Indexes::Countries.countries.keys.freeze
     end
-    
+
     # Returns the name of this DataSource.
     def to_s
       "Ruby DataSource"
     end
-    
+
     private
-    
+
     # Requires a zone definition by its identifier (split on /).
     def require_definition(identifier)
       require_data(*(['definitions'] + identifier))
     end
-    
+
     # Requires an index by its name.
     def self.require_index(name)
       require_data(*['indexes', name])
     end
-    
+
     # Requires a file from tzinfo/data.
     def require_data(*file)
       self.class.require_data(*file)
     end
-    
+
     # Requires a file from tzinfo/data.
     def self.require_data(*file)
       require File.join('tzinfo', 'data', *file)
     end
-    
+
     # Loads in the index of timezones if it hasn't already been loaded.
     def load_timezone_index
       self.class.load_timezone_index
     end
-    
+
     # Loads in the index of timezones if it hasn't already been loaded.
     def self.load_timezone_index
       unless @@timezone_index_loaded
         require_index('timezones')
         @@timezone_index_loaded = true
-      end        
+      end
     end
-    
+
     # Loads in the index of countries if it hasn't already been loaded.
     def load_country_index
       self.class.load_country_index
     end
-    
+
     # Loads in the index of countries if it hasn't already been loaded.
     def self.load_country_index
       unless @@country_index_loaded

--- a/lib/tzinfo/timezone.rb
+++ b/lib/tzinfo/timezone.rb
@@ -3,33 +3,33 @@ require 'set'
 require 'thread_safe'
 
 module TZInfo
-  # AmbiguousTime is raised to indicates that a specified time in a local 
-  # timezone has more than one possible equivalent UTC time. This happens when 
-  # transitioning from daylight savings time to standard time where the clocks 
+  # AmbiguousTime is raised to indicates that a specified time in a local
+  # timezone has more than one possible equivalent UTC time. This happens when
+  # transitioning from daylight savings time to standard time where the clocks
   # are rolled back.
   #
-  # AmbiguousTime is raised by period_for_local and local_to_utc when using an 
+  # AmbiguousTime is raised by period_for_local and local_to_utc when using an
   # ambiguous time and not specifying any means to resolve the ambiguity.
   class AmbiguousTime < StandardError
   end
-  
+
   # PeriodNotFound is raised to indicate that no TimezonePeriod matching a given
   # time could be found.
   class PeriodNotFound < StandardError
   end
-  
+
   # Raised by Timezone#get if the identifier given is not valid.
   class InvalidTimezoneIdentifier < StandardError
   end
-  
+
   # Raised if an attempt is made to use a timezone created with
   # Timezone.new(nil).
   class UnknownTimezone < StandardError
   end
-  
+
   # Timezone is the base class of all timezones. It provides a factory method,
   # 'get', to access timezones by identifier. Once a specific Timezone has been
-  # retrieved, DateTimes, Times and timestamps can be converted between the UTC 
+  # retrieved, DateTimes, Times and timestamps can be converted between the UTC
   # and the local time for the zone. For example:
   #
   #   tz = TZInfo::Timezone.get('America/New_York')
@@ -37,85 +37,85 @@ module TZInfo
   #   puts tz.local_to_utc(Time.utc(2005,8,29,11,35,0)).to_s
   #   puts tz.utc_to_local(1125315300).to_s
   #
-  # Each time conversion method returns an object of the same type it was 
+  # Each time conversion method returns an object of the same type it was
   # passed.
   #
-  # The Timezone class is thread-safe. It is safe to use class and instance 
+  # The Timezone class is thread-safe. It is safe to use class and instance
   # methods of Timezone in concurrently executing threads. Instances of Timezone
   # can be shared across thread boundaries.
   class Timezone
     include Comparable
-    
+
     # Cache of loaded zones by identifier to avoid using require if a zone
     # has already been loaded.
     #
     # @!visibility private
     @@loaded_zones = nil
-        
-    # Default value of the dst parameter of the local_to_utc and 
+
+    # Default value of the dst parameter of the local_to_utc and
     # period_for_local methods.
     #
     # @!visibility private
     @@default_dst = nil
-    
-    # Sets the default value of the optional dst parameter of the 
-    # local_to_utc and period_for_local methods. Can be set to nil, true or 
+
+    # Sets the default value of the optional dst parameter of the
+    # local_to_utc and period_for_local methods. Can be set to nil, true or
     # false.
     #
     # The value of default_dst defaults to nil if unset.
     def self.default_dst=(value)
       @@default_dst = value.nil? ? nil : !!value
     end
-    
-    # Gets the default value of the optional dst parameter of the 
-    # local_to_utc and period_for_local methods. Can be set to nil, true or 
+
+    # Gets the default value of the optional dst parameter of the
+    # local_to_utc and period_for_local methods. Can be set to nil, true or
     # false.
     def self.default_dst
       @@default_dst
     end
-    
-    # Returns a timezone by its identifier (e.g. "Europe/London", 
+
+    # Returns a timezone by its identifier (e.g. "Europe/London",
     # "America/Chicago" or "UTC").
     #
     # Raises InvalidTimezoneIdentifier if the timezone couldn't be found.
     def self.get(identifier)
       instance = @@loaded_zones[identifier]
-      
+
       unless instance
-        # Thread-safety: It is possible that multiple equivalent Timezone 
-        # instances could be created here in concurrently executing threads. 
-        # The consequences of this are that the data may be loaded more than 
+        # Thread-safety: It is possible that multiple equivalent Timezone
+        # instances could be created here in concurrently executing threads.
+        # The consequences of this are that the data may be loaded more than
         # once (depending on the data source) and memoized calculations could
         # be discarded. The performance benefit of ensuring that only a single
         # instance is created is unlikely to be worth the overhead of only
         # allowing one Timezone to be loaded at a time.
         info = data_source.load_timezone_info(identifier)
         instance = info.create_timezone
-        @@loaded_zones[instance.identifier] = instance         
+        @@loaded_zones[instance.identifier] = instance
       end
-      
+
       instance
     end
-    
+
     # Returns a proxy for the Timezone with the given identifier. The proxy
-    # will cause the real timezone to be loaded when an attempt is made to 
-    # find a period or convert a time. get_proxy will not validate the 
-    # identifier. If an invalid identifier is specified, no exception will be 
-    # raised until the proxy is used. 
+    # will cause the real timezone to be loaded when an attempt is made to
+    # find a period or convert a time. get_proxy will not validate the
+    # identifier. If an invalid identifier is specified, no exception will be
+    # raised until the proxy is used.
     def self.get_proxy(identifier)
       TimezoneProxy.new(identifier)
     end
-    
-    # If identifier is nil calls super(), otherwise calls get. An identfier 
+
+    # If identifier is nil calls super(), otherwise calls get. An identfier
     # should always be passed in when called externally.
     def self.new(identifier = nil)
-      if identifier        
+      if identifier
         get(identifier)
       else
         super()
       end
     end
-    
+
     # Returns an array containing all the available Timezones.
     #
     # Returns TimezoneProxy objects to avoid the overhead of loading Timezone
@@ -123,13 +123,13 @@ module TZInfo
     def self.all
       get_proxies(all_identifiers)
     end
-    
-    # Returns an array containing the identifiers of all the available 
+
+    # Returns an array containing the identifiers of all the available
     # Timezones.
     def self.all_identifiers
       data_source.timezone_identifiers
     end
-    
+
     # Returns an array containing all the available Timezones that are based
     # on data (are not links to other Timezones).
     #
@@ -138,42 +138,42 @@ module TZInfo
     def self.all_data_zones
       get_proxies(all_data_zone_identifiers)
     end
-    
-    # Returns an array containing the identifiers of all the available 
+
+    # Returns an array containing the identifiers of all the available
     # Timezones that are based on data (are not links to other Timezones)..
     def self.all_data_zone_identifiers
       data_source.data_timezone_identifiers
     end
-    
+
     # Returns an array containing all the available Timezones that are links
     # to other Timezones.
     #
     # Returns TimezoneProxy objects to avoid the overhead of loading Timezone
     # definitions until a conversion is actually required.
     def self.all_linked_zones
-      get_proxies(all_linked_zone_identifiers)      
+      get_proxies(all_linked_zone_identifiers)
     end
-    
-    # Returns an array containing the identifiers of all the available 
+
+    # Returns an array containing the identifiers of all the available
     # Timezones that are links to other Timezones.
     def self.all_linked_zone_identifiers
       data_source.linked_timezone_identifiers
     end
-    
+
     # Returns all the Timezones defined for all Countries. This is not the
-    # complete set of Timezones as some are not country specific (e.g. 
+    # complete set of Timezones as some are not country specific (e.g.
     # 'Etc/GMT').
-    # 
+    #
     # Returns TimezoneProxy objects to avoid the overhead of loading Timezone
-    # definitions until a conversion is actually required.        
+    # definitions until a conversion is actually required.
     def self.all_country_zones
       Country.all_codes.inject([]) do |zones,country|
         zones += Country.get(country).zones
       end.uniq
     end
-    
+
     # Returns all the zone identifiers defined for all Countries. This is not the
-    # complete set of zone identifiers as some are not country specific (e.g. 
+    # complete set of zone identifiers as some are not country specific (e.g.
     # 'Etc/GMT'). You can obtain a Timezone instance for a given identifier
     # with the get method.
     def self.all_country_zone_identifiers
@@ -181,8 +181,8 @@ module TZInfo
         zones += Country.get(country).zone_identifiers
       end.uniq
     end
-    
-    # Returns all US Timezone instances. A shortcut for 
+
+    # Returns all US Timezone instances. A shortcut for
     # TZInfo::Country.get('US').zones.
     #
     # Returns TimezoneProxy objects to avoid the overhead of loading Timezone
@@ -190,35 +190,35 @@ module TZInfo
     def self.us_zones
       Country.get('US').zones
     end
-    
-    # Returns all US zone identifiers. A shortcut for 
+
+    # Returns all US zone identifiers. A shortcut for
     # TZInfo::Country.get('US').zone_identifiers.
     def self.us_zone_identifiers
       Country.get('US').zone_identifiers
     end
-    
+
     # The identifier of the timezone, e.g. "Europe/Paris".
     def identifier
       raise_unknown_timezone
     end
-    
+
     # An alias for identifier.
     def name
       # Don't use alias, as identifier gets overridden.
       identifier
     end
-    
+
     # Returns a friendlier version of the identifier.
     def to_s
       friendly_identifier
     end
-    
+
     # Returns internal object state as a programmer-readable string.
     def inspect
       "#<#{self.class}: #{identifier}>"
     end
-    
-    # Returns a friendlier version of the identifier. Set skip_first_part to 
+
+    # Returns a friendlier version of the identifier. Set skip_first_part to
     # omit the first part of the identifier (typically a region name) where
     # there is more than one part.
     #
@@ -227,13 +227,13 @@ module TZInfo
     #   Timezone.get('Europe/Paris').friendly_identifier(false)          #=> "Europe - Paris"
     #   Timezone.get('Europe/Paris').friendly_identifier(true)           #=> "Paris"
     #   Timezone.get('America/Indiana/Knox').friendly_identifier(false)  #=> "America - Knox, Indiana"
-    #   Timezone.get('America/Indiana/Knox').friendly_identifier(true)   #=> "Knox, Indiana"           
+    #   Timezone.get('America/Indiana/Knox').friendly_identifier(true)   #=> "Knox, Indiana"
     def friendly_identifier(skip_first_part = false)
       parts = identifier.split('/')
       if parts.empty?
         # shouldn't happen
         identifier
-      elsif parts.length == 1        
+      elsif parts.length == 1
         parts[0]
       else
         if skip_first_part
@@ -241,62 +241,62 @@ module TZInfo
         else
           result = parts[0] + ' - '
         end
-        
+
         parts[1, parts.length - 1].reverse_each {|part|
           part.gsub!(/_/, ' ')
-          
+
           if part.index(/[a-z]/)
             # Missing a space if a lower case followed by an upper case and the
             # name isn't McXxxx.
             part.gsub!(/([^M][a-z])([A-Z])/, '\1 \2')
             part.gsub!(/([M][a-bd-z])([A-Z])/, '\1 \2')
-            
+
             # Missing an apostrophe if two consecutive upper case characters.
             part.gsub!(/([A-Z])([A-Z])/, '\1\'\2')
           end
-          
+
           result << part
           result << ', '
         }
-        
+
         result.slice!(result.length - 2, 2)
         result
       end
     end
-    
+
     # Returns the TimezonePeriod for the given UTC time. utc can either be
-    # a DateTime, Time or integer timestamp (Time.to_i). Any timezone 
-    # information in utc is ignored (it is treated as a UTC time).        
-    def period_for_utc(utc)            
+    # a DateTime, Time or integer timestamp (Time.to_i). Any timezone
+    # information in utc is ignored (it is treated as a UTC time).
+    def period_for_utc(utc)
       raise_unknown_timezone
     end
-    
+
     # Returns the set of TimezonePeriod instances that are valid for the given
-    # local time as an array. If you just want a single period, use 
+    # local time as an array. If you just want a single period, use
     # period_for_local instead and specify how ambiguities should be resolved.
     # Returns an empty array if no periods are found for the given time.
     def periods_for_local(local)
       raise_unknown_timezone
     end
-    
+
     # Returns an Array of TimezoneTransition instances representing the times
     # where the UTC offset of the timezone changes.
     #
-    # Transitions are returned up to a given date and time up to a given date 
+    # Transitions are returned up to a given date and time up to a given date
     # and time, specified in UTC (utc_to).
     #
     # A from date and time may also be supplied using the utc_from parameter
-    # (also specified in UTC). If utc_from is not nil, only transitions from 
+    # (also specified in UTC). If utc_from is not nil, only transitions from
     # that date and time onwards will be returned.
     #
     # Comparisons with utc_to are exclusive. Comparisons with utc_from are
     # inclusive. If a transition falls precisely on utc_to, it will be excluded.
     # If a transition falls on utc_from, it will be included.
     #
-    # Transitions returned are ordered by when they occur, from earliest to 
+    # Transitions returned are ordered by when they occur, from earliest to
     # latest.
     #
-    # utc_to and utc_from can be specified using either DateTime, Time or 
+    # utc_to and utc_from can be specified using either DateTime, Time or
     # integer timestamps (Time.to_i).
     #
     # If utc_from is specified and utc_to is not greater than utc_from, then
@@ -304,49 +304,49 @@ module TZInfo
     def transitions_up_to(utc_to, utc_from = nil)
       raise_unknown_timezone
     end
-    
+
     # Returns the canonical Timezone instance for this Timezone.
     #
-    # The IANA Time Zone database contains two types of definition: Zones and 
-    # Links. Zones are defined by rules that set out when transitions occur. 
-    # Links are just references to fully defined Zone, creating an alias for 
+    # The IANA Time Zone database contains two types of definition: Zones and
+    # Links. Zones are defined by rules that set out when transitions occur.
+    # Links are just references to fully defined Zone, creating an alias for
     # that Zone.
     #
-    # Links are commonly used where a time zone has been renamed in a 
-    # release of the Time Zone database. For example, the Zone US/Eastern was 
+    # Links are commonly used where a time zone has been renamed in a
+    # release of the Time Zone database. For example, the Zone US/Eastern was
     # renamed as America/New_York. A US/Eastern Link was added in its place,
     # linking to (and creating an alias for) for America/New_York.
     #
-    # Links are also used for time zones that are currently identical to a full 
+    # Links are also used for time zones that are currently identical to a full
     # Zone, but that are administered seperately. For example, Europe/Vatican is
     # a Link to (and alias for) Europe/Rome.
     #
     # For a full Zone, canonical_zone returns self.
     #
-    # For a Link, canonical_zone returns a Timezone instance representing the 
+    # For a Link, canonical_zone returns a Timezone instance representing the
     # full Zone that the link targets.
     #
     # TZInfo can be used with different data sources (see the documentation for
-    # TZInfo::DataSource). Please note that some DataSource implementations may 
+    # TZInfo::DataSource). Please note that some DataSource implementations may
     # not support distinguishing between full Zones and Links and will treat all
-    # time zones as full Zones. In this case, the canonical_zone will always 
+    # time zones as full Zones. In this case, the canonical_zone will always
     # return self.
     #
     # There are two built-in DataSource implementations. RubyDataSource (which
     # will be used if the tzinfo-data gem is available) supports Link zones.
-    # ZoneinfoDataSource returns Link zones as if they were full Zones. If the 
-    # canonical_zone or canonical_identifier methods are required, the 
+    # ZoneinfoDataSource returns Link zones as if they were full Zones. If the
+    # canonical_zone or canonical_identifier methods are required, the
     # tzinfo-data gem should be installed.
     #
-    # The TZInfo::DataSource.get method can be used to check which DataSource 
+    # The TZInfo::DataSource.get method can be used to check which DataSource
     # implementation is being used.
     def canonical_zone
       raise_unknown_timezone
     end
-    
+
     # Returns the TimezonePeriod for the given local time. local can either be
-    # a DateTime, Time or integer timestamp (Time.to_i). Any timezone 
-    # information in local is ignored (it is treated as a time in the current 
+    # a DateTime, Time or integer timestamp (Time.to_i). Any timezone
+    # information in local is ignored (it is treated as a time in the current
     # timezone).
     #
     # Warning: There are local times that have no equivalent UTC times (e.g.
@@ -359,21 +359,21 @@ module TZInfo
     #
     # In the second case (more than one equivalent UTC time), an AmbiguousTime
     # exception will be raised unless the optional dst parameter or block
-    # handles the ambiguity. 
+    # handles the ambiguity.
     #
     # If the ambiguity is due to a transition from daylight savings time to
-    # standard time, the dst parameter can be used to select whether the 
+    # standard time, the dst parameter can be used to select whether the
     # daylight savings time or local time is used. For example,
     #
     #   Timezone.get('America/New_York').period_for_local(DateTime.new(2004,10,31,1,30,0))
     #
     # would raise an AmbiguousTime exception.
     #
-    # Specifying dst=true would the daylight savings period from April to 
+    # Specifying dst=true would the daylight savings period from April to
     # October 2004. Specifying dst=false would return the standard period
     # from October 2004 to April 2005.
     #
-    # If the dst parameter does not resolve the ambiguity, and a block is 
+    # If the dst parameter does not resolve the ambiguity, and a block is
     # specified, it is called. The block must take a single parameter - an
     # array of the periods that need to be resolved. The block can select and
     # return a single period or return nil or an empty array
@@ -385,49 +385,49 @@ module TZInfo
     # a block is given to resolve the ambiguity.
     def period_for_local(local, dst = Timezone.default_dst)
       results = periods_for_local(local)
-      
+
       if results.empty?
         raise PeriodNotFound
       elsif results.size < 2
         results.first
       else
         # ambiguous result try to resolve
-        
+
         if !dst.nil?
           matches = results.find_all {|period| period.dst? == dst}
-          results = matches if !matches.empty?            
+          results = matches if !matches.empty?
         end
-        
+
         if results.size < 2
           results.first
         else
           # still ambiguous, try the block
-                    
+
           if block_given?
             results = yield results
           end
-          
+
           if results.is_a?(TimezonePeriod)
             results
           elsif results && results.size == 1
             results.first
-          else          
+          else
             raise AmbiguousTime, "#{local} is an ambiguous local time."
           end
         end
-      end      
+      end
     end
-    
+
     # Converts a time in UTC to the local timezone. utc can either be
     # a DateTime, Time or timestamp (Time.to_i). The returned time has the same
-    # type as utc. Any timezone information in utc is ignored (it is treated as 
+    # type as utc. Any timezone information in utc is ignored (it is treated as
     # a UTC time).
     def utc_to_local(utc)
       TimeOrDateTime.wrap(utc) {|wrapped|
         period_for_utc(wrapped).to_local(wrapped)
       }
     end
-    
+
     # Converts a time in the local timezone to UTC. local can either be
     # a DateTime, Time or timestamp (Time.to_i). The returned time has the same
     # type as local. Any timezone information in local is ignored (it is treated
@@ -443,10 +443,10 @@ module TZInfo
     #
     # In the second case (more than one equivalent UTC time), an AmbiguousTime
     # exception will be raised unless the optional dst parameter or block
-    # handles the ambiguity. 
+    # handles the ambiguity.
     #
     # If the ambiguity is due to a transition from daylight savings time to
-    # standard time, the dst parameter can be used to select whether the 
+    # standard time, the dst parameter can be used to select whether the
     # daylight savings time or local time is used. For example,
     #
     #   Timezone.get('America/New_York').local_to_utc(DateTime.new(2004,10,31,1,30,0))
@@ -456,7 +456,7 @@ module TZInfo
     # Specifying dst=true would return 2004-10-31 5:30:00. Specifying dst=false
     # would return 2004-10-31 6:30:00.
     #
-    # If the dst parameter does not resolve the ambiguity, and a block is 
+    # If the dst parameter does not resolve the ambiguity, and a block is
     # specified, it is called. The block must take a single parameter - an
     # array of the periods that need to be resolved. The block can return a
     # single period to use to convert the time or return nil or an empty array
@@ -473,17 +473,17 @@ module TZInfo
         else
           period = period_for_local(wrapped, dst)
         end
-        
+
         period.to_utc(wrapped)
       }
     end
-    
+
     # Returns information about offsets used by the Timezone up to a given
     # date and time, specified using UTC (utc_to). The information is returned
     # as an Array of TimezoneOffset instances.
     #
     # A from date and time may also be supplied using the utc_from parameter
-    # (also specified in UTC). If utc_from is not nil, only offsets used from 
+    # (also specified in UTC). If utc_from is not nil, only offsets used from
     # that date and time forward will be returned.
     #
     # Comparisons with utc_to are exclusive. Comparisons with utc_from are
@@ -491,7 +491,7 @@ module TZInfo
     #
     # Offsets may be returned in any order.
     #
-    # utc_to and utc_from can be specified using either DateTime, Time or 
+    # utc_to and utc_from can be specified using either DateTime, Time or
     # integer timestamps (Time.to_i).
     #
     # If utc_from is specified and utc_to is not greater than utc_from, then
@@ -499,7 +499,7 @@ module TZInfo
     def offsets_up_to(utc_to, utc_from = nil)
       utc_to = TimeOrDateTime.wrap(utc_to)
       transitions = transitions_up_to(utc_to, utc_from)
-      
+
       if transitions.empty?
         # No transitions in the range, find the period that covers it.
 
@@ -509,28 +509,28 @@ module TZInfo
         else
           # utc_to is exclusive, so this can't be used with period_for_utc.
           # However, any time earlier than utc_to can be used.
-          
+
           # Subtract 1 hour (since this is one of the cached OffsetRationals).
           # Use add_with_convert so that conversion to DateTime is performed if
           # required.
           period = period_for_utc(utc_to.add_with_convert(-3600))
         end
-      
+
         [period.offset]
       else
         result = Set.new
-        
-        first = transitions.first        
+
+        first = transitions.first
         result << first.previous_offset unless utc_from && first.at == utc_from
-        
+
         transitions.each do |t|
           result << t.offset
         end
-        
+
         result.to_a
       end
     end
-    
+
     # Returns the canonical identifier for this Timezone.
     #
     # This is a shortcut for calling canonical_zone.identifier. Please refer
@@ -538,17 +538,17 @@ module TZInfo
     def canonical_identifier
       canonical_zone.identifier
     end
-    
+
     # Returns the current time in the timezone as a Time.
     def now
       utc_to_local(Time.now.utc)
     end
-    
-    # Returns the TimezonePeriod for the current time. 
+
+    # Returns the TimezonePeriod for the current time.
     def current_period
       period_for_utc(Time.now.utc)
     end
-    
+
     # Returns the current Time and TimezonePeriod as an array. The first element
     # is the time, the second element is the period.
     def current_period_and_time
@@ -556,10 +556,10 @@ module TZInfo
       period = period_for_utc(utc)
       [period.to_local(utc), period]
     end
-    
+
     alias :current_time_and_period :current_period_and_time
 
-    # Converts a time in UTC to local time and returns it as a string 
+    # Converts a time in UTC to local time and returns it as a string
     # according to the given format.
     #
     # The formatting is identical to Time.strftime and DateTime.strftime, except
@@ -572,12 +572,12 @@ module TZInfo
     # - %:z - hour and minute separated with a colon (e.g. +05:00)
     # - %::z - hour minute and second separated with colons (e.g. +05:00:00)
     # - %:::z - hour only (e.g. +05)
-    def strftime(format, utc = Time.now.utc)      
+    def strftime(format, utc = Time.now.utc)
       period = period_for_utc(utc)
-      local = period.to_local(utc)      
+      local = period.to_local(utc)
       local = Time.at(local).utc unless local.kind_of?(Time) || local.kind_of?(DateTime)
       abbreviation = period.abbreviation.to_s.gsub(/%/, '%%')
-      
+
       format = format.gsub(/%(%*)(Z|:{0,3}z)/) do
         if $1.length.odd?
           # return %%Z so the real strftime treats it as a literal %Z too
@@ -599,10 +599,10 @@ module TZInfo
           end
         end
       end
-      
+
       local.strftime(format)
     end
-    
+
     # Compares two Timezones based on their identifier. Returns -1 if tz is less
     # than self, 0 if tz is equal to self and +1 if tz is greater than self.
     #
@@ -612,40 +612,40 @@ module TZInfo
       identifier <=> tz.identifier
     end
 
-    # Returns true if and only if the identifier of tz is equal to the 
+    # Returns true if and only if the identifier of tz is equal to the
     # identifier of this Timezone.
     def eql?(tz)
       self == tz
     end
-    
+
     # Returns a hash of this Timezone.
     def hash
       identifier.hash
     end
-    
+
     # Dumps this Timezone for marshalling.
     def _dump(limit)
       identifier
     end
-    
+
     # Loads a marshalled Timezone.
     def self._load(data)
       Timezone.get(data)
     end
-    
+
     private
       # Initializes @@loaded_zones.
       def self.init_loaded_zones
         @@loaded_zones = ThreadSafe::Cache.new
       end
       init_loaded_zones
-    
-      # Returns an array of proxies corresponding to the given array of 
+
+      # Returns an array of proxies corresponding to the given array of
       # identifiers.
       def self.get_proxies(identifiers)
         identifiers.collect {|identifier| get_proxy(identifier)}
       end
-      
+
       # Returns the current DataSource.
       def self.data_source
         DataSource.get
@@ -655,5 +655,5 @@ module TZInfo
       def raise_unknown_timezone
         raise UnknownTimezone, 'TZInfo::Timezone constructed directly'
       end
-  end        
+  end
 end

--- a/lib/tzinfo/timezone_definition.rb
+++ b/lib/tzinfo/timezone_definition.rb
@@ -1,5 +1,5 @@
 module TZInfo
-  
+
   # TimezoneDefinition is included into Timezone definition modules.
   # TimezoneDefinition provides the methods for defining timezones.
   #
@@ -10,23 +10,23 @@ module TZInfo
       super
       base.extend(ClassMethods)
     end
-    
+
     # Class methods for inclusion.
     #
     # @private
     module ClassMethods #:nodoc:
-      # Returns and yields a TransitionDataTimezoneInfo object to define a 
+      # Returns and yields a TransitionDataTimezoneInfo object to define a
       # timezone.
       def timezone(identifier)
         yield @timezone = TransitionDataTimezoneInfo.new(identifier)
       end
-      
+
       # Defines a linked timezone.
       def linked_timezone(identifier, link_to_identifier)
         @timezone = LinkedTimezoneInfo.new(identifier, link_to_identifier)
       end
-      
-      # Returns the last TimezoneInfo to be defined with timezone or 
+
+      # Returns the last TimezoneInfo to be defined with timezone or
       # linked_timezone.
       def get
         @timezone

--- a/lib/tzinfo/timezone_index_definition.rb
+++ b/lib/tzinfo/timezone_index_definition.rb
@@ -14,7 +14,7 @@ module TZInfo
         @linked_timezones = []
       end
     end
-    
+
     # Class methods for inclusion.
     #
     # @private
@@ -24,31 +24,31 @@ module TZInfo
         @timezones << identifier
         @data_timezones << identifier
       end
-      
+
       # Defines a timezone which is a link to another timezone.
       def linked_timezone(identifier)
         @timezones << identifier
         @linked_timezones << identifier
       end
-      
+
       # Returns a frozen array containing the identifiers of all the timezones.
       # Identifiers appear in the order they were defined in the index.
       def timezones
         @timezones.freeze
       end
-      
+
       # Returns a frozen array containing the identifiers of all data timezones.
       # Identifiers appear in the order they were defined in the index.
       def data_timezones
         @data_timezones.freeze
       end
-      
+
       # Returns a frozen array containing the identifiers of all linked
-      # timezones. Identifiers appear in the order they were defined in 
+      # timezones. Identifiers appear in the order they were defined in
       # the index.
       def linked_timezones
         @linked_timezones.freeze
-      end      
+      end
     end
   end
 end

--- a/lib/tzinfo/timezone_info.rb
+++ b/lib/tzinfo/timezone_info.rb
@@ -1,20 +1,20 @@
 module TZInfo
   # Represents a timezone defined by a data source.
   class TimezoneInfo
-    
+
     # The timezone identifier.
     attr_reader :identifier
-    
+
     # Constructs a new TimezoneInfo with an identifier.
     def initialize(identifier)
       @identifier = identifier
     end
-    
+
     # Returns internal object state as a programmer-readable string.
     def inspect
       "#<#{self.class}: #@identifier>"
     end
-    
+
     # Constructs a Timezone instance for the timezone represented by this
     # TimezoneInfo.
     def create_timezone

--- a/lib/tzinfo/timezone_offset.rb
+++ b/lib/tzinfo/timezone_offset.rb
@@ -3,43 +3,43 @@ module TZInfo
   class TimezoneOffset
     # The base offset of the timezone from UTC in seconds.
     attr_reader :utc_offset
-    
-    # The offset from standard time for the zone in seconds (i.e. non-zero if 
+
+    # The offset from standard time for the zone in seconds (i.e. non-zero if
     # daylight savings is being observed).
     attr_reader :std_offset
-    
-    # The total offset of this observance from UTC in seconds 
+
+    # The total offset of this observance from UTC in seconds
     # (utc_offset + std_offset).
     attr_reader :utc_total_offset
-    
-    # The abbreviation that identifies this observance, e.g. "GMT" 
-    # (Greenwich Mean Time) or "BST" (British Summer Time) for "Europe/London". The returned identifier is a 
+
+    # The abbreviation that identifies this observance, e.g. "GMT"
+    # (Greenwich Mean Time) or "BST" (British Summer Time) for "Europe/London". The returned identifier is a
     # symbol.
     attr_reader :abbreviation
-    
-    # Constructs a new TimezoneOffset. utc_offset and std_offset are specified 
+
+    # Constructs a new TimezoneOffset. utc_offset and std_offset are specified
     # in seconds.
     def initialize(utc_offset, std_offset, abbreviation)
       @utc_offset = utc_offset
-      @std_offset = std_offset      
+      @std_offset = std_offset
       @abbreviation = abbreviation
-      
+
       @utc_total_offset = @utc_offset + @std_offset
     end
-    
+
     # True if std_offset is non-zero.
     def dst?
       @std_offset != 0
     end
-    
-    # Converts a UTC Time, DateTime or integer timestamp to local time, based on 
+
+    # Converts a UTC Time, DateTime or integer timestamp to local time, based on
     # the offset of this period.
     def to_local(utc)
       TimeOrDateTime.wrap(utc) {|wrapped|
         wrapped + @utc_total_offset
       }
     end
-    
+
     # Converts a local Time, DateTime or integer timestamp to UTC, based on the
     # offset of this period.
     def to_utc(local)
@@ -47,25 +47,25 @@ module TZInfo
         wrapped - @utc_total_offset
       }
     end
-    
+
     # Returns true if and only if toi has the same utc_offset, std_offset
     # and abbreviation as this TimezoneOffset.
     def ==(toi)
       toi.kind_of?(TimezoneOffset) &&
         utc_offset == toi.utc_offset && std_offset == toi.std_offset && abbreviation == toi.abbreviation
     end
-    
+
     # Returns true if and only if toi has the same utc_offset, std_offset
     # and abbreviation as this TimezoneOffset.
     def eql?(toi)
       self == toi
     end
-    
+
     # Returns a hash of this TimezoneOffset.
     def hash
       utc_offset.hash ^ std_offset.hash ^ abbreviation.hash
     end
-    
+
     # Returns internal object state as a programmer-readable string.
     def inspect
       "#<#{self.class}: #@utc_offset,#@std_offset,#@abbreviation>"

--- a/lib/tzinfo/timezone_period.rb
+++ b/lib/tzinfo/timezone_period.rb
@@ -4,29 +4,29 @@ module TZInfo
   # All the methods that take times accept instances of Time or DateTime as well
   # as Integer timestamps.
   class TimezonePeriod
-    # The TimezoneTransition that defines the start of this TimezonePeriod 
+    # The TimezoneTransition that defines the start of this TimezonePeriod
     # (may be nil if unbounded).
     attr_reader :start_transition
-    
+
     # The TimezoneTransition that defines the end of this TimezonePeriod
     # (may be nil if unbounded).
     attr_reader :end_transition
-    
+
     # The TimezoneOffset for this period.
     attr_reader :offset
-    
+
     # Initializes a new TimezonePeriod.
     #
     # TimezonePeriod instances should not normally be constructed manually.
     def initialize(start_transition, end_transition, offset = nil)
       @start_transition = start_transition
       @end_transition = end_transition
-      
+
       if offset
         raise ArgumentError, 'Offset specified with transitions' if @start_transition || @end_transition
         @offset = offset
       else
-        if @start_transition 
+        if @start_transition
           @offset = @start_transition.offset
         elsif @end_transition
           @offset = @end_transition.previous_offset
@@ -34,142 +34,142 @@ module TZInfo
           raise ArgumentError, 'No offset specified and no transitions to determine it from'
         end
       end
-      
-      @utc_total_offset_rational = nil      
+
+      @utc_total_offset_rational = nil
     end
-            
+
     # Base offset of the timezone from UTC (seconds).
     def utc_offset
       @offset.utc_offset
     end
-    
+
     # Offset from the local time where daylight savings is in effect (seconds).
-    # E.g.: utc_offset could be -5 hours. Normally, std_offset would be 0. 
+    # E.g.: utc_offset could be -5 hours. Normally, std_offset would be 0.
     # During daylight savings, std_offset would typically become +1 hours.
     def std_offset
       @offset.std_offset
     end
-    
+
     # The identifier of this period, e.g. "GMT" (Greenwich Mean Time) or "BST"
-    # (British Summer Time) for "Europe/London". The returned identifier is a 
+    # (British Summer Time) for "Europe/London". The returned identifier is a
     # symbol.
     def abbreviation
       @offset.abbreviation
     end
     alias :zone_identifier :abbreviation
-    
+
     # Total offset from UTC (seconds). Equal to utc_offset + std_offset.
     def utc_total_offset
       @offset.utc_total_offset
     end
-    
+
     # Total offset from UTC (days). Result is a Rational.
     def utc_total_offset_rational
-      # Thread-safety: It is possible that the value of 
-      # @utc_total_offset_rational may be calculated multiple times in 
+      # Thread-safety: It is possible that the value of
+      # @utc_total_offset_rational may be calculated multiple times in
       # concurrently executing threads. It is not worth the overhead of locking
       # to ensure that @zone_identifiers is only calculated once.
-    
+
       unless @utc_total_offset_rational
-        @utc_total_offset_rational = OffsetRationals.rational_for_offset(utc_total_offset) 
+        @utc_total_offset_rational = OffsetRationals.rational_for_offset(utc_total_offset)
       end
       @utc_total_offset_rational
     end
-    
+
     # The start time of the period in UTC as a DateTime. May be nil if unbounded.
     def utc_start
       @start_transition ? @start_transition.at.to_datetime : nil
     end
-    
+
     # The start time of the period in UTC as a Time. May be nil if unbounded.
     def utc_start_time
       @start_transition ? @start_transition.at.to_time : nil
     end
-    
+
     # The end time of the period in UTC as a DateTime. May be nil if unbounded.
     def utc_end
       @end_transition ? @end_transition.at.to_datetime : nil
     end
-    
+
     # The end time of the period in UTC as a Time. May be nil if unbounded.
     def utc_end_time
       @end_transition ? @end_transition.at.to_time : nil
     end
-    
-    # The start time of the period in local time as a DateTime. May be nil if 
+
+    # The start time of the period in local time as a DateTime. May be nil if
     # unbounded.
     def local_start
       @start_transition ? @start_transition.local_start_at.to_datetime : nil
     end
-    
-    # The start time of the period in local time as a Time. May be nil if 
+
+    # The start time of the period in local time as a Time. May be nil if
     # unbounded.
     def local_start_time
       @start_transition ? @start_transition.local_start_at.to_time : nil
     end
-    
-    # The end time of the period in local time as a DateTime. May be nil if 
+
+    # The end time of the period in local time as a DateTime. May be nil if
     # unbounded.
     def local_end
       @end_transition ? @end_transition.local_end_at.to_datetime : nil
     end
-    
-    # The end time of the period in local time as a Time. May be nil if 
+
+    # The end time of the period in local time as a Time. May be nil if
     # unbounded.
     def local_end_time
       @end_transition ? @end_transition.local_end_at.to_time : nil
     end
-    
+
     # true if daylight savings is in effect for this period; otherwise false.
     def dst?
       @offset.dst?
     end
-    
+
     # true if this period is valid for the given UTC DateTime; otherwise false.
     def valid_for_utc?(utc)
-      utc_after_start?(utc) && utc_before_end?(utc) 
+      utc_after_start?(utc) && utc_before_end?(utc)
     end
-    
-    # true if the given UTC DateTime is after the start of the period 
+
+    # true if the given UTC DateTime is after the start of the period
     # (inclusive); otherwise false.
     def utc_after_start?(utc)
       !@start_transition || @start_transition.at <= utc
     end
-    
-    # true if the given UTC DateTime is before the end of the period 
+
+    # true if the given UTC DateTime is before the end of the period
     # (exclusive); otherwise false.
     def utc_before_end?(utc)
       !@end_transition || @end_transition.at > utc
     end
-    
+
     # true if this period is valid for the given local DateTime; otherwise false.
-    def valid_for_local?(local)      
-      local_after_start?(local) && local_before_end?(local) 
+    def valid_for_local?(local)
+      local_after_start?(local) && local_before_end?(local)
     end
-    
-    # true if the given local DateTime is after the start of the period 
+
+    # true if the given local DateTime is after the start of the period
     # (inclusive); otherwise false.
     def local_after_start?(local)
       !@start_transition || @start_transition.local_start_at <= local
     end
-    
-    # true if the given local DateTime is before the end of the period 
+
+    # true if the given local DateTime is before the end of the period
     # (exclusive); otherwise false.
     def local_before_end?(local)
       !@end_transition || @end_transition.local_end_at > local
     end
-    
+
     # Converts a UTC DateTime to local time based on the offset of this period.
     def to_local(utc)
       @offset.to_local(utc)
     end
-    
+
     # Converts a local DateTime to UTC based on the offset of this period.
     def to_utc(local)
       @offset.to_utc(local)
     end
-    
-    # Returns true if this TimezonePeriod is equal to p. This compares the 
+
+    # Returns true if this TimezonePeriod is equal to p. This compares the
     # start_transition, end_transition and offset using ==.
     def ==(p)
       p.kind_of?(TimezonePeriod) &&
@@ -177,7 +177,7 @@ module TZInfo
         end_transition == p.end_transition &&
         offset == p.offset
     end
-    
+
     # Returns true if this TimezonePeriods is equal to p. This compares the
     # start_transition, end_transition and offset using eql?
     def eql?(p)
@@ -186,14 +186,14 @@ module TZInfo
         end_transition.eql?(p.end_transition) &&
         offset.eql?(p.offset)
     end
-    
+
     # Returns a hash of this TimezonePeriod.
     def hash
       result = @start_transition.hash ^ @end_transition.hash
       result ^= @offset.hash unless @start_transition || @end_transition
-      result       
+      result
     end
-    
+
     # Returns internal object state as a programmer-readable string.
     def inspect
       result = "#<#{self.class}: #{@start_transition.inspect},#{@end_transition.inspect}"

--- a/lib/tzinfo/timezone_proxy.rb
+++ b/lib/tzinfo/timezone_proxy.rb
@@ -4,9 +4,9 @@ module TZInfo
   # inherits from Timezone and can be treated like any Timezone loaded with
   # Timezone.get.
   #
-  # The first time an attempt is made to access the data for the timezone, the 
-  # real Timezone is loaded. If the proxy's identifier was not valid, then an 
-  # exception will be raised at this point.  
+  # The first time an attempt is made to access the data for the timezone, the
+  # real Timezone is loaded. If the proxy's identifier was not valid, then an
+  # exception will be raised at this point.
   class TimezoneProxy < Timezone
     # Construct a new TimezoneProxy for the given identifier. The identifier
     # is not checked when constructing the proxy. It will be validated on the
@@ -17,54 +17,54 @@ module TZInfo
       tzp.send(:setup, identifier)
       tzp
     end
-        
+
     # The identifier of the timezone, e.g. "Europe/Paris".
     def identifier
       @real_timezone ? @real_timezone.identifier : @identifier
     end
-    
+
     # Returns the TimezonePeriod for the given UTC time. utc can either be
-    # a DateTime, Time or integer timestamp (Time.to_i). Any timezone 
-    # information in utc is ignored (it is treated as a UTC time).        
-    def period_for_utc(utc)            
-      real_timezone.period_for_utc(utc)            
+    # a DateTime, Time or integer timestamp (Time.to_i). Any timezone
+    # information in utc is ignored (it is treated as a UTC time).
+    def period_for_utc(utc)
+      real_timezone.period_for_utc(utc)
     end
-    
+
     # Returns the set of TimezonePeriod instances that are valid for the given
-    # local time as an array. If you just want a single period, use 
+    # local time as an array. If you just want a single period, use
     # period_for_local instead and specify how abiguities should be resolved.
     # Returns an empty array if no periods are found for the given time.
     def periods_for_local(local)
       real_timezone.periods_for_local(local)
     end
-    
+
     # Returns the canonical zone for this Timezone.
     def canonical_zone
       real_timezone.canonical_zone
     end
-    
+
     # Dumps this TimezoneProxy for marshalling.
     def _dump(limit)
       identifier
     end
-    
+
     # Loads a marshalled TimezoneProxy.
     def self._load(data)
       TimezoneProxy.new(data)
     end
-    
+
     private
       def setup(identifier)
         @identifier = identifier
         @real_timezone = nil
-      end  
-    
+      end
+
       def real_timezone
-        # Thread-safety: It is possible that the value of @real_timezone may be 
-        # calculated multiple times in concurrently executing threads. It is not 
-        # worth the overhead of locking to ensure that @real_timezone is only 
+        # Thread-safety: It is possible that the value of @real_timezone may be
+        # calculated multiple times in concurrently executing threads. It is not
+        # worth the overhead of locking to ensure that @real_timezone is only
         # calculated once.
         @real_timezone ||= Timezone.get(@identifier)
-      end     
-  end 
+      end
+  end
 end

--- a/lib/tzinfo/timezone_transition.rb
+++ b/lib/tzinfo/timezone_transition.rb
@@ -4,10 +4,10 @@ module TZInfo
   class TimezoneTransition
     # The offset this transition changes to (a TimezoneOffset instance).
     attr_reader :offset
-    
+
     # The offset this transition changes from (a TimezoneOffset instance).
     attr_reader :previous_offset
-    
+
     # Initializes a new TimezoneTransition.
     #
     # TimezoneTransition instances should not normally be constructed manually.
@@ -17,98 +17,98 @@ module TZInfo
       @local_end_at = nil
       @local_start_at = nil
     end
-    
+
     # A TimeOrDateTime instance representing the UTC time when this transition
     # occurs.
     def at
       raise_not_implemented('at')
     end
-    
+
     # The UTC time when this transition occurs, returned as a DateTime instance.
     def datetime
       at.to_datetime
     end
-    
+
     # The UTC time when this transition occurs, returned as a Time instance.
     def time
       at.to_time
     end
-    
+
     # A TimeOrDateTime instance representing the local time when this transition
-    # causes the previous observance to end (calculated from at using 
+    # causes the previous observance to end (calculated from at using
     # previous_offset).
     def local_end_at
       # Thread-safety: It is possible that the value of @local_end_at may be
-      # calculated multiple times in concurrently executing threads. It is not 
+      # calculated multiple times in concurrently executing threads. It is not
       # worth the overhead of locking to ensure that @local_end_at is only
       # calculated once.
-    
+
       @local_end_at = at.add_with_convert(@previous_offset.utc_total_offset) unless @local_end_at
       @local_end_at
     end
-    
+
     # The local time when this transition causes the previous observance to end,
     # returned as a DateTime instance.
     def local_end
       local_end_at.to_datetime
     end
-    
+
     # The local time when this transition causes the previous observance to end,
     # returned as a Time instance.
     def local_end_time
       local_end_at.to_time
     end
-    
+
     # A TimeOrDateTime instance representing the local time when this transition
     # causes the next observance to start (calculated from at using offset).
     def local_start_at
       # Thread-safety: It is possible that the value of @local_start_at may be
-      # calculated multiple times in concurrently executing threads. It is not 
+      # calculated multiple times in concurrently executing threads. It is not
       # worth the overhead of locking to ensure that @local_start_at is only
       # calculated once.
-    
+
       @local_start_at = at.add_with_convert(@offset.utc_total_offset) unless @local_start_at
       @local_start_at
     end
-    
+
     # The local time when this transition causes the next observance to start,
     # returned as a DateTime instance.
     def local_start
       local_start_at.to_datetime
     end
-    
+
     # The local time when this transition causes the next observance to start,
     # returned as a Time instance.
     def local_start_time
       local_start_at.to_time
     end
-    
+
     # Returns true if this TimezoneTransition is equal to the given
-    # TimezoneTransition. Two TimezoneTransition instances are 
-    # considered to be equal by == if offset, previous_offset and at are all 
+    # TimezoneTransition. Two TimezoneTransition instances are
+    # considered to be equal by == if offset, previous_offset and at are all
     # equal.
     def ==(tti)
       tti.kind_of?(TimezoneTransition) &&
         offset == tti.offset && previous_offset == tti.previous_offset && at == tti.at
     end
-    
+
     # Returns true if this TimezoneTransition is equal to the given
-    # TimezoneTransition. Two TimezoneTransition instances are 
+    # TimezoneTransition. Two TimezoneTransition instances are
     # considered to be equal by eql? if offset, previous_offset and at are all
     # equal and the type used to define at in both instances is the same.
     def eql?(tti)
       tti.kind_of?(TimezoneTransition) &&
         offset == tti.offset && previous_offset == tti.previous_offset && at.eql?(tti.at)
     end
-    
+
     # Returns a hash of this TimezoneTransition instance.
     def hash
       @offset.hash ^ @previous_offset.hash ^ at.hash
     end
-    
+
     # Returns internal object state as a programmer-readable string.
     def inspect
-      "#<#{self.class}: #{at.inspect},#{@offset.inspect}>"      
+      "#<#{self.class}: #{at.inspect},#{@offset.inspect}>"
     end
 
     private

--- a/lib/tzinfo/timezone_transition_definition.rb
+++ b/lib/tzinfo/timezone_transition_definition.rb
@@ -2,19 +2,19 @@ module TZInfo
   # A TimezoneTransition defined by as integer timestamp, as a rational to
   # create a DateTime or as both.
   #
-  # @private 
+  # @private
   class TimezoneTransitionDefinition < TimezoneTransition #:nodoc:
-    # The numerator of the DateTime if the transition time is defined as a 
+    # The numerator of the DateTime if the transition time is defined as a
     # DateTime, otherwise the transition time as a timestamp.
     attr_reader :numerator_or_time
     protected :numerator_or_time
-    
+
     # Either the denominator of the DateTime if the transition time is defined
-    # as a DateTime, otherwise nil. 
+    # as a DateTime, otherwise nil.
     attr_reader :denominator
     protected :denominator
-    
-    # Creates a new TimezoneTransitionDefinition with the given offset, 
+
+    # Creates a new TimezoneTransitionDefinition with the given offset,
     # previous_offset (both TimezoneOffset instances) and UTC time.
     #
     # The time can be specified as a timestamp, as a rational to create a
@@ -25,14 +25,14 @@ module TZInfo
     # platform being used at runtime.
     #
     # DateTimes are created from the rational as follows:
-    # 
+    #
     #  RubyCoreSupport.datetime_new!(RubyCoreSupport.rational_new!(numerator, denominator), 0, Date::ITALY)
     #
     # For performance reasons, the numerator and denominator must be specified
     # in their lowest form.
     def initialize(offset, previous_offset, numerator_or_timestamp, denominator_or_numerator = nil, denominator = nil)
       super(offset, previous_offset)
-      
+
       if denominator
         numerator = denominator_or_numerator
         timestamp = numerator_or_timestamp
@@ -45,33 +45,33 @@ module TZInfo
         denominator = nil
         timestamp = numerator_or_timestamp
       end
-      
+
       # Determine whether to use the timestamp or the numerator and denominator.
       if numerator && (
-        !timestamp || 
-        (timestamp < 0 && !RubyCoreSupport.time_supports_negative) || 
+        !timestamp ||
+        (timestamp < 0 && !RubyCoreSupport.time_supports_negative) ||
         ((timestamp < -2147483648 || timestamp > 2147483647) && !RubyCoreSupport.time_supports_64bit)
         )
-        
+
         @numerator_or_time = numerator
         @denominator = denominator
       else
         @numerator_or_time = timestamp
         @denominator = nil
       end
-      
+
       @at = nil
     end
-    
+
     # A TimeOrDateTime instance representing the UTC time when this transition
     # occurs.
     def at
       # Thread-safety: It is possible that the value of @at may be calculated
       # multiple times in concurrently executing threads. It is not worth the
       # overhead of locking to ensure that @at is only calculated once.
-      
+
       unless @at
-        unless @denominator 
+        unless @denominator
           @at = TimeOrDateTime.new(@numerator_or_time)
         else
           r = RubyCoreSupport.rational_new!(@numerator_or_time, @denominator)
@@ -79,20 +79,20 @@ module TZInfo
           @at = TimeOrDateTime.new(dt)
         end
       end
-      
+
       @at
     end
-    
+
     # Returns true if this TimezoneTransitionDefinition is equal to the given
-    # TimezoneTransitionDefinition. Two TimezoneTransitionDefinition instances 
-    # are considered to be equal by eql? if offset, previous_offset, 
+    # TimezoneTransitionDefinition. Two TimezoneTransitionDefinition instances
+    # are considered to be equal by eql? if offset, previous_offset,
     # numerator_or_time and denominator are all equal.
     def eql?(tti)
       tti.kind_of?(TimezoneTransitionDefinition) &&
         offset == tti.offset && previous_offset == tti.previous_offset &&
-        numerator_or_time == tti.numerator_or_time && denominator == tti.denominator        
+        numerator_or_time == tti.numerator_or_time && denominator == tti.denominator
     end
-    
+
     # Returns a hash of this TimezoneTransitionDefinition instance.
     def hash
       @offset.hash ^ @previous_offset.hash ^ @numerator_or_time.hash ^ @denominator.hash

--- a/lib/tzinfo/transition_data_timezone_info.rb
+++ b/lib/tzinfo/transition_data_timezone_info.rb
@@ -3,25 +3,25 @@ module TZInfo
   # periods_for_local. Indicates an error in the timezone data.
   class NoOffsetsDefined < StandardError
   end
-    
-  # Represents a data timezone defined by a set of offsets and a set 
+
+  # Represents a data timezone defined by a set of offsets and a set
   # of transitions.
   #
   # @private
   class TransitionDataTimezoneInfo < DataTimezoneInfo #:nodoc:
-            
+
     # Constructs a new TransitionDataTimezoneInfo with its identifier.
-    def initialize(identifier)   
+    def initialize(identifier)
       super(identifier)
       @offsets = {}
       @transitions = []
       @previous_offset = nil
       @transitions_index = nil
     end
- 
+
     # Defines a offset. The id uniquely identifies this offset within the
-    # timezone. utc_offset and std_offset define the offset in seconds of 
-    # standard time from UTC and daylight savings from standard time 
+    # timezone. utc_offset and std_offset define the offset in seconds of
+    # standard time from UTC and daylight savings from standard time
     # respectively. abbreviation describes the timezone offset (e.g. GMT, BST,
     # EST or EDT).
     #
@@ -31,32 +31,32 @@ module TZInfo
     # ArgumentError will be raised if the id is already defined.
     def offset(id, utc_offset, std_offset, abbreviation)
       raise ArgumentError, 'Offset already defined' if @offsets.has_key?(id)
-      
+
       offset = TimezoneOffset.new(utc_offset, std_offset, abbreviation)
       @offsets[id] = offset
       @previous_offset = offset unless @previous_offset
     end
-    
+
     # Defines a transition. Transitions must be defined in chronological order.
     # ArgumentError will be raised if a transition is added out of order.
-    # offset_id refers to an id defined with offset. ArgumentError will be 
+    # offset_id refers to an id defined with offset. ArgumentError will be
     # raised if the offset_id cannot be found. numerator_or_time and
-    # denomiator specify the time the transition occurs as. See 
+    # denomiator specify the time the transition occurs as. See
     # TimezoneTransition for more detail about specifying times.
     def transition(year, month, offset_id, numerator_or_timestamp, denominator_or_numerator = nil, denominator = nil)
-      offset = @offsets[offset_id]      
+      offset = @offsets[offset_id]
       raise ArgumentError, 'Offset not found' unless offset
-            
+
       if @transitions_index
         if year < @last_year || (year == @last_year && month < @last_month)
           raise ArgumentError, 'Transitions must be increasing date order'
         end
-        
+
         # Record the position of the first transition with this index.
         index = transition_index(year, month)
         @transitions_index[index] ||= @transitions.length
-                
-        # Fill in any gaps       
+
+        # Fill in any gaps
         (index - 1).downto(0) do |i|
           break if @transitions_index[i]
           @transitions_index[i] = @transitions.length
@@ -64,23 +64,23 @@ module TZInfo
       else
         @transitions_index = [@transitions.length]
         @start_year = year
-        @start_month = month        
+        @start_month = month
       end
-      
+
       @transitions << TimezoneTransitionDefinition.new(offset, @previous_offset,
         numerator_or_timestamp, denominator_or_numerator, denominator)
       @last_year = year
-      @last_month = month             
+      @last_month = month
       @previous_offset = offset
-    end           
-    
+    end
+
     # Returns the TimezonePeriod for the given UTC time.
     # Raises NoOffsetsDefined if no offsets have been defined.
     def period_for_utc(utc)
       unless @transitions.empty?
-        utc = TimeOrDateTime.wrap(utc)               
+        utc = TimeOrDateTime.wrap(utc)
         index = transition_index(utc.year, utc.mon)
-        
+
         start_transition = nil
         start = transition_before_end(index)
         if start
@@ -91,9 +91,9 @@ module TZInfo
             end
           end
         end
-        
+
         end_transition = nil
-        start = transition_after_start(index)      
+        start = transition_after_start(index)
         if start
           start.upto(@transitions.length - 1) do |i|
             if @transitions[i].at > utc
@@ -102,32 +102,32 @@ module TZInfo
             end
           end
         end
-               
+
         if start_transition || end_transition
           TimezonePeriod.new(start_transition, end_transition)
         else
           # Won't happen since there are transitions. Must always find one
           # transition that is either >= or < the specified time.
           raise 'No transitions found in search'
-        end        
+        end
       else
-        raise NoOffsetsDefined, 'No offsets have been defined' unless @previous_offset        
+        raise NoOffsetsDefined, 'No offsets have been defined' unless @previous_offset
         TimezonePeriod.new(nil, nil, @previous_offset)
       end
     end
-    
-    # Returns the set of TimezonePeriods for the given local time as an array.    
+
+    # Returns the set of TimezonePeriods for the given local time as an array.
     # Results returned are ordered by increasing UTC start date.
     # Returns an empty array if no periods are found for the given time.
-    # Raises NoOffsetsDefined if no offsets have been defined.    
+    # Raises NoOffsetsDefined if no offsets have been defined.
     def periods_for_local(local)
       unless @transitions.empty?
         local = TimeOrDateTime.wrap(local)
         index = transition_index(local.year, local.mon)
-        
+
         result = []
-       
-        start_index = transition_after_start(index - 1)       
+
+        start_index = transition_after_start(index - 1)
         if start_index && @transitions[start_index].local_end_at > local
           if start_index > 0
             if @transitions[start_index - 1].local_start_at <= local
@@ -137,12 +137,12 @@ module TZInfo
             result << TimezonePeriod.new(nil, @transitions[start_index])
           end
         end
-        
+
         end_index = transition_before_end(index + 1)
-        
-        if end_index        
+
+        if end_index
           start_index = end_index unless start_index
-          
+
           start_index.upto(transition_before_end(index + 1)) do |i|
             if @transitions[i].local_start_at <= local
               if i + 1 < @transitions.length
@@ -155,32 +155,32 @@ module TZInfo
             end
           end
         end
-        
+
         result
       else
         raise NoOffsetsDefined, 'No offsets have been defined' unless @previous_offset
         [TimezonePeriod.new(nil, nil, @previous_offset)]
       end
     end
-    
+
     # Returns an Array of TimezoneTransition instances representing the times
     # where the UTC offset of the timezone changes.
     #
-    # Transitions are returned up to a given date and time up to a given date 
+    # Transitions are returned up to a given date and time up to a given date
     # and time, specified in UTC (utc_to).
     #
     # A from date and time may also be supplied using the utc_from parameter
-    # (also specified in UTC). If utc_from is not nil, only transitions from 
+    # (also specified in UTC). If utc_from is not nil, only transitions from
     # that date and time onwards will be returned.
     #
     # Comparisons with utc_to are exclusive. Comparisons with utc_from are
     # inclusive. If a transition falls precisely on utc_to, it will be excluded.
     # If a transition falls on utc_from, it will be included.
     #
-    # Transitions returned are ordered by when they occur, from earliest to 
+    # Transitions returned are ordered by when they occur, from earliest to
     # latest.
     #
-    # utc_to and utc_from can be specified using either DateTime, Time or 
+    # utc_to and utc_from can be specified using either DateTime, Time or
     # integer timestamps (Time.to_i).
     #
     # If utc_from is specified and utc_to is not greater than utc_from, then
@@ -188,20 +188,20 @@ module TZInfo
     def transitions_up_to(utc_to, utc_from = nil)
       utc_to = TimeOrDateTime.wrap(utc_to)
       utc_from = utc_from ? TimeOrDateTime.wrap(utc_from) : nil
-      
+
       if utc_from && utc_to <= utc_from
         raise ArgumentError, 'utc_to must be greater than utc_from'
       end
-      
+
       unless @transitions.empty?
         if utc_from
           from = transition_after_start(transition_index(utc_from.year, utc_from.mon))
-          
+
           if from
             while from < @transitions.length && @transitions[from].at < utc_from
               from += 1
             end
-            
+
             if from >= @transitions.length
               return []
             end
@@ -212,14 +212,14 @@ module TZInfo
         else
           from = 0
         end
-        
+
         to = transition_before_end(transition_index(utc_to.year, utc_to.mon))
-        
+
         if to
           while to >= 0 && @transitions[to].at >= utc_to
             to -= 1
           end
-          
+
           if to < 0
             return []
           end
@@ -233,9 +233,9 @@ module TZInfo
         []
       end
     end
-    
+
     private
-      # Returns the index into the @transitions_index array for a given year 
+      # Returns the index into the @transitions_index array for a given year
       # and month.
       def transition_index(year, month)
         index = (year - @start_year) * 2
@@ -243,7 +243,7 @@ module TZInfo
         index -= 1 if @start_month > 6
         index
       end
-      
+
       # Returns the index into @transitions of the first transition that occurs
       # on or after the start of the given index into @transitions_index.
       # Returns nil if there are no such transitions.
@@ -255,20 +255,20 @@ module TZInfo
           @transitions_index[index]
         end
       end
-      
+
       # Returns the index into @transitions of the first transition that occurs
       # before the end of the given index into @transitions_index.
       # Returns nil if there are no such transitions.
       def transition_before_end(index)
         index = index + 1
-        
+
         if index <= 0
           nil
-        elsif index >= @transitions_index.length          
+        elsif index >= @transitions_index.length
           @transitions.length - 1
-        else      
-          @transitions_index[index] - 1          
+        else
+          @transitions_index[index] - 1
         end
-      end            
+      end
   end
 end

--- a/lib/tzinfo/zoneinfo_country_info.rb
+++ b/lib/tzinfo/zoneinfo_country_info.rb
@@ -1,32 +1,32 @@
-module TZInfo  
+module TZInfo
   # Represents information about a country returned by ZoneinfoDataSource.
   #
   # @private
   class ZoneinfoCountryInfo < CountryInfo #:nodoc:
-    # Constructs a new CountryInfo with an ISO 3166 country code, name and 
+    # Constructs a new CountryInfo with an ISO 3166 country code, name and
     # an array of CountryTimezones.
     def initialize(code, name, zones)
       super(code, name)
       @zones = zones.dup.freeze
       @zone_identifiers = nil
     end
-    
+
     # Returns a frozen array of all the zone identifiers for the country ordered
     # geographically, most populous first.
     def zone_identifiers
-      # Thread-safety: It is possible that the value of @zone_identifiers may be 
-      # calculated multiple times in concurrently executing threads. It is not 
-      # worth the overhead of locking to ensure that @zone_identifiers is only 
+      # Thread-safety: It is possible that the value of @zone_identifiers may be
+      # calculated multiple times in concurrently executing threads. It is not
+      # worth the overhead of locking to ensure that @zone_identifiers is only
       # calculated once.
-    
+
       unless @zone_identifiers
         @zone_identifiers = zones.collect {|zone| zone.identifier}.freeze
       end
-      
+
       @zone_identifiers
     end
-    
-    # Returns a frozen array of all the timezones for the for the country 
+
+    # Returns a frozen array of all the timezones for the for the country
     # ordered geographically, most populous first.
     def zones
       @zones

--- a/lib/tzinfo/zoneinfo_data_source.rb
+++ b/lib/tzinfo/zoneinfo_data_source.rb
@@ -5,25 +5,25 @@ module TZInfo
   # as well as other timezone files).
   class InvalidZoneinfoDirectory < StandardError
   end
-  
-  # A ZoneinfoDirectoryNotFound exception is raised if no valid zoneinfo 
+
+  # A ZoneinfoDirectoryNotFound exception is raised if no valid zoneinfo
   # directory could be found when checking the paths listed in
   # ZoneinfoDataSource.search_path. A valid zoneinfo directory is one that
   # contains timezone files, a country code index file named iso3166.tab and a
   # timezone index file named zone1970.tab or zone.tab.
   class ZoneinfoDirectoryNotFound < StandardError
   end
-  
+
   # A DataSource that loads data from a 'zoneinfo' directory containing
   # compiled "TZif" version 3 (or earlier) files in addition to iso3166.tab and
   # zone1970.tab or zone.tab index files.
   #
-  # To have TZInfo load the system zoneinfo files, call TZInfo::DataSource.set 
+  # To have TZInfo load the system zoneinfo files, call TZInfo::DataSource.set
   # as follows:
   #
   #   TZInfo::DataSource.set(:zoneinfo)
   #
-  # To load zoneinfo files from a particular directory, pass the directory to 
+  # To load zoneinfo files from a particular directory, pass the directory to
   # TZInfo::DataSource.set:
   #
   #   TZInfo::DataSource.set(:zoneinfo, directory)
@@ -32,14 +32,14 @@ module TZInfo
   # transition data that can be loaded from zoneinfo files. There are two
   # factors to consider:
   #
-  # First of all, the zoneinfo support in TZInfo makes use of Ruby's Time class. 
-  # On 32-bit builds of Ruby 1.8, the Time class only supports 32-bit 
+  # First of all, the zoneinfo support in TZInfo makes use of Ruby's Time class.
+  # On 32-bit builds of Ruby 1.8, the Time class only supports 32-bit
   # timestamps. This means that only Times between 1901-12-13 20:45:52 and
   # 2038-01-19 03:14:07 can be represented. Furthermore, certain platforms only
   # allow for positive 32-bit timestamps (notably Windows), making the earliest
   # representable time 1970-01-01 00:00:00.
   #
-  # 64-bit builds of Ruby 1.8 and all builds of Ruby 1.9 support 64-bit 
+  # 64-bit builds of Ruby 1.8 and all builds of Ruby 1.9 support 64-bit
   # timestamps. This means that there is no practical restriction on the range
   # of the Time class on these platforms.
   #
@@ -59,7 +59,7 @@ module TZInfo
   # to at least 10.8.4) still uses 32-bit zoneinfo files.
   #
   # To check whether your zoneinfo files contain 32-bit or 64-bit transition
-  # data, you can run the following code (substituting the identifier of the 
+  # data, you can run the following code (substituting the identifier of the
   # zone you want to test for zone_identifier):
   #
   #   TZInfo::DataSource.set(:zoneinfo)
@@ -70,22 +70,22 @@ module TZInfo
   # If it returns "TZif2" or "TZif3" then you have a 64-bit zoneinfo file.
   #
   # If you require support for 64-bit transitions, but are restricted to 32-bit
-  # zoneinfo support, then you may want to consider using TZInfo::RubyDataSource 
+  # zoneinfo support, then you may want to consider using TZInfo::RubyDataSource
   # instead.
   class ZoneinfoDataSource < DataSource
     # The default value of ZoneinfoDataSource.search_path.
     DEFAULT_SEARCH_PATH = ['/usr/share/zoneinfo', '/usr/share/lib/zoneinfo', '/etc/zoneinfo'].freeze
-    
+
     # The default value of ZoneinfoDataSource.alternate_iso3166_tab_search_path.
     DEFAULT_ALTERNATE_ISO3166_TAB_SEARCH_PATH = ['/usr/share/misc/iso3166.tab', '/usr/share/misc/iso3166'].freeze
-    
+
     # Paths to be checked to find the system zoneinfo directory.
     @@search_path = DEFAULT_SEARCH_PATH.dup
-    
-    # Paths to possible alternate iso3166.tab files (used to locate the 
+
+    # Paths to possible alternate iso3166.tab files (used to locate the
     # system-wide iso3166.tab files on FreeBSD and OpenBSD).
     @@alternate_iso3166_tab_search_path = DEFAULT_ALTERNATE_ISO3166_TAB_SEARCH_PATH.dup
-    
+
     # An Array of directories that will be checked to find the system zoneinfo
     # directory.
     #
@@ -95,8 +95,8 @@ module TZInfo
     def self.search_path
       @@search_path
     end
-    
-    # Sets the directories to be checked when locating the system zoneinfo 
+
+    # Sets the directories to be checked when locating the system zoneinfo
     # directory.
     #
     # Can be set to an Array of directories or a String containing directories
@@ -106,11 +106,11 @@ module TZInfo
     #
     # Set to nil to revert to the default paths.
     def self.search_path=(search_path)
-      @@search_path = process_search_path(search_path, DEFAULT_SEARCH_PATH)      
+      @@search_path = process_search_path(search_path, DEFAULT_SEARCH_PATH)
     end
-    
-    # An Array of paths that will be checked to find an alternate iso3166.tab 
-    # file if one was not included in the zoneinfo directory (for example, on 
+
+    # An Array of paths that will be checked to find an alternate iso3166.tab
+    # file if one was not included in the zoneinfo directory (for example, on
     # FreeBSD and OpenBSD systems).
     #
     # Paths are checked in the order they appear in the array.
@@ -119,7 +119,7 @@ module TZInfo
     def self.alternate_iso3166_tab_search_path
       @@alternate_iso3166_tab_search_path
     end
-    
+
     # Sets the paths to check to locate an alternate iso3166.tab file if one was
     # not included in the zoneinfo directory.
     #
@@ -132,73 +132,73 @@ module TZInfo
     def self.alternate_iso3166_tab_search_path=(alternate_iso3166_tab_search_path)
       @@alternate_iso3166_tab_search_path = process_search_path(alternate_iso3166_tab_search_path, DEFAULT_ALTERNATE_ISO3166_TAB_SEARCH_PATH)
     end
-    
+
     # The zoneinfo directory being used.
     attr_reader :zoneinfo_dir
-    
+
     # Creates a new ZoneinfoDataSource.
     #
     # If zoneinfo_dir is specified, it will be checked and used as the source
-    # of zoneinfo files. 
+    # of zoneinfo files.
     #
     # The directory must contain a file named iso3166.tab and a file named
     # either zone1970.tab or zone.tab. These may either be included in the root
     # of the directory or in a 'tab' sub-directory and named 'country.tab' and
     # 'zone_sun.tab' respectively (as is the case on Solaris.
     #
-    # Additionally, the path to iso3166.tab can be overridden using the 
+    # Additionally, the path to iso3166.tab can be overridden using the
     # alternate_iso3166_tab_path parameter.
     #
     # InvalidZoneinfoDirectory will be raised if the iso3166.tab and
     # zone1970.tab or zone.tab files cannot be found using the zoneinfo_dir and
     # alternate_iso3166_tab_path parameters.
-    # 
+    #
     # If zoneinfo_dir is not specified or nil, the paths referenced in
-    # search_path are searched in order to find a valid zoneinfo directory 
+    # search_path are searched in order to find a valid zoneinfo directory
     # (one that contains zone1970.tab or zone.tab and iso3166.tab files as
     # above).
     #
     # The paths referenced in alternate_iso3166_tab_search_path are also
     # searched to find an iso3166.tab file if one of the searched zoneinfo
     # directories doesn't contain an iso3166.tab file.
-    # 
+    #
     # If no valid directory can be found by searching, ZoneinfoDirectoryNotFound
     # will be raised.
     def initialize(zoneinfo_dir = nil, alternate_iso3166_tab_path = nil)
       if zoneinfo_dir
         iso3166_tab_path, zone_tab_path = validate_zoneinfo_dir(zoneinfo_dir, alternate_iso3166_tab_path)
-      
+
         unless iso3166_tab_path && zone_tab_path
-          raise InvalidZoneinfoDirectory, "#{zoneinfo_dir} is not a directory or doesn't contain a iso3166.tab file and a zone1970.tab or zone.tab file." 
+          raise InvalidZoneinfoDirectory, "#{zoneinfo_dir} is not a directory or doesn't contain a iso3166.tab file and a zone1970.tab or zone.tab file."
         end
-        
+
         @zoneinfo_dir = zoneinfo_dir
       else
         @zoneinfo_dir, iso3166_tab_path, zone_tab_path = find_zoneinfo_dir
-        
+
         unless @zoneinfo_dir && iso3166_tab_path && zone_tab_path
           raise ZoneinfoDirectoryNotFound, "None of the paths included in TZInfo::ZoneinfoDataSource.search_path are valid zoneinfo directories."
         end
       end
-      
+
       @zoneinfo_dir = File.expand_path(@zoneinfo_dir).freeze
       @timezone_index = load_timezone_index.freeze
       @country_index = load_country_index(iso3166_tab_path, zone_tab_path).freeze
     end
-    
-    # Returns a TimezoneInfo instance for a given identifier. 
-    # Raises InvalidTimezoneIdentifier if the timezone is not found or the 
+
+    # Returns a TimezoneInfo instance for a given identifier.
+    # Raises InvalidTimezoneIdentifier if the timezone is not found or the
     # identifier is invalid.
     def load_timezone_info(identifier)
       begin
         if @timezone_index.include?(identifier)
           path = File.join(@zoneinfo_dir, identifier)
-          
-          # Untaint path rather than identifier. We don't want to modify 
+
+          # Untaint path rather than identifier. We don't want to modify
           # identifier. identifier may also be frozen and therefore cannot be
           # untainted.
           path.untaint
-          
+
           begin
             ZoneinfoTimezoneInfo.new(identifier, path)
           rescue InvalidZoneinfoFile => e
@@ -212,22 +212,22 @@ module TZInfo
       rescue Errno::EACCES => e
         raise InvalidTimezoneIdentifier, e.message
       end
-    end    
-    
+    end
+
     # Returns an array of all the available timezone identifiers.
     def timezone_identifiers
       @timezone_index
     end
-    
+
     # Returns an array of all the available timezone identifiers for
     # data timezones (i.e. those that actually contain definitions).
     #
-    # For ZoneinfoDataSource, this will always be identical to 
+    # For ZoneinfoDataSource, this will always be identical to
     # timezone_identifers.
     def data_timezone_identifiers
       @timezone_index
     end
-    
+
     # Returns an array of all the available timezone identifiers that
     # are links to other timezones.
     #
@@ -235,7 +235,7 @@ module TZInfo
     def linked_timezone_identifiers
       [].freeze
     end
-    
+
     # Returns a CountryInfo instance for the given ISO 3166-1 alpha-2
     # country code. Raises InvalidCountryCode if the country could not be found
     # or the code is invalid.
@@ -244,25 +244,25 @@ module TZInfo
       raise InvalidCountryCode, 'Invalid country code' unless info
       info
     end
-    
+
     # Returns an array of all the available ISO 3166-1 alpha-2
     # country codes.
     def country_codes
       @country_index.keys.freeze
     end
-    
+
     # Returns the name and information about this DataSource.
     def to_s
       "Zoneinfo DataSource: #{@zoneinfo_dir}"
     end
-    
+
     # Returns internal object state as a programmer-readable string.
     def inspect
       "#<#{self.class}: #{@zoneinfo_dir}>"
-    end    
-    
+    end
+
     private
-    
+
     # Processes a path for use as the search_path or
     # alternate_iso3166_tab_search_path.
     def self.process_search_path(path, default)
@@ -276,32 +276,32 @@ module TZInfo
         default.dup
       end
     end
-    
-    # Validates a zoneinfo directory and returns the paths to the iso3166.tab 
+
+    # Validates a zoneinfo directory and returns the paths to the iso3166.tab
     # and zone1970.tab or zone.tab files if valid. If the directory is not
     # valid, returns nil.
     #
     # The path to the iso3166.tab file may be overriden by passing in a path.
     # This is treated as either absolute or relative to the current working
-    # directory.    
+    # directory.
     def validate_zoneinfo_dir(path, iso3166_tab_path = nil)
       if File.directory?(path)
         if iso3166_tab_path
           return nil unless File.file?(iso3166_tab_path)
         else
           iso3166_tab_path = resolve_tab_path(path, ['iso3166.tab'], 'country.tab')
-          return nil unless iso3166_tab_path          
+          return nil unless iso3166_tab_path
         end
-        
+
         zone_tab_path = resolve_tab_path(path, ['zone1970.tab', 'zone.tab'], 'zone_sun.tab')
         return nil unless zone_tab_path
-      
+
         [iso3166_tab_path, zone_tab_path]
       else
         nil
       end
     end
-    
+
     # Attempts to resolve the path to a tab file given its standard names and
     # tab sub-directory name (as used on Solaris).
     def resolve_tab_path(zoneinfo_path, standard_names, tab_name)
@@ -309,55 +309,55 @@ module TZInfo
         path = File.join(zoneinfo_path, standard_name)
         return path if File.file?(path)
       end
-      
+
       path = File.join(zoneinfo_path, 'tab', tab_name)
       return path if File.file?(path)
-      
+
       nil
     end
-    
-    # Finds a zoneinfo directory using search_path and 
+
+    # Finds a zoneinfo directory using search_path and
     # alternate_iso3166_tab_search_path. Returns the paths to the directory,
     # the iso3166.tab file and the zone.tab file or nil if not found.
     def find_zoneinfo_dir
       alternate_iso3166_tab_path = self.class.alternate_iso3166_tab_search_path.detect do |path|
         File.file?(path)
       end
-      
+
       self.class.search_path.each do |path|
         # Try without the alternate_iso3166_tab_path first.
-        iso3166_tab_path, zone_tab_path = validate_zoneinfo_dir(path)        
+        iso3166_tab_path, zone_tab_path = validate_zoneinfo_dir(path)
         return path, iso3166_tab_path, zone_tab_path if iso3166_tab_path && zone_tab_path
-        
+
         if alternate_iso3166_tab_path
-          iso3166_tab_path, zone_tab_path = validate_zoneinfo_dir(path, alternate_iso3166_tab_path)        
+          iso3166_tab_path, zone_tab_path = validate_zoneinfo_dir(path, alternate_iso3166_tab_path)
           return path, iso3166_tab_path, zone_tab_path if iso3166_tab_path && zone_tab_path
         end
       end
-      
+
       # Not found.
       nil
     end
-       
-    # Scans @zoneinfo_dir and returns an Array of available timezone 
+
+    # Scans @zoneinfo_dir and returns an Array of available timezone
     # identifiers.
     def load_timezone_index
       index = []
-      
+
       # Ignoring particular files:
       # +VERSION is included on Mac OS X.
       # localtime current local timezone (may be a link).
       # posix, posixrules and right are directories containing other versions of the zoneinfo files.
       # src is a directory containing the tzdata source included on Solaris.
       # Factory is the compiled in default timezone.
-      
+
       enum_timezones(nil, ['+VERSION', 'localtime', 'posix', 'posixrules', 'right', 'src', 'Factory']) do |identifier|
         index << identifier
       end
-      
+
       index.sort
     end
-    
+
     # Recursively scans a directory of timezones, calling the passed in block
     # for each identifier found.
     def enum_timezones(dir, exclude = [], &block)
@@ -366,7 +366,7 @@ module TZInfo
           entry.untaint
           path = dir ? File.join(dir, entry) : entry
           full_path = File.join(@zoneinfo_dir, path)
- 
+
           if File.directory?(full_path)
             enum_timezones(path, [], &block)
           elsif File.file?(full_path)
@@ -375,15 +375,15 @@ module TZInfo
         end
       end
     end
-    
+
     # Uses the iso3166.tab and zone1970.tab or zone.tab files to build an index
     # of the available countries and their timezones.
     def load_country_index(iso3166_tab_path, zone_tab_path)
-      
-      # Handle standard 3 to 4 column zone.tab files as well as the 4 to 5 
+
+      # Handle standard 3 to 4 column zone.tab files as well as the 4 to 5
       # column format used by Solaris.
       #
-      # On Solaris, an extra column before the comment gives an optional 
+      # On Solaris, an extra column before the comment gives an optional
       # linked/alternate timezone identifier (or '-' if not set).
       #
       # Additionally, there is a section at the end of the file for timezones
@@ -391,7 +391,7 @@ module TZInfo
       # identifier column refers to a continent instead of an identifier. These
       # lines will be ignored by TZInfo.
       #
-      # Since the last column is optional in both formats, testing for the 
+      # Since the last column is optional in both formats, testing for the
       # Solaris format is done in two passes. The first pass identifies if there
       # are any lines using 5 columns.
 
@@ -407,17 +407,17 @@ module TZInfo
       # The zones for each country are ordered primary first, then secondary.
       # Within the primary and secondary groups, the zones are ordered by their
       # order in the file.
-      
+
       file_is_5_column = false
       zone_tab = []
-      
+
       RubyCoreSupport.open_file(zone_tab_path, 'r', :external_encoding => 'UTF-8', :internal_encoding => 'UTF-8') do |file|
         file.each_line do |line|
           line.chomp!
-          
+
           if line =~ /\A([A-Z]{2}(?:,[A-Z]{2})*)\t(?:([+\-])(\d{2})(\d{2})([+\-])(\d{3})(\d{2})|([+\-])(\d{2})(\d{2})(\d{2})([+\-])(\d{3})(\d{2})(\d{2}))\t([^\t]+)(?:\t([^\t]+))?(?:\t([^\t]+))?\z/
             codes = $1
-            
+
             if $2
               latitude = dms_to_rational($2, $3, $4)
               longitude = dms_to_rational($5, $6, $7)
@@ -425,21 +425,21 @@ module TZInfo
               latitude = dms_to_rational($8, $9, $10, $11)
               longitude = dms_to_rational($12, $13, $14, $15)
             end
-            
+
             zone_identifier = $16
             column4 = $17
             column5 = $18
-            
+
             file_is_5_column = true if column5
-            
+
             zone_tab << [codes.split(','), zone_identifier, latitude, longitude, column4, column5]
           end
         end
       end
-      
+
       primary_zones = {}
       secondary_zones = {}
-      
+
       zone_tab.each do |codes, zone_identifier, latitude, longitude, column4, column5|
         description = file_is_5_column ? column5 : column4
         country_timezone = CountryTimezone.new(zone_identifier, latitude, longitude, description)
@@ -452,17 +452,17 @@ module TZInfo
           (secondary_zones[code] ||= []) << country_timezone
         end
       end
-      
+
       countries = {}
-      
+
       RubyCoreSupport.open_file(iso3166_tab_path, 'r', :external_encoding => 'UTF-8', :internal_encoding => 'UTF-8') do |file|
         file.each_line do |line|
           line.chomp!
-          
-          # Handle both the two column alpha-2 and name format used in the tz 
-          # database as well as the 4 column alpha-2, alpha-3, numeric-3 and 
+
+          # Handle both the two column alpha-2 and name format used in the tz
+          # database as well as the 4 column alpha-2, alpha-3, numeric-3 and
           # name format used by FreeBSD and OpenBSD.
-          
+
           if line =~ /\A([A-Z]{2})(?:\t[A-Z]{3}\t[0-9]{3})?\t(.+)\z/
             code = $1
             name = $2
@@ -472,10 +472,10 @@ module TZInfo
           end
         end
       end
-      
+
       countries
     end
-    
+
     # Converts degrees, minutes and seconds to a Rational.
     def dms_to_rational(sign, degrees, minutes, seconds = nil)
       result = degrees.to_i + Rational(minutes.to_i, 60)

--- a/lib/tzinfo/zoneinfo_timezone_info.rb
+++ b/lib/tzinfo/zoneinfo_timezone_info.rb
@@ -8,7 +8,7 @@ module TZInfo
   #
   # @private
   class ZoneinfoTimezoneInfo < TransitionDataTimezoneInfo #:nodoc:
-    
+
     # Minimum supported timestamp (inclusive).
     #
     # Time.utc(1700, 1, 1).to_i
@@ -23,46 +23,46 @@ module TZInfo
     # to the file.
     def initialize(identifier, file_path)
       super(identifier)
-      
+
       File.open(file_path, 'rb') do |file|
         parse(file)
       end
     end
-    
+
     private
-      # Unpack will return unsigned 32-bit integers. Translate to 
+      # Unpack will return unsigned 32-bit integers. Translate to
       # signed 32-bit.
       def make_signed_int32(long)
         long >= 0x80000000 ? long - 0x100000000 : long
       end
-      
+
       # Unpack will return a 64-bit integer as two unsigned 32-bit integers
       # (most significant first). Translate to signed 64-bit
       def make_signed_int64(high, low)
         unsigned = (high << 32) | low
         unsigned >= 0x8000000000000000 ? unsigned - 0x10000000000000000 : unsigned
       end
-      
+
       # Read bytes from file and check that the correct number of bytes could
       # be read. Raises InvalidZoneinfoFile if the number of bytes didn't match
       # the number requested.
       def check_read(file, bytes)
         result = file.read(bytes)
-        
+
         unless result && result.length == bytes
           raise InvalidZoneinfoFile, "Expected #{bytes} bytes reading '#{file.path}', but got #{result ? result.length : 0} bytes"
         end
-        
+
         result
       end
-      
+
       # Zoneinfo doesn't include the offset from standard time (std_offset).
       # Derive the missing offsets by looking at changes in the total UTC
       # offset.
       #
-      # This will be run through forwards and then backwards by the parse 
+      # This will be run through forwards and then backwards by the parse
       # method.
-      def derive_offsets(transitions, offsets)      
+      def derive_offsets(transitions, offsets)
         previous_offset = nil
 
         transitions.each do |t|
@@ -70,7 +70,7 @@ module TZInfo
 
           if !offset[:std_offset] && offset[:is_dst] && previous_offset
             difference = offset[:utc_total_offset] - previous_offset[:utc_total_offset]
-            
+
             if previous_offset[:is_dst]
               if previous_offset[:std_offset]
                 std_offset = previous_offset[:std_offset] + difference
@@ -80,17 +80,17 @@ module TZInfo
             else
               std_offset = difference
             end
-            
+
             if std_offset && std_offset > 0
               offset[:std_offset] = std_offset
               offset[:utc_offset] = offset[:utc_total_offset] - std_offset
             end
           end
-          
+
           previous_offset = offset
         end
       end
-      
+
       # Parses a zoneinfo file and intializes the DataTimezoneInfo structures.
       def parse(file)
         magic, version, ttisgmtcnt, ttisstdcnt, leapcnt, timecnt, typecnt, charcnt =
@@ -103,85 +103,85 @@ module TZInfo
         if (version == '2' || version == '3') && RubyCoreSupport.time_supports_64bit
           # Skip the first 32-bit section and read the header of the second 64-bit section
           file.seek(timecnt * 5 + typecnt * 6 + charcnt + leapcnt * 8 + ttisgmtcnt + ttisstdcnt, IO::SEEK_CUR)
-          
+
           prev_version = version
-          
+
           magic, version, ttisgmtcnt, ttisstdcnt, leapcnt, timecnt, typecnt, charcnt =
             check_read(file, 44).unpack('a4 a x15 NNNNNN')
-            
+
           unless magic == 'TZif' && (version == prev_version)
             raise InvalidZoneinfoFile, "The file '#{file.path}' contains an invalid 64-bit section header."
           end
-          
+
           using_64bit = true
         elsif version != '3' && version != '2' && version != "\0"
           raise InvalidZoneinfoFile, "The file '#{file.path}' contains a version of the zoneinfo format that is not currently supported."
         else
           using_64bit = false
         end
-        
+
         unless leapcnt == 0
           raise InvalidZoneinfoFile, "The zoneinfo file '#{file.path}' contains leap second data. TZInfo requires zoneinfo files that omit leap seconds."
         end
-        
+
         transitions = []
-        
+
         if using_64bit
           (0...timecnt).each do |i|
             high, low = check_read(file, 8).unpack('NN')
             transition_time = make_signed_int64(high, low)
-            transitions << {:at => transition_time}          
+            transitions << {:at => transition_time}
           end
         else
           (0...timecnt).each do |i|
             transition_time = make_signed_int32(check_read(file, 4).unpack('N')[0])
-            transitions << {:at => transition_time}          
+            transitions << {:at => transition_time}
           end
         end
-        
+
         (0...timecnt).each do |i|
           localtime_type = check_read(file, 1).unpack('C')[0]
           transitions[i][:offset] = localtime_type
         end
-        
+
         offsets = []
-        
+
         (0...typecnt).each do |i|
           gmtoff, isdst, abbrind = check_read(file, 6).unpack('NCC')
           gmtoff = make_signed_int32(gmtoff)
           isdst = isdst == 1
           offset = {:utc_total_offset => gmtoff, :is_dst => isdst, :abbr_index => abbrind}
-          
+
           unless isdst
             offset[:utc_offset] = gmtoff
             offset[:std_offset] = 0
           end
-          
+
           offsets << offset
         end
-        
+
         abbrev = check_read(file, charcnt)
 
         offsets.each do |o|
-          abbrev_start = o[:abbr_index]         
+          abbrev_start = o[:abbr_index]
           raise InvalidZoneinfoFile, "Abbreviation index is out of range in file '#{file.path}'" unless abbrev_start < abbrev.length
-          
+
           abbrev_end = abbrev.index("\0", abbrev_start)
           raise InvalidZoneinfoFile, "Missing abbreviation null terminator in file '#{file.path}'" unless abbrev_end
 
           o[:abbr] = RubyCoreSupport.force_encoding(abbrev[abbrev_start...abbrev_end], 'UTF-8')
         end
-        
+
         transitions.each do |t|
           if t[:offset] < 0 || t[:offset] >= offsets.length
             raise InvalidZoneinfoFile, "Invalid offset referenced by transition in file '#{file.path}'."
           end
         end
-        
+
         # Derive the offsets from standard time (std_offset).
         derive_offsets(transitions, offsets)
         derive_offsets(transitions.reverse, offsets)
-        
+
         # Assign anything left a standard offset of one hour
         offsets.each do |o|
           if !o[:std_offset] && o[:is_dst]
@@ -189,7 +189,7 @@ module TZInfo
             o[:utc_offset] = o[:utc_total_offset] - 3600
           end
         end
-        
+
         # Find the first non-dst offset. This is used as the offset for the time
         # before the first transition.
         first = nil
@@ -199,11 +199,11 @@ module TZInfo
             break
           end
         end
-        
+
         if first
           offset first, offsets[first][:utc_offset], offsets[first][:std_offset], offsets[first][:abbr].untaint.to_sym
         end
-        
+
         offsets.each_with_index do |o, i|
           offset i, o[:utc_offset], o[:std_offset], o[:abbr].untaint.to_sym unless i == first
         end
@@ -226,7 +226,7 @@ module TZInfo
             transitions = after_epoch
           end
         end
-        
+
         # Ignore transitions that occur outside of a defined window. The
         # transition index cannot handle a large range of transition times.
         #

--- a/test/tc_country.rb
+++ b/test/tc_country.rb
@@ -7,45 +7,45 @@ class TCCountry < Minitest::Test
     @orig_data_source = DataSource.get
     Country.send :init_countries
   end
-  
+
   def teardown
     DataSource.set(@orig_data_source)
   end
-  
+
   def test_get_valid
     c = Country.get('GB')
-    
+
     assert c
     assert_equal('GB', c.code)
   end
-    
+
   def test_get_not_exist
     assert_raises(InvalidCountryCode) {
       Country.get('ZZ')
     }
   end
-  
+
   def test_get_invalid
     assert_raises(InvalidCountryCode) {
       Country.get('../Countries/GB')
     }
   end
-  
+
   def test_get_nil
     assert_raises(InvalidCountryCode) {
       Country.get(nil)
     }
   end
-  
-  def test_get_case    
+
+  def test_get_case
     assert_raises(InvalidCountryCode) {
       Country.get('gb')
     }
   end
-  
+
   def test_get_tainted_loaded
     Country.get('GB')
-  
+
     safe_test do
       code = 'GB'.dup.taint
       assert(code.tainted?)
@@ -54,16 +54,16 @@ class TCCountry < Minitest::Test
       assert(code.tainted?)
     end
   end
-  
+
   def test_get_tainted_and_frozen_loaded
     Country.get('GB')
-  
+
     safe_test do
       country = Country.get('GB'.dup.taint.freeze)
       assert_equal('GB', country.code)
     end
   end
-  
+
   def test_get_tainted_not_previously_loaded
     safe_test do
       code = 'GB'.dup.taint
@@ -73,83 +73,83 @@ class TCCountry < Minitest::Test
       assert(code.tainted?)
     end
   end
-  
+
   def test_get_tainted_and_frozen_not_previously_loaded
     safe_test do
       country = Country.get('GB'.dup.taint.freeze)
       assert_equal('GB', country.code)
     end
   end
-    
+
   def test_new_nil
     assert_raises(InvalidCountryCode) {
       Country.new(nil)
-    }        
+    }
   end
-  
+
   def test_new_arg
     c = Country.new('GB')
-    assert_same(Country.get('GB'), c)    
+    assert_same(Country.get('GB'), c)
   end
-  
-  def test_new_arg_not_exist    
+
+  def test_new_arg_not_exist
     assert_raises(InvalidCountryCode) {
       Country.new('ZZ')
     }
-  end 
-  
+  end
+
   def test_all_codes
     all_codes = Country.all_codes
     assert_kind_of(Array, all_codes)
   end
-  
+
   def test_all
-    all = Country.all    
+    all = Country.all
     assert_equal(Country.all_codes, all.collect {|c| c.code})
   end
-  
-  def test_code    
+
+  def test_code
     assert_equal('US', Country.get('US').code)
   end
-  
+
   def test_name
     assert_kind_of(String, Country.get('US').name)
   end
-  
+
   def test_to_s
     assert_equal(Country.get('US').name, Country.get('US').to_s)
     assert_equal(Country.get('GB').name, Country.get('GB').to_s)
   end
-  
+
   def test_zone_identifiers
     zone_names = Country.get('US').zone_names
     assert_kind_of(Array, zone_names)
-    assert_equal(true, zone_names.frozen?)    
+    assert_equal(true, zone_names.frozen?)
   end
-  
+
   def test_zone_names
     assert_equal(Country.get('US').zone_identifiers, Country.get('US').zone_names)
   end
-  
+
   def test_zones
     zones = Country.get('US').zones
-    assert_kind_of(Array, zones)    
+    assert_kind_of(Array, zones)
     assert_equal(Country.get('US').zone_identifiers, zones.collect {|z| z.identifier})
-    
+
     zones.each {|z| assert_kind_of(TimezoneProxy, z)}
   end
-  
+
   def test_zone_info
     zones = Country.get('US').zone_info
     assert_kind_of(Array, zones)
     assert_equal(true, zones.frozen?)
-    
+
     assert_equal(Country.get('US').zone_identifiers, zones.collect {|z| z.identifier})
     assert_equal(Country.get('US').zone_identifiers, zones.collect {|z| z.timezone.identifier})
-    
+
     zones.each {|z| assert_kind_of(CountryTimezone, z)}
-  end  
-      
+  end
+
   def test_compare
     assert_equal(0, Country.get('GB') <=> Country.get('GB'))
     assert_equal(-1, Country.get('GB') <=> Country.get('US'))
@@ -157,39 +157,39 @@ class TCCountry < Minitest::Test
     assert_equal(-1, Country.get('FR') <=> Country.get('US'))
     assert_equal(1, Country.get('US') <=> Country.get('FR'))
   end
-  
+
   def test_compare_non_comparable
     assert_nil(Country.get('GB') <=> Object.new)
   end
-  
+
   def test_equality
     assert_equal(true, Country.get('GB') == Country.get('GB'))
     assert_equal(false, Country.get('GB') == Country.get('US'))
     assert(!(Country.get('GB') == Object.new))
   end
-  
+
   def test_eql
     assert_equal(true, Country.get('GB').eql?(Country.get('GB')))
     assert_equal(false, Country.get('GB').eql?(Country.get('US')))
     assert(!Country.get('GB').eql?(Object.new))
   end
-  
+
   def test_hash
     assert_equal('GB'.hash, Country.get('GB').hash)
     assert_equal('US'.hash, Country.get('US').hash)
   end
-  
+
   def test_marshal
     c = Country.get('US')
-    
+
     # Should get back the same instance because load calls Country.get.
     assert_same(c, Marshal.load(Marshal.dump(c)))
   end
-  
+
   def test_reload
     # If country gets reloaded for some reason, it needs to force a reload of
     # the country index.
-    
+
     c = Country.get('US')
     assert_equal('US', Country.get('US').code)
 
@@ -197,38 +197,38 @@ class TCCountry < Minitest::Test
     without_warnings do
       load 'tzinfo/country.rb'
     end
-    
+
     c = Country.get('US')
     assert_equal('US', Country.get('US').code)
   end
-  
+
   def test_get_missing_data_source
     DataSource.set(DataSource.new)
-    
+
     assert_raises(InvalidDataSource) do
       Country.get('GB')
     end
   end
-  
+
   def test_new_missing_data_source
     DataSource.set(DataSource.new)
-    
+
     assert_raises(InvalidDataSource) do
       Country.new('GB')
     end
   end
-  
+
   def test_all_codes_missing_data_source
     DataSource.set(DataSource.new)
-    
+
     assert_raises(InvalidDataSource) do
       Country.all_codes
     end
   end
-  
+
   def test_all_missing_data_source
     DataSource.set(DataSource.new)
-    
+
     assert_raises(InvalidDataSource) do
       Country.all
     end

--- a/test/tc_country_index_definition.rb
+++ b/test/tc_country_index_definition.rb
@@ -4,66 +4,66 @@ include TZInfo
 
 class TCCountryIndexDefinition < Minitest::Test
 
-  module CountriesTest1     
+  module CountriesTest1
     include CountryIndexDefinition
-    
+
     country 'ZZ', 'Country One' do |c|
       c.timezone 'Test/Zone/1', 3, 2, 41,20
     end
-    
+
     country 'AA', 'Aland' do |c|
       c.timezone 'Test/Zone/3', 71,30, 358, 15
       c.timezone 'Test/Zone/2', 41, 20, 211, 30
     end
-    
-    country 'TE', 'Three'    
+
+    country 'TE', 'Three'
   end
-  
+
   module CountriesTest2
     include CountryIndexDefinition
-    
+
     country 'CO', 'First Country' do |c|
     end
   end
-  
+
   def test_module_1
     hash = CountriesTest1.countries
     assert_equal(3, hash.length)
     assert_equal(true, hash.frozen?)
-    
+
     zz = hash['ZZ']
     aa = hash['AA']
     te = hash['TE']
-    
+
     assert_kind_of(RubyCountryInfo, zz)
     assert_equal('ZZ', zz.code)
     assert_equal('Country One', zz.name)
     assert_equal(1, zz.zones.length)
     assert_equal('Test/Zone/1', zz.zones[0].identifier)
-    
+
     assert_kind_of(RubyCountryInfo, aa)
     assert_equal('AA', aa.code)
     assert_equal('Aland', aa.name)
     assert_equal(2, aa.zones.length)
     assert_equal('Test/Zone/3', aa.zones[0].identifier)
     assert_equal('Test/Zone/2', aa.zones[1].identifier)
-    
+
     assert_kind_of(RubyCountryInfo, te)
     assert_equal('TE', te.code)
     assert_equal('Three', te.name)
-    assert_equal(0, te.zones.length)    
+    assert_equal(0, te.zones.length)
   end
-  
+
   def test_module_2
     hash = CountriesTest2.countries
     assert_equal(1, hash.length)
     assert_equal(true, hash.frozen?)
-    
+
     co = hash['CO']
-    
+
     assert_kind_of(RubyCountryInfo, co)
     assert_equal('CO', co.code)
     assert_equal('First Country', co.name)
     assert_equal(0, co.zones.length)
-  end  
+  end
 end

--- a/test/tc_country_info.rb
+++ b/test/tc_country_info.rb
@@ -3,12 +3,12 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 include TZInfo
 
 class TCCountryInfo < Minitest::Test
-  
+
   def test_code
     ci = CountryInfo.new('ZZ', 'Zzz') {|c| }
     assert_equal('ZZ', ci.code)
   end
-  
+
   def test_name
     ci = CountryInfo.new('ZZ', 'Zzz') {|c| }
     assert_equal('Zzz', ci.name)

--- a/test/tc_country_timezone.rb
+++ b/test/tc_country_timezone.rb
@@ -4,81 +4,81 @@ include TZInfo
 
 class TCCountryTimezone < Minitest::Test
   def test_identifier_new!
-    ct = CountryTimezone.new!('Europe/London', 2059, 40, -5, 16)    
+    ct = CountryTimezone.new!('Europe/London', 2059, 40, -5, 16)
     assert_equal('Europe/London', ct.identifier)
   end
-  
+
   def test_identifier_new
-    ct = CountryTimezone.new('Europe/London', Rational(2059, 40), Rational(-5, 16))    
+    ct = CountryTimezone.new('Europe/London', Rational(2059, 40), Rational(-5, 16))
     assert_equal('Europe/London', ct.identifier)
   end
-  
+
   def test_latitude_new!
     ct = CountryTimezone.new!('Europe/London', 2059, 40, -5, 16)
     assert_equal(Rational(2059, 40), ct.latitude)
   end
-  
+
   def test_latitude_new
     ct = CountryTimezone.new('Europe/London', Rational(2059, 40), Rational(-5, 16))
     assert_equal(Rational(2059, 40), ct.latitude)
   end
-  
+
   def test_longitude_new!
     ct = CountryTimezone.new!('Europe/London', 2059, 40, -5, 16)
     assert_equal(Rational(-5, 16), ct.longitude)
   end
-  
+
   def test_longitude_new
     ct = CountryTimezone.new('Europe/London', Rational(2059, 40), Rational(-5, 16))
     assert_equal(Rational(-5, 16), ct.longitude)
   end
-  
+
   def test_description_omit_new!
     ct = CountryTimezone.new!('Europe/London', 2059, 40, -5, 16)
     assert_nil(ct.description)
   end
-  
+
   def test_description_omit_new
     ct = CountryTimezone.new('Europe/London', Rational(2059, 40), Rational(-5, 16))
     assert_nil(ct.description)
   end
-  
+
   def test_description_nil_new!
     ct = CountryTimezone.new!('Europe/London', 2059, 40, -5, 16, nil)
     assert_nil(ct.description)
   end
-  
+
   def test_description_nil_new
     ct = CountryTimezone.new('Europe/London', Rational(2059, 40), Rational(-5, 16), nil)
     assert_nil(ct.description)
   end
-  
+
   def test_description_new!
     ct = CountryTimezone.new!('America/New_York', 48857, 1200, -266423, 3600, 'Eastern Time')
     assert_equal('Eastern Time', ct.description)
   end
-  
+
   def test_description_new
     ct = CountryTimezone.new('America/New_York', Rational(48857, 1200), Rational(-266423, 3600), 'Eastern Time')
     assert_equal('Eastern Time', ct.description)
   end
-  
-  def test_timezone    
+
+  def test_timezone
     ct = CountryTimezone.new('Europe/London', Rational(2059, 40), Rational(-5, 16))
     assert_kind_of(TimezoneProxy, ct.timezone)
     assert_equal('Europe/London', ct.timezone.identifier)
   end
-  
+
   def test_description_or_friendly_idenfier_no_description
     ct = CountryTimezone.new('Europe/London', Rational(2059, 40), Rational(-5, 16))
     assert_equal('London', ct.description_or_friendly_identifier)
   end
-  
+
   def test_description_or_friendly_idenfier_description
     ct = CountryTimezone.new('America/New_York', Rational(48857, 1200), Rational(-266423, 3600), 'Eastern Time')
     assert_equal('Eastern Time', ct.description_or_friendly_identifier)
   end
-  
+
   def test_equality_1
     ct1 = CountryTimezone.new!('Europe/London', 2059, 40, -5, 16)
     ct2 = CountryTimezone.new!('Europe/London', 2059, 40, -5, 16)
@@ -87,7 +87,7 @@ class TCCountryTimezone < Minitest::Test
     ct5 = CountryTimezone.new!('Europe/LondonB', 2059, 40, -5, 16)
     ct6 = CountryTimezone.new!('Europe/London', 2060, 40, -5, 16)
     ct7 = CountryTimezone.new!('Europe/London', 2059, 40, -6, 16)
-    
+
     assert_equal(true, ct1 == ct1)
     assert_equal(true, ct1 == ct2)
     assert_equal(true, ct1 == ct3)
@@ -96,21 +96,21 @@ class TCCountryTimezone < Minitest::Test
     assert_equal(false, ct1 == ct6)
     assert_equal(false, ct1 == ct7)
   end
-  
+
   def test_equality_2
     ct1 = CountryTimezone.new!('America/New_York', 48857, 1200, -266423, 3600, 'Eastern Time')
     ct2 = CountryTimezone.new!('America/New_York', 48857, 1200, -266423, 3600, 'Eastern Time2')
-    
+
     assert_equal(true, ct1 == ct1)
-    assert_equal(false, ct1 == ct2)    
+    assert_equal(false, ct1 == ct2)
   end
-  
+
   def test_equality_non_country_timezone
     ct = CountryTimezone.new('Europe/London', Rational(2059, 40), Rational(-5, 16))
-    
+
     assert_equal(false, ct == Object.new)
   end
-  
+
   def test_eql_1
     ct1 = CountryTimezone.new!('Europe/London', 2059, 40, -5, 16)
     ct2 = CountryTimezone.new!('Europe/London', 2059, 40, -5, 16)
@@ -119,7 +119,7 @@ class TCCountryTimezone < Minitest::Test
     ct5 = CountryTimezone.new!('Europe/LondonB', 2059, 40, -5, 16)
     ct6 = CountryTimezone.new!('Europe/London', 2060, 40, -5, 16)
     ct7 = CountryTimezone.new!('Europe/London', 2059, 40, -6, 16)
-    
+
     assert_equal(true, ct1.eql?(ct1))
     assert_equal(true, ct1.eql?(ct2))
     assert_equal(true, ct1.eql?(ct3))
@@ -128,33 +128,33 @@ class TCCountryTimezone < Minitest::Test
     assert_equal(false, ct1.eql?(ct6))
     assert_equal(false, ct1.eql?(ct7))
   end
-  
+
   def test_eql_2
     ct1 = CountryTimezone.new!('America/New_York', 48857, 1200, -266423, 3600, 'Eastern Time')
     ct2 = CountryTimezone.new!('America/New_York', 48857, 1200, -266423, 3600, 'Eastern Time2')
-    
+
     assert_equal(true, ct1.eql?(ct1))
-    assert_equal(false, ct1.eql?(ct2))    
+    assert_equal(false, ct1.eql?(ct2))
   end
-  
+
   def test_eql_non_country_timezone
     ct = CountryTimezone.new('Europe/London', Rational(2059, 40), Rational(-5, 16))
-    
+
     assert_equal(false, ct.eql?(Object.new))
   end
-  
+
   def test_hash_new!
     ct1 = CountryTimezone.new!('Europe/London', 2059, 40, -5, 16)
     ct2 = CountryTimezone.new!('America/New_York', 48857, 1200, -266423, 3600, 'Eastern Time')
-    
+
     assert_equal('Europe/London'.hash ^ 2059.hash ^ 40.hash ^ -5.hash ^ 16.hash ^ nil.hash, ct1.hash)
     assert_equal('America/New_York'.hash ^ 48857.hash ^ 1200.hash ^ -266423.hash ^ 3600.hash ^ 'Eastern Time'.hash, ct2.hash)
   end
-  
+
   def test_hash_new
     ct1 = CountryTimezone.new('Europe/London', Rational(2059, 40), Rational(-5, 16))
     ct2 = CountryTimezone.new('America/New_York', Rational(48857, 1200), Rational(-266423, 3600), 'Eastern Time')
-    
+
     assert_equal('Europe/London'.hash ^ 2059.hash ^ 40.hash ^ -5.hash ^ 16.hash ^ nil.hash, ct1.hash)
     assert_equal('America/New_York'.hash ^ 48857.hash ^ 1200.hash ^ -266423.hash ^ 3600.hash ^ 'Eastern Time'.hash, ct2.hash)
   end

--- a/test/tc_data_source.rb
+++ b/test/tc_data_source.rb
@@ -6,52 +6,52 @@ include TZInfo
 class TCDataSource < Minitest::Test
   class InitDataSource < DataSource
   end
-  
+
   class DummyDataSource < DataSource
   end
-  
+
   def setup
     @orig_data_source = DataSource.get
     DataSource.set(InitDataSource.new)
     @orig_search_path = ZoneinfoDataSource.search_path.clone
   end
-  
+
   def teardown
     DataSource.set(@orig_data_source)
     ZoneinfoDataSource.search_path = @orig_search_path
   end
-  
+
   def test_get
     data_source = DataSource.get
     assert_kind_of(InitDataSource, data_source)
   end
-  
-  def test_get_default_ruby_only    
+
+  def test_get_default_ruby_only
     code = <<-EOF
       require 'tmpdir'
-      
+
       begin
         Dir.mktmpdir('tzinfo_test_dir') do |dir|
           TZInfo::ZoneinfoDataSource.search_path = [dir]
-          
+
           puts TZInfo::DataSource.get.class
         end
       rescue Exception => e
         puts "Unexpected exception: \#{e}"
       end
     EOF
-    
+
     assert_sub_process_returns(['TZInfo::RubyDataSource'], code, [TZINFO_TEST_DATA_DIR])
   end
-  
+
   def test_get_default_zoneinfo_only
     code = <<-EOF
       require 'tmpdir'
-      
+
       begin
         Dir.mktmpdir('tzinfo_test_dir') do |dir|
           TZInfo::ZoneinfoDataSource.search_path = [dir, '#{TZINFO_TEST_ZONEINFO_DIR}']
-          
+
           puts TZInfo::DataSource.get.class
           puts TZInfo::DataSource.get.zoneinfo_dir
         end
@@ -59,34 +59,34 @@ class TCDataSource < Minitest::Test
         puts "Unexpected exception: \#{e}"
       end
     EOF
-    
+
     assert_sub_process_returns(
-      ['TZInfo::ZoneinfoDataSource', TZINFO_TEST_ZONEINFO_DIR], 
+      ['TZInfo::ZoneinfoDataSource', TZINFO_TEST_ZONEINFO_DIR],
       code)
   end
-  
+
   def test_get_default_ruby_and_zoneinfo
     code = <<-EOF
       begin
         TZInfo::ZoneinfoDataSource.search_path = ['#{TZINFO_TEST_ZONEINFO_DIR}']
-          
+
         puts TZInfo::DataSource.get.class
       rescue Exception => e
         puts "Unexpected exception: \#{e}"
       end
     EOF
-    
+
     assert_sub_process_returns(['TZInfo::RubyDataSource'], code, [TZINFO_TEST_DATA_DIR])
   end
-  
+
   def test_get_default_no_data
     code = <<-EOF
       require 'tmpdir'
-      
+
       begin
         Dir.mktmpdir('tzinfo_test_dir') do |dir|
           TZInfo::ZoneinfoDataSource.search_path = [dir]
-          
+
           begin
             data_source = TZInfo::DataSource.get
             puts "No exception raised, returned \#{data_source} instead"
@@ -98,33 +98,33 @@ class TCDataSource < Minitest::Test
         puts "Unexpected exception: \#{e}"
       end
     EOF
-    
+
     assert_sub_process_returns(['TZInfo::DataSourceNotFound'], code)
   end
-  
+
   def test_set_instance
     DataSource.set(DummyDataSource.new)
     data_source = DataSource.get
     assert_kind_of(DummyDataSource, data_source)
   end
-  
+
   def test_set_standard_ruby
     DataSource.set(:ruby)
     data_source = DataSource.get
     assert_kind_of(RubyDataSource, data_source)
   end
-  
+
   def test_set_standard_zoneinfo_search
     Dir.mktmpdir('tzinfo_test_dir') do |dir|
       FileUtils.touch(File.join(dir, 'iso3166.tab'))
       FileUtils.touch(File.join(dir, 'zone.tab'))
-              
+
       ZoneinfoDataSource.search_path = [dir]
-      
+
       DataSource.set(:zoneinfo)
       data_source = DataSource.get
       assert_kind_of(ZoneinfoDataSource, data_source)
-      assert_equal(dir, data_source.zoneinfo_dir)      
+      assert_equal(dir, data_source.zoneinfo_dir)
     end
   end
 
@@ -141,16 +141,16 @@ class TCDataSource < Minitest::Test
       assert_equal(dir, data_source.zoneinfo_dir)
     end
   end
-  
+
   def test_set_standard_zoneinfo_explicit
     Dir.mktmpdir('tzinfo_test_dir') do |dir|
       FileUtils.touch(File.join(dir, 'iso3166.tab'))
-      FileUtils.touch(File.join(dir, 'zone.tab'))      
-      
+      FileUtils.touch(File.join(dir, 'zone.tab'))
+
       DataSource.set(:zoneinfo, dir)
       data_source = DataSource.get
       assert_kind_of(ZoneinfoDataSource, data_source)
-      assert_equal(dir, data_source.zoneinfo_dir)      
+      assert_equal(dir, data_source.zoneinfo_dir)
     end
   end
 
@@ -165,54 +165,54 @@ class TCDataSource < Minitest::Test
       assert_equal(dir, data_source.zoneinfo_dir)
     end
   end
-  
+
   def test_set_standard_zoneinfo_explicit_alternate_iso3166
     Dir.mktmpdir('tzinfo_test_dir') do |dir|
       zoneinfo_dir = File.join(dir, 'zoneinfo')
       tab_dir = File.join(dir, 'tab')
-      
+
       FileUtils.mkdir(zoneinfo_dir)
       FileUtils.mkdir(tab_dir)
-    
+
       FileUtils.touch(File.join(zoneinfo_dir, 'zone.tab'))
-      
+
       iso3166_file = File.join(tab_dir, 'iso3166.tab')
       FileUtils.touch(iso3166_file)
-      
+
       DataSource.set(:zoneinfo, zoneinfo_dir, iso3166_file)
       data_source = DataSource.get
       assert_kind_of(ZoneinfoDataSource, data_source)
       assert_equal(zoneinfo_dir, data_source.zoneinfo_dir)
     end
   end
-  
+
   def test_set_standard_zoneinfo_search_not_found
     Dir.mktmpdir('tzinfo_test_dir') do |dir|
       ZoneinfoDataSource.search_path = [dir]
-      
+
       assert_raises(ZoneinfoDirectoryNotFound) do
         DataSource.set(:zoneinfo)
       end
-      
+
       assert_kind_of(InitDataSource, DataSource.get)
     end
   end
-  
+
   def test_set_standard_zoneinfo_explicit_invalid
     Dir.mktmpdir('tzinfo_test_dir') do |dir|
       assert_raises(InvalidZoneinfoDirectory) do
         DataSource.set(:zoneinfo, dir)
       end
-      
-      assert_kind_of(InitDataSource, DataSource.get)      
+
+      assert_kind_of(InitDataSource, DataSource.get)
     end
   end
-  
+
   def test_set_standard_zoneinfo_wrong_arg_count
     assert_raises(ArgumentError) do
       DataSource.set(:zoneinfo, 1, 2, 3)
     end
-    
+
     assert_kind_of(InitDataSource, DataSource.get)
   end
 end

--- a/test/tc_data_timezone.rb
+++ b/test/tc_data_timezone.rb
@@ -3,95 +3,95 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 include TZInfo
 
 class TCDataTimezone < Minitest::Test
-  
+
   class TestTimezoneInfo < TimezoneInfo
     attr_reader :utc
     attr_reader :local
     attr_reader :utc_to
     attr_reader :utc_from
-    
+
     def initialize(identifier, utc_period, local_periods, transitions_up_to)
       super(identifier)
       @utc_period = utc_period
       @local_periods = local_periods || []
       @transitions_up_to = transitions_up_to
     end
-    
+
     def period_for_utc(utc)
       @utc = utc
-      @utc_period     
+      @utc_period
     end
-    
+
     def periods_for_local(local)
-      @local = local      
+      @local = local
       @local_periods
     end
-    
+
     def transitions_up_to(utc_to, utc_from = nil)
       @utc_to = utc_to
       @utc_from = utc_from
       @transitions_up_to
     end
-  end    
+  end
 
   def test_identifier
     tz = DataTimezone.new(TestTimezoneInfo.new('Test/Zone', nil, [], []))
     assert_equal('Test/Zone', tz.identifier)
   end
-  
+
   def test_period_for_utc
     # Don't need actual TimezonePeriods. DataTimezone isn't supposed to do
     # anything with them apart from return them.
-    period = Object.new 
+    period = Object.new
     tti = TestTimezoneInfo.new('Test/Zone', period, [], [])
     tz = DataTimezone.new(tti)
-    
+
     t = Time.utc(2006, 6, 27, 22, 50, 12)
     assert_same(period, tz.period_for_utc(t))
-    assert_same(t, tti.utc)    
+    assert_same(t, tti.utc)
   end
-  
+
   def test_periods_for_local
     # Don't need actual TimezonePeriods. DataTimezone isn't supposed to do
     # anything with them apart from return them.
-    periods = [Object.new, Object.new] 
+    periods = [Object.new, Object.new]
     tti = TestTimezoneInfo.new('Test/Zone', nil, periods, [])
     tz = DataTimezone.new(tti)
-    
-    t = Time.utc(2006, 6, 27, 22, 50, 12)
-    assert_same(periods, tz.periods_for_local(t))
-    assert_same(t, tti.local)  
-  end
-  
-  def test_periods_for_local_not_found
-    periods = []
-    tti = TestTimezoneInfo.new('Test/Zone', nil, periods, [])
-    tz = DataTimezone.new(tti)
-    
+
     t = Time.utc(2006, 6, 27, 22, 50, 12)
     assert_same(periods, tz.periods_for_local(t))
     assert_same(t, tti.local)
   end
-  
+
+  def test_periods_for_local_not_found
+    periods = []
+    tti = TestTimezoneInfo.new('Test/Zone', nil, periods, [])
+    tz = DataTimezone.new(tti)
+
+    t = Time.utc(2006, 6, 27, 22, 50, 12)
+    assert_same(periods, tz.periods_for_local(t))
+    assert_same(t, tti.local)
+  end
+
   def test_transitions_up_to
     # Don't need actual TimezoneTransition instances. DataTimezone isn't
     # supposed to do anything with them apart from return them.
     transitions = [Object.new, Object.new]
     tti = TestTimezoneInfo.new('Test/Zone', nil, nil, transitions)
     tz = DataTimezone.new(tti)
-    
+
     utc_to = Time.utc(2013, 1, 1, 0, 0, 0)
     utc_from = Time.utc(2012, 1, 1, 0, 0, 0)
     assert_same(transitions, tz.transitions_up_to(utc_to, utc_from))
     assert_same(utc_to, tti.utc_to)
     assert_same(utc_from, tti.utc_from)
   end
-  
+
   def test_canonical_identifier
     tz = DataTimezone.new(TestTimezoneInfo.new('Test/Zone', nil, [], []))
-    assert_equal('Test/Zone', tz.canonical_identifier)    
+    assert_equal('Test/Zone', tz.canonical_identifier)
   end
-  
+
   def test_canonical_zone
     tz = DataTimezone.new(TestTimezoneInfo.new('Test/Zone', nil, [], []))
     assert_same(tz, tz.canonical_zone)

--- a/test/tc_data_timezone_info.rb
+++ b/test/tc_data_timezone_info.rb
@@ -3,12 +3,12 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 include TZInfo
 
 class TCDataTimezoneInfo < Minitest::Test
-  
+
   def test_identifier
     ti = DataTimezoneInfo.new('Test/Zone')
     assert_equal('Test/Zone', ti.identifier)
   end
-  
+
   def test_construct_timezone
     ti = DataTimezoneInfo.new('Test/Zone')
     tz = ti.create_timezone

--- a/test/tc_info_timezone.rb
+++ b/test/tc_info_timezone.rb
@@ -3,28 +3,28 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 include TZInfo
 
 class TCInfoTimezone < Minitest::Test
-  
+
   class TestInfoTimezone < InfoTimezone
     attr_reader :setup_info
-    
+
     protected
       def setup(info)
         super(info)
         @setup_info = info
-      end     
+      end
   end
-  
+
   def test_identifier
     tz = InfoTimezone.new(TimezoneInfo.new('Test/Identifier'))
     assert_equal('Test/Identifier', tz.identifier)
   end
-  
+
   def test_info
     i = TimezoneInfo.new('Test/Identifier')
     tz = InfoTimezone.new(i)
     assert_same(i, tz.send(:info))
   end
-  
+
   def test_setup
     i = TimezoneInfo.new('Test/Identifier')
     tz = TestInfoTimezone.new(i)

--- a/test/tc_linked_timezone.rb
+++ b/test/tc_linked_timezone.rb
@@ -3,7 +3,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 include TZInfo
 
 class TCLinkedTimezone < Minitest::Test
-  
+
   class TestTimezone < Timezone
     attr_reader :utc_period
     attr_reader :local_periods
@@ -12,43 +12,43 @@ class TCLinkedTimezone < Minitest::Test
     attr_reader :local
     attr_reader :utc_to
     attr_reader :utc_from
-    
+
     def self.new(identifier, no_local_periods = false)
       tz = super()
       tz.send(:setup, identifier, no_local_periods)
       tz
     end
-    
+
     def identifier
       @identifier
     end
-    
+
     def period_for_utc(utc)
       @utc = utc
       @utc_period
     end
-    
+
     def periods_for_local(local)
       @local = local
       raise PeriodNotFound if @no_local_periods
       @local_periods
     end
-    
+
     def transitions_up_to(utc_to, utc_from = nil)
       @utc_to = utc_to
       @utc_from = utc_from
       @up_to_transitions
     end
-    
+
     def canonical_zone
       self
     end
-    
+
     private
       def setup(identifier, no_local_periods)
         @identifier = identifier
         @no_local_periods = no_local_periods
-        
+
         # Don't have to be real TimezonePeriod or TimezoneTransition objects
         # (nothing will use them).
         @utc_period = Object.new
@@ -56,24 +56,24 @@ class TCLinkedTimezone < Minitest::Test
         @up_to_transitions = [Object.new, Object.new]
       end
   end
-  
-  
+
+
   def setup
     # Redefine Timezone.get to return a fake timezone.
     # Use without_warnings to suppress redefined get method warning.
     without_warnings do
       def Timezone.get(identifier)
         raise InvalidTimezoneIdentifier, 'Invalid identifier' if identifier == 'Invalid/Identifier'
-       
+
         @timezones ||= {}
-        @timezones[identifier] ||= 
-          identifier == 'Test/Recursive/Linked' ? 
+        @timezones[identifier] ||=
+          identifier == 'Test/Recursive/Linked' ?
             LinkedTimezone.new(LinkedTimezoneInfo.new(identifier, 'Test/Recursive/Data')) :
             TestTimezone.new(identifier, identifier == 'Test/No/Local')
       end
     end
   end
-  
+
   def teardown
     # Re-require timezone to reset.
     # Suppress redefined method warnings.
@@ -81,16 +81,16 @@ class TCLinkedTimezone < Minitest::Test
       load 'tzinfo/timezone.rb'
     end
   end
-  
+
   def test_identifier
     tz = LinkedTimezone.new(LinkedTimezoneInfo.new('Test/Zone', 'Test/Linked'))
     assert_equal('Test/Zone', tz.identifier)
   end
-  
+
   def test_invalid_linked_identifier
     assert_raises(InvalidTimezoneIdentifier) { LinkedTimezone.new(LinkedTimezoneInfo.new('Test/Zone', 'Invalid/Identifier')) }
   end
-  
+
   def test_period_for_utc
     tz = LinkedTimezone.new(LinkedTimezoneInfo.new('Test/Zone', 'Test/Linked'))
     linked_tz = Timezone.get('Test/Linked')
@@ -98,7 +98,7 @@ class TCLinkedTimezone < Minitest::Test
     assert_same(linked_tz.utc_period, tz.period_for_utc(t))
     assert_same(t, linked_tz.utc)
   end
-  
+
   def test_periods_for_local
     tz = LinkedTimezone.new(LinkedTimezoneInfo.new('Test/Zone', 'Test/Linked'))
     linked_tz = Timezone.get('Test/Linked')
@@ -106,7 +106,7 @@ class TCLinkedTimezone < Minitest::Test
     assert_same(linked_tz.local_periods, tz.periods_for_local(t))
     assert_same(t, linked_tz.local)
   end
-  
+
   def test_periods_for_local_not_found
     tz = LinkedTimezone.new(LinkedTimezoneInfo.new('Test/Zone', 'Test/No/Local'))
     linked_tz = Timezone.get('Test/No/Local')
@@ -114,7 +114,7 @@ class TCLinkedTimezone < Minitest::Test
     assert_raises(PeriodNotFound) { tz.periods_for_local(t) }
     assert_same(t, linked_tz.local)
   end
-  
+
   def test_transitions_up_to
     tz = LinkedTimezone.new(LinkedTimezoneInfo.new('Test/Zone', 'Test/Linked'))
     linked_tz = Timezone.get('Test/Linked')
@@ -124,30 +124,30 @@ class TCLinkedTimezone < Minitest::Test
     assert_same(utc_to, linked_tz.utc_to)
     assert_same(utc_from, linked_tz.utc_from)
   end
-  
+
   def test_canonical_identifier
     tz = LinkedTimezone.new(LinkedTimezoneInfo.new('Test/Zone', 'Test/Linked'))
     assert_equal('Test/Linked', tz.canonical_identifier)
   end
-  
+
   def test_canonical_identifier_recursive
-    # Recursive links are not currently used in the Time Zone database, but 
+    # Recursive links are not currently used in the Time Zone database, but
     # will be supported by TZInfo.
-  
+
     tz = LinkedTimezone.new(LinkedTimezoneInfo.new('Test/Zone', 'Test/Recursive/Linked'))
     assert_equal('Test/Recursive/Data', tz.canonical_identifier)
   end
-  
+
   def test_canonical_zone
     tz = LinkedTimezone.new(LinkedTimezoneInfo.new('Test/Zone', 'Test/Linked'))
     linked_tz = Timezone.get('Test/Linked')
     assert_same(linked_tz, tz.canonical_zone)
   end
-  
+
   def test_canonical_zone_recursive
-    # Recursive links are not currently used in the Time Zone database, but 
+    # Recursive links are not currently used in the Time Zone database, but
     # will be supported by TZInfo.
-  
+
     tz = LinkedTimezone.new(LinkedTimezoneInfo.new('Test/Zone', 'Test/Recursive/Linked'))
     linked_tz = Timezone.get('Test/Recursive/Data')
     assert_same(linked_tz, tz.canonical_zone)

--- a/test/tc_linked_timezone_info.rb
+++ b/test/tc_linked_timezone_info.rb
@@ -3,17 +3,17 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 include TZInfo
 
 class TCLinkedTimezoneInfo < Minitest::Test
-  
+
   def test_identifier
     lti = LinkedTimezoneInfo.new('Test/Zone', 'Test/Linked')
     assert_equal('Test/Zone', lti.identifier)
   end
-  
+
   def test_link_to_identifier
     lti = LinkedTimezoneInfo.new('Test/Zone', 'Test/Linked')
     assert_equal('Test/Linked', lti.link_to_identifier)
   end
-  
+
   def test_construct_timezone
     lti = LinkedTimezoneInfo.new('Test/Zone', 'Europe/London')
     tz = lti.create_timezone

--- a/test/tc_offset_rationals.rb
+++ b/test/tc_offset_rationals.rb
@@ -5,17 +5,17 @@ include TZInfo
 class TCOffsetRationals < Minitest::Test
   def test_rational_for_offset
     [0,1,2,3,4,-1,-2,-3,-4,30*60,-30*60,61*60,-61*60,14*60*60,-14*60*60,20*60*60,-20*60*60].each {|seconds|
-      assert_equal(Rational(seconds, 86400), OffsetRationals.rational_for_offset(seconds))      
+      assert_equal(Rational(seconds, 86400), OffsetRationals.rational_for_offset(seconds))
     }
   end
-  
+
   def test_rational_for_offset_constant
     -28.upto(28) {|i|
       seconds = i * 30 * 60
-      
+
       r1 = OffsetRationals.rational_for_offset(seconds)
       r2 = OffsetRationals.rational_for_offset(seconds)
-      
+
       assert_equal(Rational(seconds, 86400), r1)
       assert_same(r1, r2)
     }

--- a/test/tc_ruby_core_support.rb
+++ b/test/tc_ruby_core_support.rb
@@ -8,35 +8,35 @@ class TCRubyCoreSupport < Minitest::Test
   def test_rational_new!
     assert_equal(Rational(3,4), RubyCoreSupport.rational_new!(3,4))
   end
-  
+
   def test_datetime_new!
     assert_equal(DateTime.new(2008,10,5,12,0,0, 0, Date::ITALY), RubyCoreSupport.datetime_new!(2454745,0,2299161))
     assert_equal(DateTime.new(2008,10,5,13,0,0, Rational(1, 24), Date::ITALY), RubyCoreSupport.datetime_new!(2454745,Rational(1, 24),2299161))
-    
+
     assert_equal(DateTime.new(2008,10,5,20,30,0, 0, Date::ITALY), RubyCoreSupport.datetime_new!(Rational(117827777, 48), 0, 2299161))
     assert_equal(DateTime.new(2008,10,5,21,30,0, Rational(1, 24), Date::ITALY), RubyCoreSupport.datetime_new!(Rational(117827777, 48), Rational(1, 24), 2299161))
-    
+
     assert_equal(DateTime.new(2008,10,6,6,26,21, 0, Date::ITALY), RubyCoreSupport.datetime_new!(Rational(70696678127,28800), 0, 2299161))
     assert_equal(DateTime.new(2008,10,6,7,26,21, Rational(1, 24), Date::ITALY), RubyCoreSupport.datetime_new!(Rational(70696678127, 28800), Rational(1, 24), 2299161))
-    
+
     assert_equal(DateTime.new(-4712,1,1,12,0,0, 0, Date::ITALY), RubyCoreSupport.datetime_new!(0, 0, 2299161))
     assert_equal(DateTime.new(-4712,1,1,13,0,0, Rational(1, 24), Date::ITALY), RubyCoreSupport.datetime_new!(0, Rational(1, 24), 2299161))
-    
+
     assert_equal(DateTime.new(-4713,12,31,23,58,59, 0, Date::ITALY), RubyCoreSupport.datetime_new!(Rational(-43261, 86400), 0, 2299161))
     assert_equal(DateTime.new(-4712,1,1,0,58,59, Rational(1, 24), Date::ITALY), RubyCoreSupport.datetime_new!(Rational(-43261, 86400), Rational(1, 24), 2299161))
-    
+
     assert_equal(DateTime.new(-4713,12,30,23,58,59, 0, Date::ITALY), RubyCoreSupport.datetime_new!(Rational(-129661, 86400), 0, 2299161))
     assert_equal(DateTime.new(-4713,12,31,0,58,59, Rational(1, 24), Date::ITALY), RubyCoreSupport.datetime_new!(Rational(-129661, 86400), Rational(1, 24), 2299161))
   end
-  
+
   def test_datetime_new
     assert_equal(DateTime.new(2012, 12, 31, 23, 59, 59, 0, Date::ITALY), RubyCoreSupport.datetime_new(2012, 12, 31, 23, 59, 59, 0, Date::ITALY))
     assert_equal(DateTime.new(2013, 2, 6, 23, 2, 36, Rational(1, 24), Date::ITALY), RubyCoreSupport.datetime_new(2013, 2, 6, 23, 2, 36, Rational(1,24), Date::ITALY))
-    
+
     assert_equal(DateTime.new(2012, 12, 31, 23, 59, 59, 0, Date::ITALY) + Rational(1, 86400000), RubyCoreSupport.datetime_new(2012, 12, 31, 23, 59, 59 + Rational(1, 1000), 0, Date::ITALY))
     assert_equal(DateTime.new(2001, 10, 12, 12, 22, 59, Rational(1, 24), Date::ITALY) + Rational(501, 86400000), RubyCoreSupport.datetime_new(2001, 10, 12, 12, 22, 59 + Rational(501, 1000), Rational(1, 24), Date::ITALY))
   end
-  
+
   def test_time_supports_negative
     if RubyCoreSupport.time_supports_negative
       assert_equal(Time.utc(1969, 12, 31, 23, 59, 59), Time.at(-1).utc)
@@ -46,7 +46,7 @@ class TCRubyCoreSupport < Minitest::Test
       end
     end
   end
-  
+
   def test_time_supports_64_bit
     if RubyCoreSupport.time_supports_64bit
       assert_equal(Time.utc(1901, 12, 13, 20, 45, 51), Time.at(-2147483649).utc)
@@ -55,26 +55,26 @@ class TCRubyCoreSupport < Minitest::Test
       assert_raises(RangeError) do
         Time.at(-2147483649)
       end
-      
+
       assert_raises(RangeError) do
         Time.at(2147483648)
       end
     end
   end
-  
+
   def test_time_nsec
     t = Time.utc(2013, 2, 6, 21, 56, 23, 567890 + Rational(123,1000))
-    
+
     if t.respond_to?(:nsec)
       assert_equal(567890123, RubyCoreSupport.time_nsec(t))
     else
       assert_equal(567890000, RubyCoreSupport.time_nsec(t))
     end
   end
-  
+
   def test_force_encoding
     s = [0xC2, 0xA9].pack('c2')
-    
+
     if s.respond_to?(:force_encoding)
       # Ruby 1.9+ - should call String#force_encoding
       assert_equal('ASCII-8BIT', s.encoding.name)
@@ -92,7 +92,7 @@ class TCRubyCoreSupport < Minitest::Test
       assert_equal('©', s)
     end
   end
-  
+
   begin
     SUPPORTS_ENCODING = !!Encoding
   rescue NameError
@@ -112,16 +112,16 @@ class TCRubyCoreSupport < Minitest::Test
       end
     end
   end
-  
+
   def check_open_file_test_file_content(file)
     content = file.gets
     refute_nil(content)
     content.chomp!
-    
-    if SUPPORTS_ENCODING            
+
+    if SUPPORTS_ENCODING
       assert_equal('UTF-8', content.encoding.name)
       assert_equal(1, content.length)
-      assert_equal(2, content.bytesize) 
+      assert_equal(2, content.bytesize)
       assert_equal('©', content)
     else
       assert_equal('x', content)
@@ -129,18 +129,18 @@ class TCRubyCoreSupport < Minitest::Test
   end
 
   def test_open_file
-    Dir.mktmpdir('tzinfo_test') do |dir|          
+    Dir.mktmpdir('tzinfo_test') do |dir|
       test_file = File.join(dir, 'test.txt')
-    
+
       file = RubyCoreSupport.open_file(test_file, 'w', :external_encoding => 'UTF-8')
-      begin        
+      begin
         file.puts(SUPPORTS_ENCODING ? '©' : 'x')
       ensure
         file.close
       end
-      
+
       check_open_file_test_file_bytes(test_file)
-      
+
       file = RubyCoreSupport.open_file(test_file, 'r', :external_encoding => 'UTF-8', :internal_encoding => 'UTF-8')
       begin
         check_open_file_test_file_content(file)
@@ -149,17 +149,17 @@ class TCRubyCoreSupport < Minitest::Test
       end
     end
   end
-    
+
   def test_open_file_block
-    Dir.mktmpdir('tzinfo_test') do |dir|          
+    Dir.mktmpdir('tzinfo_test') do |dir|
       test_file = File.join(dir, 'test.txt')
-    
+
       RubyCoreSupport.open_file(test_file, 'w', :external_encoding => 'UTF-8') do |file|
         file.puts(SUPPORTS_ENCODING ? '©' : 'x')
       end
-      
+
       check_open_file_test_file_bytes(test_file)
-      
+
       RubyCoreSupport.open_file(test_file, 'r', :external_encoding => 'UTF-8', :internal_encoding => 'UTF-8') do |file|
         check_open_file_test_file_content(file)
       end

--- a/test/tc_ruby_country_info.rb
+++ b/test/tc_ruby_country_info.rb
@@ -3,29 +3,29 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 include TZInfo
 
 class TCRubyCountryInfo < Minitest::Test
-  
+
   def test_code
     ci = RubyCountryInfo.new('ZZ', 'Zzz') {|c| }
     assert_equal('ZZ', ci.code)
   end
-  
+
   def test_name
     ci = RubyCountryInfo.new('ZZ', 'Zzz') {|c| }
     assert_equal('Zzz', ci.name)
   end
-  
+
   def test_zone_identifiers_empty
     ci = RubyCountryInfo.new('ZZ', 'Zzz') {|c| }
     assert(ci.zone_identifiers.empty?)
     assert(ci.zone_identifiers.frozen?)
   end
-  
+
   def test_zone_identifiers_no_block
     ci = RubyCountryInfo.new('ZZ', 'Zzz')
     assert(ci.zone_identifiers.empty?)
     assert(ci.zone_identifiers.frozen?)
   end
-  
+
   def test_zone_identifiers
     ci = RubyCountryInfo.new('ZZ', 'Zzz') do |c|
       c.timezone('ZZ/TimezoneB', 1, 2, 1, 2, 'Timezone B')
@@ -33,23 +33,23 @@ class TCRubyCountryInfo < Minitest::Test
       c.timezone('ZZ/TimezoneC', -10, 3, -20, 7, 'C')
       c.timezone('ZZ/TimezoneD', -10, 3, -20, 7)
     end
-    
+
     assert_equal(['ZZ/TimezoneB', 'ZZ/TimezoneA', 'ZZ/TimezoneC', 'ZZ/TimezoneD'], ci.zone_identifiers)
     assert(ci.zone_identifiers.frozen?)
   end
-  
+
   def test_zones_empty
     ci = RubyCountryInfo.new('ZZ', 'Zzz') {|c| }
     assert(ci.zones.empty?)
     assert(ci.zones.frozen?)
   end
-  
+
   def test_zones_no_block
     ci = RubyCountryInfo.new('ZZ', 'Zzz')
     assert(ci.zones.empty?)
     assert(ci.zones.frozen?)
   end
-  
+
   def test_zones
     ci = RubyCountryInfo.new('ZZ', 'Zzz') do |c|
       c.timezone('ZZ/TimezoneB', 1, 2, 1, 2, 'Timezone B')
@@ -57,7 +57,7 @@ class TCRubyCountryInfo < Minitest::Test
       c.timezone('ZZ/TimezoneC', -10, 3, -20, 7, 'C')
       c.timezone('ZZ/TimezoneD', -10, 3, -20, 7)
     end
-    
+
     assert_equal([CountryTimezone.new!('ZZ/TimezoneB', 1, 2, 1, 2, 'Timezone B'),
       CountryTimezone.new!('ZZ/TimezoneA', 1, 4, 1, 4, 'Timezone A'),
       CountryTimezone.new!('ZZ/TimezoneC', -10, 3, -20, 7, 'C'),
@@ -65,14 +65,14 @@ class TCRubyCountryInfo < Minitest::Test
       ci.zones)
     assert(ci.zones.frozen?)
   end
-  
+
   def test_deferred_evaluate
     block_called = false
-    
+
     ci = RubyCountryInfo.new('ZZ', 'Zzz') do |c|
       block_called = true
     end
-    
+
     assert_equal(false, block_called)
     ci.zones
     assert_equal(true, block_called)

--- a/test/tc_ruby_data_source.rb
+++ b/test/tc_ruby_data_source.rb
@@ -6,38 +6,38 @@ class TCRubyDataSource < Minitest::Test
   def setup
     @data_source = RubyDataSource.new
   end
-  
+
   def test_load_timezone_info_data
     info = @data_source.load_timezone_info('Europe/London')
     assert_kind_of(DataTimezoneInfo, info)
     assert_equal('Europe/London', info.identifier)
   end
-  
+
   def test_load_timezone_info_linked
     info = @data_source.load_timezone_info('UTC')
     assert_kind_of(LinkedTimezoneInfo, info)
     assert_equal('UTC', info.identifier)
     assert_equal('Etc/UTC', info.link_to_identifier)
   end
-  
+
   def test_load_timezone_info_does_not_exist
     assert_raises(InvalidTimezoneIdentifier) do
       @data_source.load_timezone_info('Nowhere/Special')
     end
   end
-  
+
   def test_load_timezone_info_invalid
     assert_raises(InvalidTimezoneIdentifier) do
       @data_source.load_timezone_info('../Definitions/UTC')
     end
   end
-  
+
   def test_load_timezone_info_nil
     assert_raises(InvalidTimezoneIdentifier) do
       @data_source.load_timezone_info(nil)
     end
   end
-  
+
   def test_load_timezone_info_case
     assert_raises(InvalidTimezoneIdentifier) do
       @data_source.load_timezone_info('europe/london')
@@ -48,7 +48,7 @@ class TCRubyDataSource < Minitest::Test
     info = @data_source.load_timezone_info('Etc/GMT+1')
     assert_equal('Etc/GMT+1', info.identifier)
   end
-  
+
   def test_load_timezone_info_minus
     info = @data_source.load_timezone_info('Etc/GMT-1')
     assert_equal('Etc/GMT-1', info.identifier)
@@ -63,61 +63,61 @@ class TCRubyDataSource < Minitest::Test
       assert(identifier.tainted?)
     end
   end
-  
+
   def test_load_timezone_info_tainted_and_frozen
     safe_test do
       info = @data_source.load_timezone_info('Europe/Amsterdam'.dup.taint.freeze)
       assert_equal('Europe/Amsterdam', info.identifier)
     end
   end
-  
+
   def test_timezone_identifiers
     all = @data_source.timezone_identifiers
     assert_equal(TZInfo::Data::Indexes::Timezones.timezones, all)
     assert_equal(true, all.frozen?)
   end
-  
+
   def test_data_timezone_identifiers
     all_data = @data_source.data_timezone_identifiers
     assert_equal(TZInfo::Data::Indexes::Timezones.data_timezones, all_data)
     assert_equal(true, all_data.frozen?)
   end
-  
+
   def test_linked_timezone_identifiers
     all_linked = @data_source.linked_timezone_identifiers
     assert_equal(TZInfo::Data::Indexes::Timezones.linked_timezones, all_linked)
     assert_equal(true, all_linked.frozen?)
   end
-  
+
   def test_load_country_info
     info = @data_source.load_country_info('GB')
     assert_equal('GB', info.code)
   end
-    
+
   def test_load_country_info_not_exist
     assert_raises(InvalidCountryCode) do
       @data_source.load_country_info('ZZ')
     end
   end
-  
+
   def test_load_country_info_invalid
     assert_raises(InvalidCountryCode) do
       @data_source.load_country_info('../Countries/GB')
     end
   end
-  
+
   def test_load_country_info_nil
     assert_raises(InvalidCountryCode) do
       @data_source.load_country_info(nil)
     end
   end
-  
+
   def test_load_country_info_case
     assert_raises(InvalidCountryCode) do
       @data_source.load_country_info('gb')
     end
   end
-  
+
   def test_load_country_info_tainted
     safe_test do
       code = 'NL'.dup.taint
@@ -127,14 +127,14 @@ class TCRubyDataSource < Minitest::Test
       assert(code.tainted?)
     end
   end
-  
+
   def test_load_country_info_tainted_and_frozen
     safe_test do
       info = @data_source.load_country_info('NL'.dup.taint.freeze)
       assert_equal('NL', info.code)
     end
   end
-  
+
   def test_country_codes
     codes = @data_source.country_codes
     assert_equal(TZInfo::Data::Indexes::Countries.countries.keys, codes)

--- a/test/tc_time_or_datetime.rb
+++ b/test/tc_time_or_datetime.rb
@@ -9,15 +9,15 @@ class TCTimeOrDateTime < Minitest::Test
       TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 721000))
     end
   end
-  
-  def test_initialize_time_local 
+
+  def test_initialize_time_local
     tdt = TimeOrDateTime.new(Time.local(2006, 3, 24, 15, 32, 3))
     assert_equal(Time.utc(2006, 3, 24, 15, 32, 3), tdt.to_time)
     assert_equal(Time.utc(2006, 3, 24, 15, 32, 3), tdt.to_orig)
     assert(tdt.to_time.utc?)
     assert(tdt.to_orig.utc?)
   end
-  
+
   def test_intialize_time_local_usec
     tdt = TimeOrDateTime.new(Time.local(2006, 3, 24, 15, 32, 3, 721123))
     assert_equal(Time.utc(2006, 3, 24, 15, 32, 3, 721123), tdt.to_time)
@@ -25,7 +25,7 @@ class TCTimeOrDateTime < Minitest::Test
     assert(tdt.to_time.utc?)
     assert(tdt.to_orig.utc?)
   end
-  
+
   if Time.utc(2013, 1, 1).respond_to?(:nsec)
     def test_initialize_time_local_nsec
       tdt = TimeOrDateTime.new(Time.local(2006, 3, 24, 15, 32, 3, 721123 + Rational(456,1000)))
@@ -35,15 +35,15 @@ class TCTimeOrDateTime < Minitest::Test
       assert(tdt.to_orig.utc?)
     end
   end
-  
+
   def test_initialize_time_utc_local
-    # Check that local Time instances on systems using UTC as the system 
+    # Check that local Time instances on systems using UTC as the system
     # time zone are still converted to UTC Time instances.
-    
+
     # Note that this will only test will only work correctly on platforms where
     # setting the TZ environment variable has an effect. If setting TZ has no
     # effect, then this test will still pass.
-    
+
     old_tz = ENV['TZ']
     begin
       ENV['TZ'] = 'UTC'
@@ -56,59 +56,59 @@ class TCTimeOrDateTime < Minitest::Test
       ENV['TZ'] = old_tz
     end
   end
-  
+
   def test_initialize_datetime_offset
     tdt = TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3).new_offset(Rational(5, 24)))
     assert_equal(DateTime.new(2006, 3, 24, 15, 32, 3), tdt.to_datetime)
     assert_equal(0, tdt.to_datetime.offset)
   end
-  
+
   def test_initialize_datetime
     assert_nothing_raised do
       TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3))
     end
   end
-  
+
   def test_initialize_timestamp
     assert_nothing_raised do
       TimeOrDateTime.new(1143214323)
     end
   end
-  
+
   def test_initialize_timestamp_string
     assert_nothing_raised do
       TimeOrDateTime.new('1143214323')
     end
   end
-  
+
   unless RubyCoreSupport.time_supports_64bit
     # Only define this test for non-64bit platforms. Some 64-bit Rubies support
     # greater than 64-bit, others support less than the full range. In either
     # case, times at the far ends of the range are so far in the future or past
-    # that they are not going to turn up in timezone data.  
-    def test_initialize_timestamp_supported_range      
+    # that they are not going to turn up in timezone data.
+    def test_initialize_timestamp_supported_range
       assert_equal((2 ** 31) - 1, TimeOrDateTime.new((2 ** 31) - 1).to_orig)
-    
+
       assert_raises(RangeError) do
         TimeOrDateTime.new(2 ** 31)
       end
-    
+
       if RubyCoreSupport.time_supports_negative
         assert_equal(-(2 ** 31), TimeOrDateTime.new(-(2 ** 31)).to_orig)
-      
+
         assert_raises(RangeError) do
           TimeOrDateTime.new(-(2 ** 31) - 1)
         end
       else
         assert_equal(0, TimeOrDateTime.new(0).to_orig)
-      
+
         assert_raises(RangeError) do
           TimeOrDateTime.new(-1)
         end
       end
     end
   end
-  
+
   def test_to_time
     assert_equal(Time.utc(2006, 3, 24, 15, 32, 3),
       TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)).to_time)
@@ -123,12 +123,12 @@ class TCTimeOrDateTime < Minitest::Test
     assert_equal(Time.utc(2006, 3, 24, 15, 32, 3),
       TimeOrDateTime.new('1143214323').to_time)
   end
-  
+
   def test_to_time_trunc_to_usec
     assert_equal(Time.utc(2006, 3, 24, 15, 32, 3, 721123),
       TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(7211239, 10000000))).to_time)
   end
-  
+
   def test_to_datetime
     assert_equal(DateTime.new(2006, 3, 24, 15, 32, 3),
       TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)).to_datetime)
@@ -143,21 +143,21 @@ class TCTimeOrDateTime < Minitest::Test
     assert_equal(DateTime.new(2006, 3, 24, 15, 32, 3),
       TimeOrDateTime.new('1143214323').to_datetime)
   end
-  
+
   def test_to_datetime_ruby186_bug
-    # DateTime.new in Ruby 1.8.6 won't allow a time to be specified using 
+    # DateTime.new in Ruby 1.8.6 won't allow a time to be specified using
     # fractions of a second that is within the 60th second of a minute.
-    
+
     # TimeOrDateTime has a workaround for this issue.
     assert_equal(DateTime.new(2006, 3, 24, 15, 32, 59) + Rational(721123, 86400000000),
       TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 59, 721123)).to_datetime)
   end
-  
+
   def test_to_datetime_trunc_to_usec
     assert_equal(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721123, 1000000)),
       TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 721123 + Rational(9, 10))).to_datetime)
   end
-  
+
   def test_to_i
     assert_equal(1143214323,
       TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)).to_i)
@@ -172,7 +172,7 @@ class TCTimeOrDateTime < Minitest::Test
     assert_equal(1143214323,
       TimeOrDateTime.new('1143214323').to_i)
   end
-  
+
   def test_to_orig
     assert_equal(Time.utc(2006, 3, 24, 15, 32, 3),
       TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)).to_orig)
@@ -185,9 +185,9 @@ class TCTimeOrDateTime < Minitest::Test
     assert_equal(1143214323,
       TimeOrDateTime.new(1143214323).to_orig)
     assert_equal(1143214323,
-      TimeOrDateTime.new('1143214323').to_orig) 
+      TimeOrDateTime.new('1143214323').to_orig)
   end
-  
+
   def test_to_s
     assert_equal("Time: #{Time.utc(2006, 3, 24, 15, 32, 3).to_s}",
       TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)).to_s)
@@ -196,57 +196,57 @@ class TCTimeOrDateTime < Minitest::Test
     assert_equal('Timestamp: 1143214323',
       TimeOrDateTime.new(1143214323).to_s)
     assert_equal('Timestamp: 1143214323',
-      TimeOrDateTime.new('1143214323').to_s) 
+      TimeOrDateTime.new('1143214323').to_s)
   end
-  
+
   def test_year
     assert_equal(2006, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)).year)
     assert_equal(2006, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)).year)
     assert_equal(2006, TimeOrDateTime.new(1143214323).year)
   end
-  
+
   def test_mon
     assert_equal(3, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)).mon)
     assert_equal(3, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)).mon)
-    assert_equal(3, TimeOrDateTime.new(1143214323).mon)    
+    assert_equal(3, TimeOrDateTime.new(1143214323).mon)
   end
-  
+
   def test_month
     assert_equal(3, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)).month)
     assert_equal(3, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)).month)
     assert_equal(3, TimeOrDateTime.new(1143214323).month)
   end
-  
+
   def test_mday
     assert_equal(24, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)).mday)
     assert_equal(24, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)).mday)
     assert_equal(24, TimeOrDateTime.new(1143214323).mday)
   end
-  
+
   def test_day
     assert_equal(24, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)).day)
     assert_equal(24, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)).day)
     assert_equal(24, TimeOrDateTime.new(1143214323).day)
   end
-  
+
   def test_hour
     assert_equal(15, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)).hour)
     assert_equal(15, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)).hour)
     assert_equal(15, TimeOrDateTime.new(1143214323).hour)
   end
-  
+
   def test_min
     assert_equal(32, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)).min)
     assert_equal(32, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)).min)
     assert_equal(32, TimeOrDateTime.new(1143214323).min)
   end
-  
+
   def test_sec
     assert_equal(3, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)).sec)
     assert_equal(3, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)).sec)
     assert_equal(3, TimeOrDateTime.new(1143214323).sec)
   end
-  
+
   def test_usec
     assert_equal(0, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)).usec)
     assert_equal(721123, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 721123)).usec)
@@ -260,7 +260,7 @@ class TCTimeOrDateTime < Minitest::Test
     assert_equal(Time.utc(2013, 2, 4, 22, 10, 33).to_i, val.to_i)
     assert_equal(598000, val.usec)
   end
-    
+
   def test_compare_timeordatetime_time
     assert_equal(-1, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)) <=> TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 4)))
     assert_equal(-1, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)) <=> TimeOrDateTime.new(Time.utc(2007, 3, 24, 15, 32, 3)))
@@ -279,7 +279,7 @@ class TCTimeOrDateTime < Minitest::Test
     assert_equal(0, TimeOrDateTime.new(1143214323) <=> TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)))
     assert_equal(1, TimeOrDateTime.new(1143214323) <=> TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 2)))
     assert_equal(1, TimeOrDateTime.new(1143214323) <=> TimeOrDateTime.new(Time.utc(2005, 3, 24, 15, 32, 3)))
-    
+
     assert_equal(-1, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 500000)) <=> TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 500001)))
     assert_equal(0, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 500000)) <=> TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 500000)))
     assert_equal(1, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 500000)) <=> TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 499999)))
@@ -287,7 +287,7 @@ class TCTimeOrDateTime < Minitest::Test
     assert_equal(0, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(500000, 1000000))) <=> TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 500000)))
     assert_equal(1, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(500000, 1000000))) <=> TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 500000 - DATETIME_RESOLUTION)))
   end
-  
+
   def test_compare_timeordatetime_datetime
     assert_equal(-1, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)) <=> TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 4)))
     assert_equal(-1, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)) <=> TimeOrDateTime.new(DateTime.new(2040, 3, 24, 15, 32, 3)))
@@ -306,7 +306,7 @@ class TCTimeOrDateTime < Minitest::Test
     assert_equal(0, TimeOrDateTime.new(1143214323) <=> TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)))
     assert_equal(1, TimeOrDateTime.new(1143214323) <=> TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 2)))
     assert_equal(1, TimeOrDateTime.new(1143214323) <=> TimeOrDateTime.new(DateTime.new(1960, 3, 24, 15, 32, 3)))
-    
+
     assert_equal(-1, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 500000)) <=> TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(500000 + DATETIME_RESOLUTION, 1000000))))
     assert_equal(0, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 500000)) <=> TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(500000, 1000000))))
     assert_equal(1, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 500000)) <=> TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(500000 - DATETIME_RESOLUTION, 1000000))))
@@ -314,7 +314,7 @@ class TCTimeOrDateTime < Minitest::Test
     assert_equal(0, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(500000, 1000000))) <=> TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(500000, 1000000))))
     assert_equal(1, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(500000, 1000000))) <=> TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(500000 - DATETIME_RESOLUTION, 1000000))))
   end
-  
+
   def test_compare_timeordatetime_timestamp
     assert_equal(-1, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)) <=> TimeOrDateTime.new(1143214324))
     assert_equal(-1, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)) <=> TimeOrDateTime.new(1174750323))
@@ -334,7 +334,7 @@ class TCTimeOrDateTime < Minitest::Test
     assert_equal(1, TimeOrDateTime.new(1143214323) <=> TimeOrDateTime.new(1143214322))
     assert_equal(1, TimeOrDateTime.new(1143214323) <=> TimeOrDateTime.new(1111678323))
   end
-  
+
   def test_compare_time
     assert_equal(-1, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)) <=> Time.utc(2006, 3, 24, 15, 32, 4))
     assert_equal(-1, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)) <=> Time.utc(2007, 3, 24, 15, 32, 3))
@@ -353,7 +353,7 @@ class TCTimeOrDateTime < Minitest::Test
     assert_equal(0, TimeOrDateTime.new(1143214323) <=> Time.utc(2006, 3, 24, 15, 32, 3))
     assert_equal(1, TimeOrDateTime.new(1143214323) <=> Time.utc(2006, 3, 24, 15, 32, 2))
     assert_equal(1, TimeOrDateTime.new(1143214323) <=> Time.utc(2005, 3, 24, 15, 32, 3))
-    
+
     assert_equal(-1, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 500000)) <=> Time.utc(2006, 3, 24, 15, 32, 3, 500001))
     assert_equal(0, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 500000)) <=> Time.utc(2006, 3, 24, 15, 32, 3, 500000))
     assert_equal(1, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 500000)) <=> Time.utc(2006, 3, 24, 15, 32, 3, 499999))
@@ -361,7 +361,7 @@ class TCTimeOrDateTime < Minitest::Test
     assert_equal(0, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(500000, 1000000))) <=> Time.utc(2006, 3, 24, 15, 32, 3, 500000))
     assert_equal(1, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(500000, 1000000))) <=> Time.utc(2006, 3, 24, 15, 32, 3, 500000 - DATETIME_RESOLUTION))
   end
-  
+
   def test_compare_datetime
     assert_equal(-1, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)) <=> DateTime.new(2006, 3, 24, 15, 32, 4))
     assert_equal(-1, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)) <=> DateTime.new(2040, 3, 24, 15, 32, 3))
@@ -380,7 +380,7 @@ class TCTimeOrDateTime < Minitest::Test
     assert_equal(0, TimeOrDateTime.new(1143214323) <=> DateTime.new(2006, 3, 24, 15, 32, 3))
     assert_equal(1, TimeOrDateTime.new(1143214323) <=> DateTime.new(2006, 3, 24, 15, 32, 2))
     assert_equal(1, TimeOrDateTime.new(1143214323) <=> DateTime.new(1960, 3, 24, 15, 32, 3))
-    
+
     assert_equal(-1, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 500000)) <=> DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(500000 + DATETIME_RESOLUTION, 1000000)))
     assert_equal(0, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 500000)) <=> DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(500000, 1000000)))
     assert_equal(1, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 500000)) <=> DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(500000 - DATETIME_RESOLUTION, 1000000)))
@@ -388,7 +388,7 @@ class TCTimeOrDateTime < Minitest::Test
     assert_equal(0, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(500000, 1000000))) <=> DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(500000, 1000000)))
     assert_equal(1, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(500000, 1000000))) <=> DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(500000 - DATETIME_RESOLUTION, 1000000)))
   end
-  
+
   def test_compare_timestamp
     assert_equal(-1, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)) <=> 1143214324)
     assert_equal(-1, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)) <=> 1174750323)
@@ -408,7 +408,7 @@ class TCTimeOrDateTime < Minitest::Test
     assert_equal(1, TimeOrDateTime.new(1143214323) <=> 1143214322)
     assert_equal(1, TimeOrDateTime.new(1143214323) <=> 1111678323)
   end
-  
+
   def test_compare_timestamp_str
     assert_equal(-1, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)) <=> '1143214324')
     assert_equal(-1, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)) <=> '1174750323')
@@ -428,13 +428,13 @@ class TCTimeOrDateTime < Minitest::Test
     assert_equal(1, TimeOrDateTime.new(1143214323) <=> '1143214322')
     assert_equal(1, TimeOrDateTime.new(1143214323) <=> '1111678323')
   end
-  
+
   def test_compare_non_comparable
     assert_nil(TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)) <=> Object.new)
     assert_nil(TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)) <=> Object.new)
     assert_nil(TimeOrDateTime.new(1143214323) <=> Object.new)
   end
-  
+
   def test_eql
     assert_equal(true, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)).eql?(TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3))))
     assert_equal(false, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)).eql?(TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3))))
@@ -442,25 +442,25 @@ class TCTimeOrDateTime < Minitest::Test
     assert_equal(false, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)).eql?(TimeOrDateTime.new('1143214323')))
     assert_equal(false, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)).eql?(TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 4))))
     assert_equal(false, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)).eql?(Object.new))
-    
+
     assert_equal(true, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 721000)).eql?(TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 721000))))
     assert_equal(false, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 721000)).eql?(TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721, 1000)))))
     assert_equal(false, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 721000)).eql?(TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 722000))))
     assert_equal(false, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 721000)).eql?(Object.new))
-    
+
     assert_equal(false, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)).eql?(TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3))))
     assert_equal(true, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)).eql?(TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3))))
     assert_equal(false, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)).eql?(TimeOrDateTime.new(1143214323)))
     assert_equal(false, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)).eql?(TimeOrDateTime.new('1143214323')))
     assert_equal(false, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)).eql?(TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 4))))
     assert_equal(false, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)).eql?(Object.new))
-    
+
     assert_equal(false, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721, 1000))).eql?(TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 721000))))
     assert_equal(true, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721, 1000))).eql?(TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721, 1000)))))
     assert_equal(false, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721, 1000))).eql?(TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(722, 1000)))))
     assert_equal(false, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721, 1000))).eql?(Object.new))
 
-    
+
     assert_equal(false, TimeOrDateTime.new(1143214323).eql?(TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3))))
     assert_equal(false, TimeOrDateTime.new(1143214323).eql?(TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3))))
     assert_equal(true, TimeOrDateTime.new(1143214323).eql?(TimeOrDateTime.new(1143214323)))
@@ -468,14 +468,14 @@ class TCTimeOrDateTime < Minitest::Test
     assert_equal(false, TimeOrDateTime.new(1143214323).eql?(TimeOrDateTime.new(1143214324)))
     assert_equal(false, TimeOrDateTime.new(1143214323).eql?(Object.new))
   end
-  
+
   def test_hash
     assert_equal(Time.utc(2006, 3, 24, 15, 32, 3).hash, TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)).hash)
     assert_equal(DateTime.new(2006, 3, 24, 15, 32, 3).hash, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)).hash)
     assert_equal(1143214323.hash, TimeOrDateTime.new(1143214323).hash)
     assert_equal(1143214323.hash, TimeOrDateTime.new('1143214323').hash)
   end
-  
+
   def test_add
     assert_equal(Time.utc(2006, 3, 24, 15, 32, 3), (TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)) + 0).to_orig)
     assert_equal(Time.utc(2006, 3, 24, 15, 32, 3, 721000), (TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 721000)) + 0).to_orig)
@@ -493,12 +493,12 @@ class TCTimeOrDateTime < Minitest::Test
     assert_equal(DateTime.new(2006, 3, 24, 15, 32, 2 + Rational(721, 1000)), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721, 1000))) + (-1)).to_orig)
     assert_equal(1143214322, (TimeOrDateTime.new(1143214323) + (-1)).to_orig)
   end
-  
-  def test_subtract     
+
+  def test_subtract
     assert_equal(Time.utc(2006, 3, 24, 15, 32, 3), (TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)) - 0).to_orig)
     assert_equal(Time.utc(2006, 3, 24, 15, 32, 3, 721000), (TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 721000)) - 0).to_orig)
-    assert_equal(DateTime.new(2006, 3, 24, 15, 32, 3), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)) - 0).to_orig)   
-    assert_equal(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721, 1000)), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721, 1000))) - 0).to_orig)   
+    assert_equal(DateTime.new(2006, 3, 24, 15, 32, 3), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)) - 0).to_orig)
+    assert_equal(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721, 1000)), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721, 1000))) - 0).to_orig)
     assert_equal(1143214323, (TimeOrDateTime.new(1143214323) - 0).to_orig)
     assert_equal(Time.utc(2006, 3, 24, 15, 32, 2), (TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)) - 1).to_orig)
     assert_equal(Time.utc(2006, 3, 24, 15, 32, 2, 721000), (TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 721000)) - 1).to_orig)
@@ -511,7 +511,7 @@ class TCTimeOrDateTime < Minitest::Test
     assert_equal(DateTime.new(2006, 3, 24, 15, 32, 4 + Rational(721, 1000)), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721, 1000))) - (-1)).to_orig)
     assert_equal(1143214324, (TimeOrDateTime.new(1143214323) - (-1)).to_orig)
   end
-  
+
   def test_add_with_convert
     assert_equal(Time.utc(2006, 3, 24, 15, 32, 3), TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)).add_with_convert(0).to_orig)
     assert_equal(Time.utc(2006, 3, 24, 15, 32, 3, 721000), TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 721000)).add_with_convert(0).to_orig)
@@ -528,12 +528,12 @@ class TCTimeOrDateTime < Minitest::Test
     assert_equal(DateTime.new(2006, 3, 24, 15, 32, 2), TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)).add_with_convert(-1).to_orig)
     assert_equal(DateTime.new(2006, 3, 24, 15, 32, 2 + Rational(721, 1000)), TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721, 1000))).add_with_convert(-1).to_orig)
     assert_equal(1143214322, TimeOrDateTime.new(1143214323).add_with_convert(-1).to_orig)
-    
+
     if RubyCoreSupport.time_supports_negative
       assert_equal(Time.utc(1969, 12, 31, 23, 59, 59), TimeOrDateTime.new(Time.utc(1970, 1, 1, 0, 0, 0)).add_with_convert(-1).to_orig)
       assert_equal(-1, TimeOrDateTime.new(0).add_with_convert(-1).to_orig)
       assert_equal(Time.utc(1969, 12, 31, 23, 59, 59, 892000), TimeOrDateTime.new(Time.utc(1970, 1, 1, 0, 0, 0, 892000)).add_with_convert(-1).to_orig)
-      
+
       if RubyCoreSupport.time_supports_64bit
         assert_equal(Time.utc(1901, 12, 13, 20, 45, 51), TimeOrDateTime.new(Time.utc(1901, 12, 13, 20, 45, 52)).add_with_convert(-1).to_orig)
         assert_equal(-2147483649, TimeOrDateTime.new(-2147483648).add_with_convert(-1).to_orig)
@@ -548,38 +548,38 @@ class TCTimeOrDateTime < Minitest::Test
       assert_equal(DateTime.new(1969, 12, 31, 23, 59, 59), TimeOrDateTime.new(0).add_with_convert(-1).to_orig)
       assert_equal(RubyCoreSupport.datetime_new(1969, 12, 31, 23, 59, 59 + Rational(892,1000)), TimeOrDateTime.new(Time.utc(1970, 1, 1, 0, 0, 0, 892000)).add_with_convert(-1).to_orig)
     end
-    
-    if RubyCoreSupport.time_supports_64bit      
+
+    if RubyCoreSupport.time_supports_64bit
       assert_equal(Time.utc(2038, 1, 19, 3, 14, 8), TimeOrDateTime.new(Time.utc(2038, 1, 19, 3, 14, 7)).add_with_convert(1).to_orig)
       assert_equal(2147483648, TimeOrDateTime.new(2147483647).add_with_convert(1).to_orig)
       assert_equal(Time.utc(2038, 1, 19, 3, 14, 8, 892000), TimeOrDateTime.new(Time.utc(2038, 1, 19, 3, 14, 7, 892000)).add_with_convert(1).to_orig)
-    else      
+    else
       assert_equal(DateTime.new(2038, 1, 19, 3, 14, 8), TimeOrDateTime.new(Time.utc(2038, 1, 19, 3, 14, 7)).add_with_convert(1).to_orig)
       assert_equal(DateTime.new(2038, 1, 19, 3, 14, 8), TimeOrDateTime.new(2147483647).add_with_convert(1).to_orig)
       assert_equal(DateTime.new(2038, 1, 19, 3, 14, 8 + Rational(892,1000)), TimeOrDateTime.new(Time.utc(2038, 1, 19, 3, 14, 7, 892000)).add_with_convert(1).to_orig)
-      
+
       assert_equal(Time.utc(2038, 1, 19, 3, 14, 7, 892000), TimeOrDateTime.new(Time.utc(2038, 1, 19, 3, 14, 6, 892000)).add_with_convert(1).to_orig)
-    end    
+    end
   end
-  
+
   def test_wrap_time
     t = TimeOrDateTime.wrap(Time.utc(2006, 3, 24, 15, 32, 3))
     assert_instance_of(TimeOrDateTime, t)
     assert_equal(Time.utc(2006, 3, 24, 15, 32, 3), t.to_orig)
   end
-  
+
   def test_wrap_datetime
     t = TimeOrDateTime.wrap(DateTime.new(2006, 3, 24, 15, 32, 3))
     assert_instance_of(TimeOrDateTime, t)
     assert_equal(DateTime.new(2006, 3, 24, 15, 32, 3), t.to_orig)
   end
-  
+
   def test_wrap_timestamp
     t = TimeOrDateTime.wrap(1143214323)
     assert_instance_of(TimeOrDateTime, t)
     assert_equal(1143214323, t.to_orig)
-  end 
-  
+  end
+
   def test_wrap_timestamp_str
     t = TimeOrDateTime.wrap('1143214323')
     assert_instance_of(TimeOrDateTime, t)
@@ -589,9 +589,9 @@ class TCTimeOrDateTime < Minitest::Test
   def test_wrap_timeordatetime
     t = TimeOrDateTime.new(1143214323)
     t2 = TimeOrDateTime.wrap(t)
-    assert_same(t, t2)    
+    assert_same(t, t2)
   end
-  
+
   def test_wrap_block_time
     assert_equal(Time.utc(2006, 3, 24, 15, 32, 4), TimeOrDateTime.wrap(Time.utc(2006, 3, 24, 15, 32, 3)) {|t|
       assert_instance_of(TimeOrDateTime, t)
@@ -599,7 +599,7 @@ class TCTimeOrDateTime < Minitest::Test
       t + 1
     })
   end
-  
+
   def test_wrap_block_datetime
     assert_equal(DateTime.new(2006, 3, 24, 15, 32, 4), TimeOrDateTime.wrap(DateTime.new(2006, 3, 24, 15, 32, 3)) {|t|
       assert_instance_of(TimeOrDateTime, t)
@@ -607,7 +607,7 @@ class TCTimeOrDateTime < Minitest::Test
       t + 1
     })
   end
-  
+
   def test_wrap_block_timestamp
     assert_equal(1143214324, TimeOrDateTime.wrap(1143214323) {|t|
       assert_instance_of(TimeOrDateTime, t)
@@ -615,7 +615,7 @@ class TCTimeOrDateTime < Minitest::Test
       t + 1
     })
   end
-  
+
   def test_wrap_block_timestamp_str
     assert_equal(1143214324, TimeOrDateTime.wrap('1143214323') {|t|
       assert_instance_of(TimeOrDateTime, t)
@@ -623,15 +623,15 @@ class TCTimeOrDateTime < Minitest::Test
       t + 1
     })
   end
-  
+
   def test_wrap_block_timeordatetime
     t1 = TimeOrDateTime.new(1143214323)
-        
+
     t2 = TimeOrDateTime.wrap(t1) {|t|
       assert_same(t1, t)
-      t + 1           
+      t + 1
     }
-      
+
     assert t2
     assert_instance_of(TimeOrDateTime, t2)
     assert_equal(1143214324, t2.to_orig)

--- a/test/tc_timezone.rb
+++ b/test/tc_timezone.rb
@@ -6,34 +6,34 @@ class TCTimezone < Minitest::Test
 
   class BlockCalled < StandardError
   end
-  
+
   class TestTimezone < Timezone
     def self.new(identifier, period_for_utc = nil, periods_for_local = nil, expected = nil)
       t = super()
       t.send(:setup, identifier, period_for_utc, periods_for_local, expected)
       t
     end
-    
+
     def identifier
       @identifier
     end
-    
+
     def period_for_utc(utc)
       utc = TimeOrDateTime.wrap(utc)
       raise "Unexpected utc #{utc} in period_for_utc" unless @expected.eql?(utc)
       @period_for_utc
     end
-    
-    def periods_for_local(local)            
+
+    def periods_for_local(local)
       local = TimeOrDateTime.wrap(local)
       raise "Unexpected local #{local} in periods_for_local" unless @expected.eql?(local)
-      @periods_for_local.clone        
+      @periods_for_local.clone
     end
-    
+
     def transitions_up_to(utc_to, utc_from = nil)
       raise 'transitions_up_to called'
     end
-    
+
     private
       def setup(identifier, period_for_utc, periods_for_local, expected)
         @identifier = identifier
@@ -42,42 +42,42 @@ class TCTimezone < Minitest::Test
         @expected = TimeOrDateTime.wrap(expected)
       end
   end
-  
+
   class OffsetsUpToTestTimezone < Timezone
     def self.new(identifier, expected_utc_to, expected_utc_from, transitions_up_to)
       t = super()
       t.send(:setup, identifier, expected_utc_to, expected_utc_from, transitions_up_to)
-      t      
+      t
     end
-    
+
     def identifier
       @identifier
     end
-    
+
     def period_for_utc(utc)
       raise 'period_for_utc called'
     end
-    
+
     def periods_for_local(local)
       raise 'periods_for_local called'
     end
-    
+
     def transitions_up_to(utc_to, utc_from = nil)
       utc_to = TimeOrDateTime.wrap(utc_to)
       raise "Unexpected utc_to #{utc_to || 'nil'} in transitions_up_to" unless @expected_utc_to.eql?(utc_to)
-      
+
       utc_from = utc_from ? TimeOrDateTime.wrap(utc_from) : nil
       raise "Unexpected utc_from #{utc_from || 'nil'} in transitions_up_to" unless @expected_utc_from.eql?(utc_from)
-      
+
       if utc_from && utc_to <= utc_from
         raise ArgumentError, 'utc_to must be greater than utc_from'
       end
-      
+
       @transitions_up_to
     end
-    
+
     private
-    
+
     def setup(identifier, expected_utc_to, expected_utc_from, transitions_up_to)
       @identifier = identifier
       @expected_utc_to = TimeOrDateTime.wrap(expected_utc_to)
@@ -85,47 +85,47 @@ class TCTimezone < Minitest::Test
       @transitions_up_to = transitions_up_to
     end
   end
-  
+
   class OffsetsUpToNoTransitionsTestTimezone < Timezone
     def self.new(identifier, expected_utc_to, expected_utc_from, period_for_utc)
       t = super()
       t.send(:setup, identifier, expected_utc_to, expected_utc_from, period_for_utc)
-      t      
+      t
     end
-    
+
     def identifier
       @identifier
     end
-    
+
     def period_for_utc(utc)
       utc = TimeOrDateTime.wrap(utc)
-      
+
       raise "Unexpected utc #{utc} in period_for_utc (should be utc_from)" if @expected_utc_from && !@expected_utc_from.eql?(utc)
       raise "Unexpected utc #{utc} in period_for_utc (should be < utc_to)" if !@expected_utc_from && @expected_utc_to <= utc
-      
+
       @period_for_utc
     end
-    
+
     def periods_for_local(local)
       raise 'periods_for_local called'
     end
-    
+
     def transitions_up_to(utc_to, utc_from = nil)
       utc_to = TimeOrDateTime.wrap(utc_to)
       raise "Unexpected utc_to #{utc_to || 'nil'} in transitions_up_to" unless @expected_utc_to.eql?(utc_to)
-      
+
       utc_from = utc_from ? TimeOrDateTime.wrap(utc_from) : nil
       raise "Unexpected utc_from #{utc_from || 'nil'} in transitions_up_to" unless @expected_utc_from.eql?(utc_from)
-      
+
       if utc_from && utc_to <= utc_from
         raise ArgumentError, 'utc_to must be greater than utc_from'
       end
-      
+
       []
     end
-    
+
     private
-    
+
     def setup(identifier, expected_utc_to, expected_utc_from, period_for_utc)
       @identifier = identifier
       @expected_utc_to = TimeOrDateTime.wrap(expected_utc_to)
@@ -133,33 +133,33 @@ class TCTimezone < Minitest::Test
       @period_for_utc = period_for_utc
     end
   end
-  
+
   class TestTimezoneTransition < TimezoneTransition
     def initialize(offset, previous_offset, at)
       super(offset, previous_offset)
       @at = TimeOrDateTime.wrap(at)
     end
-    
+
     def at
       @at
     end
   end
-  
+
   def setup
     @orig_default_dst = Timezone.default_dst
     @orig_data_source = DataSource.get
     Timezone.send :init_loaded_zones
   end
-  
+
   def teardown
     Timezone.default_dst = @orig_default_dst
     DataSource.set(@orig_data_source)
   end
-  
+
   def test_default_dst_initial_value
     assert_nil(Timezone.default_dst)
   end
-  
+
   def test_set_default_dst
     Timezone.default_dst = true
     assert_equal(true, Timezone.default_dst)
@@ -170,78 +170,78 @@ class TCTimezone < Minitest::Test
     Timezone.default_dst = 0
     assert_equal(true, Timezone.default_dst)
   end
-  
+
   def test_get_valid_1
     tz = Timezone.get('Europe/London')
-    
+
     assert_kind_of(DataTimezone, tz)
     assert_equal('Europe/London', tz.identifier)
   end
-  
+
   def test_get_valid_2
     tz = Timezone.get('UTC')
-    
+
     # ZoneinfoDataSource doesn't return LinkedTimezoneInfo for any timezone.
     if DataSource.get.load_timezone_info('UTC').kind_of?(LinkedTimezoneInfo)
-      assert_kind_of(LinkedTimezone, tz)  
+      assert_kind_of(LinkedTimezone, tz)
     else
       assert_kind_of(DataTimezone, tz)
     end
-    
+
     assert_equal('UTC', tz.identifier)
   end
-  
+
   def test_get_valid_3
     tz = Timezone.get('America/Argentina/Buenos_Aires')
-    
+
     assert_kind_of(DataTimezone, tz)
     assert_equal('America/Argentina/Buenos_Aires', tz.identifier)
   end
-  
+
   def test_get_same_instance
     tz1 = Timezone.get('Europe/London')
     tz2 = Timezone.get('Europe/London')
     assert_same(tz1, tz2)
   end
-  
+
   def test_get_not_exist
     assert_raises(InvalidTimezoneIdentifier) { Timezone.get('Nowhere/Special') }
   end
-  
+
   def test_get_invalid
     assert_raises(InvalidTimezoneIdentifier) { Timezone.get('../Definitions/UTC') }
   end
-  
+
   def test_get_nil
     assert_raises(InvalidTimezoneIdentifier) { Timezone.get(nil) }
   end
-  
-  def test_get_case    
+
+  def test_get_case
     Timezone.get('Europe/Prague')
     assert_raises(InvalidTimezoneIdentifier) { Timezone.get('Europe/prague') }
   end
-  
+
   def test_get_proxy_valid
     proxy = Timezone.get_proxy('Europe/London')
     assert_kind_of(TimezoneProxy, proxy)
     assert_equal('Europe/London', proxy.identifier)
   end
-  
+
   def test_get_proxy_not_exist
     proxy = Timezone.get_proxy('Not/There')
     assert_kind_of(TimezoneProxy, proxy)
     assert_equal('Not/There', proxy.identifier)
   end
-  
+
   def test_get_proxy_invalid
     proxy = Timezone.get_proxy('../Invalid/Identifier')
     assert_kind_of(TimezoneProxy, proxy)
     assert_equal('../Invalid/Identifier', proxy.identifier)
   end
-  
+
   def test_get_tainted_loaded
     Timezone.get('Europe/Andorra')
-  
+
     safe_test do
       identifier = 'Europe/Andorra'.dup.taint
       assert(identifier.tainted?)
@@ -250,16 +250,16 @@ class TCTimezone < Minitest::Test
       assert(identifier.tainted?)
     end
   end
-  
+
   def test_get_tainted_and_frozen_loaded
     Timezone.get('Europe/Andorra')
-  
+
     safe_test do
       tz = Timezone.get('Europe/Andorra'.dup.taint.freeze)
       assert_equal('Europe/Andorra', tz.identifier)
     end
   end
-  
+
   def test_get_tainted_not_previously_loaded
     safe_test do
       identifier = 'Europe/Andorra'.dup.taint
@@ -269,17 +269,17 @@ class TCTimezone < Minitest::Test
       assert(identifier.tainted?)
     end
   end
-  
+
   def test_get_tainted_and_frozen_not_previously_loaded
     safe_test do
       tz = Timezone.get('Europe/Amsterdam'.dup.taint.freeze)
       assert_equal('Europe/Amsterdam', tz.identifier)
     end
   end
-  
+
   def test_new_no_args
     tz = Timezone.new
-    
+
     assert_raises(UnknownTimezone) { tz.identifier }
     assert_raises(UnknownTimezone) { tz.friendly_identifier }
     assert_raises(UnknownTimezone) { tz.utc_to_local(DateTime.new(2006,1,1,1,0,0)) }
@@ -293,10 +293,10 @@ class TCTimezone < Minitest::Test
     assert_raises(UnknownTimezone) { tz.canonical_identifier }
     assert_raises(UnknownTimezone) { tz.canonical_zone }
   end
-  
+
   def test_new_nil
     tz = Timezone.new(nil)
-    
+
     assert_raises(UnknownTimezone) { tz.identifier }
     assert_raises(UnknownTimezone) { tz.friendly_identifier }
     assert_raises(UnknownTimezone) { tz.utc_to_local(DateTime.new(2006,1,1,1,0,0)) }
@@ -310,49 +310,49 @@ class TCTimezone < Minitest::Test
     assert_raises(UnknownTimezone) { tz.canonical_identifier }
     assert_raises(UnknownTimezone) { tz.canonical_zone }
   end
-  
+
   def test_new_arg
     tz = Timezone.new('Europe/London')
-    assert_same(Timezone.get('Europe/London'), tz)    
+    assert_same(Timezone.get('Europe/London'), tz)
   end
-  
-  def test_new_arg_not_exist    
+
+  def test_new_arg_not_exist
     assert_raises(InvalidTimezoneIdentifier) { Timezone.new('Nowhere/Special') }
-  end 
-  
+  end
+
   def test_all
     all = Timezone.all
     expected = DataSource.get.timezone_identifiers.collect {|identifier| Timezone.get_proxy(identifier)}
     assert_equal(expected, all)
   end
-  
+
   def test_all_identifiers
     all = Timezone.all_identifiers
     assert_equal(DataSource.get.timezone_identifiers, all)
   end
-  
+
   def test_all_data_zones
     all_data = Timezone.all_data_zones
     expected = DataSource.get.data_timezone_identifiers.collect {|identifier| Timezone.get_proxy(identifier)}
     assert_equal(expected, all_data)
   end
-  
+
   def test_all_data_zone_identifiers
     all_data = Timezone.all_data_zone_identifiers
     assert_equal(DataSource.get.data_timezone_identifiers, all_data)
   end
-  
+
   def test_all_linked_zones
     all_linked = Timezone.all_linked_zones
     expected = DataSource.get.linked_timezone_identifiers.collect {|identifier| Timezone.get_proxy(identifier)}
     assert_equal(expected, all_linked)
   end
-  
+
   def test_all_linked_zone_identifiers
     all_linked = Timezone.all_linked_zone_identifiers
     assert_equal(DataSource.get.linked_timezone_identifiers, all_linked)
   end
-  
+
   def test_all_country_zones
     # Probably should relax this test - just need all the zones, don't care
     # about order.
@@ -360,19 +360,19 @@ class TCTimezone < Minitest::Test
       result += country.zones
     }
     expected.uniq!
-    
+
     all_country_zones = Timezone.all_country_zones
     assert_equal(expected, all_country_zones)
-    
+
     all_country_zone_identifiers = Timezone.all_country_zone_identifiers
     assert_equal(all_country_zone_identifiers.length, all_country_zones.length)
-    
+
     all_country_zones.each {|zone|
       assert_kind_of(TimezoneProxy, zone)
       assert(all_country_zone_identifiers.include?(zone.identifier))
-    }            
+    }
   end
-  
+
   def test_all_country_zone_identifiers
     # Probably should relax this test - just need all the zones, don't care
     # about order.
@@ -380,41 +380,41 @@ class TCTimezone < Minitest::Test
       result += country.zone_identifiers
     }
     expected.uniq!
-        
+
     assert_equal(expected, Timezone.all_country_zone_identifiers)
   end
-  
-  def test_us_zones   
+
+  def test_us_zones
     # Probably should relax this test - just need all the zones, don't care
     # about order.
     us_zones = Timezone.us_zones
     assert_equal(Country.get('US').zones.uniq, us_zones)
-    
+
     us_zone_identifiers = Timezone.us_zone_identifiers
     assert_equal(us_zone_identifiers.length, us_zones.length)
-    
+
     us_zones.each {|zone|
       assert_kind_of(TimezoneProxy, zone)
       assert(us_zone_identifiers.include?(zone.identifier))
     }
   end
-  
+
   def test_us_zone_identifiers
     # Probably should relax this test - just need all the zones, don't care
-    # about order.        
+    # about order.
     assert_equal(Country.get('US').zone_identifiers.uniq, Timezone.us_zone_identifiers)
-  end    
-  
+  end
+
   def test_identifier
-    assert_raises(UnknownTimezone) { Timezone.new.identifier }    
+    assert_raises(UnknownTimezone) { Timezone.new.identifier }
     assert_equal('Europe/Paris', TestTimezone.new('Europe/Paris').identifier)
   end
-  
+
   def test_name
-    assert_raises(UnknownTimezone) { Timezone.new.name }    
-    assert_equal('Europe/Paris', TestTimezone.new('Europe/Paris').name)    
+    assert_raises(UnknownTimezone) { Timezone.new.name }
+    assert_equal('Europe/Paris', TestTimezone.new('Europe/Paris').name)
   end
-  
+
   def test_friendly_identifier
     assert_equal('Paris', TestTimezone.new('Europe/Paris').friendly_identifier(true))
     assert_equal('Europe - Paris', TestTimezone.new('Europe/Paris').friendly_identifier(false))
@@ -435,7 +435,7 @@ class TCTimezone < Minitest::Test
     assert_equal('UTC', TestTimezone.new('UTC').friendly_identifier(false))
     assert_equal('UTC', TestTimezone.new('UTC').friendly_identifier)
   end
-  
+
   def test_to_s
     assert_equal('Europe - Paris', TestTimezone.new('Europe/Paris').to_s)
     assert_equal('America - Knox, Indiana', TestTimezone.new('America/Indiana/Knox').to_s)
@@ -443,8 +443,8 @@ class TCTimezone < Minitest::Test
     assert_equal('Antarctica - McMurdo', TestTimezone.new('Antarctica/McMurdo').to_s)
     assert_equal('Etc - GMT+1', TestTimezone.new('Etc/GMT+1').to_s)
     assert_equal('UTC', TestTimezone.new('UTC').to_s)
-  end    
-    
+  end
+
   def test_period_for_local
     dt = DateTime.new(2005,2,18,16,24,23)
     dt2 = DateTime.new(2005,2,18,16,24,23).new_offset(Rational(5,24))
@@ -453,14 +453,14 @@ class TCTimezone < Minitest::Test
     t2 = Time.local(2005,2,18,16,24,23)
     t3 = Time.utc(2005,2,18,16,24,23,789000)
     ts = t.to_i
-    
+
     o1 = TimezoneOffset.new(0, 0, :GMT)
     o2 = TimezoneOffset.new(0, 3600, :BST)
-        
+
     period = TimezonePeriod.new(
       TestTimezoneTransition.new(o1, o2, 1099184400),
       TestTimezoneTransition.new(o2, o1, 1111885200))
-    
+
     dt_period = TestTimezone.new('Europe/London', nil, [period], dt).period_for_local(dt)
     dt2_period = TestTimezone.new('Europe/London', nil, [period], dt2).period_for_local(dt2)
     dt3_period = TestTimezone.new('Europe/London', nil, [period], dt3).period_for_local(dt3)
@@ -468,7 +468,7 @@ class TCTimezone < Minitest::Test
     t2_period = TestTimezone.new('Europe/London', nil, [period], t2).period_for_local(t2)
     t3_period = TestTimezone.new('Europe/London', nil, [period], t3).period_for_local(t3)
     ts_period = TestTimezone.new('Europe/London', nil, [period], ts).period_for_local(ts)
-    
+
     assert_equal(period, dt_period)
     assert_equal(period, dt2_period)
     assert_equal(period, dt3_period)
@@ -477,125 +477,125 @@ class TCTimezone < Minitest::Test
     assert_equal(period, t3_period)
     assert_equal(period, ts_period)
   end
-  
+
   def test_period_for_local_invalid
     dt = DateTime.new(2004,4,4,2,30,0)
     tz = TestTimezone.new('America/New_York', nil, [], dt)
-    
+
     assert_raises(PeriodNotFound) do
       tz.period_for_local(dt)
     end
   end
-  
-  def test_period_for_local_ambiguous    
+
+  def test_period_for_local_ambiguous
     o1 = TimezoneOffset.new(-18000, 0, :EST)
     o2 = TimezoneOffset.new(-18000, 3600, :EDT)
-    
+
     t1 = TestTimezoneTransition.new(o2, o1, 1081062000)
     t2 = TestTimezoneTransition.new(o1, o2, 1099202400)
     t3 = TestTimezoneTransition.new(o2, o1, 1112511600)
-    
+
     p1 = TimezonePeriod.new(t1, t2)
     p2 = TimezonePeriod.new(t2, t3)
-    
+
     dt = DateTime.new(2004,10,31,1,0,0)
     dt2 = DateTime.new(2004,10,31,1,0,Rational(555,1000))
     t = Time.utc(2004,10,31,1,30,0)
     t2 = Time.utc(2004,10,31,1,30,0,555000)
     i = Time.utc(2004,10,31,1,59,59).to_i
-    
+
     dt_tz = TestTimezone.new('America/New_York', nil, [p1, p2], dt)
     dt2_tz = TestTimezone.new('America/New_York', nil, [p1, p2], dt2)
     t_tz = TestTimezone.new('America/New_York', nil, [p1, p2], t)
     t2_tz = TestTimezone.new('America/New_York', nil, [p1, p2], t2)
     i_tz = TestTimezone.new('America/New_York', nil, [p1, p2], i)
-        
+
     assert_raises(AmbiguousTime) { dt_tz.period_for_local(dt) }
     assert_raises(AmbiguousTime) { dt2_tz.period_for_local(dt2) }
     assert_raises(AmbiguousTime) { t_tz.period_for_local(t) }
     assert_raises(AmbiguousTime) { t2_tz.period_for_local(t2) }
     assert_raises(AmbiguousTime) { i_tz.period_for_local(i) }
   end
-  
+
   def test_period_for_local_not_found
     dt = DateTime.new(2004,4,4,2,0,0)
     dt2 = DateTime.new(2004,4,4,2,0,Rational(987,1000))
     t = Time.utc(2004,4,4,2,30,0)
     t2 = Time.utc(2004,4,4,2,30,0,987000)
     i = Time.utc(2004,4,4,2,59,59).to_i
-    
+
     dt_tz = TestTimezone.new('America/New_York', nil, [], dt)
     dt2_tz = TestTimezone.new('America/New_York', nil, [], dt2)
     t_tz = TestTimezone.new('America/New_York', nil, [], t)
     t2_tz = TestTimezone.new('America/New_York', nil, [], t2)
-    i_tz = TestTimezone.new('America/New_York', nil, [], i)    
-        
+    i_tz = TestTimezone.new('America/New_York', nil, [], i)
+
     assert_raises(PeriodNotFound) { dt_tz.period_for_local(dt) }
     assert_raises(PeriodNotFound) { dt2_tz.period_for_local(dt2) }
     assert_raises(PeriodNotFound) { t_tz.period_for_local(t) }
     assert_raises(PeriodNotFound) { t2_tz.period_for_local(t2) }
     assert_raises(PeriodNotFound) { i_tz.period_for_local(i) }
   end
-  
+
   def test_period_for_local_default_dst_set_true
     Timezone.default_dst = true
-    
+
     o1 = TimezoneOffset.new(-18000, 0, :EST)
     o2 = TimezoneOffset.new(-18000, 3600, :EDT)
-    
+
     t1 = TestTimezoneTransition.new(o2, o1, 1081062000)
     t2 = TestTimezoneTransition.new(o1, o2, 1099202400)
     t3 = TestTimezoneTransition.new(o2, o1, 1112511600)
-    
+
     p1 = TimezonePeriod.new(t1, t2)
     p2 = TimezonePeriod.new(t2, t3)
-    
+
     dt = DateTime.new(2004,10,31,1,30,0)
-    
+
     tz = TestTimezone.new('America/New_York', nil, [p1, p2], dt)
-    
+
     assert_equal(p1, tz.period_for_local(dt))
     assert_equal(p1, tz.period_for_local(dt, true))
     assert_equal(p2, tz.period_for_local(dt, false))
     assert_raises(AmbiguousTime) { tz.period_for_local(dt, nil) }
   end
-  
+
   def test_period_for_local_default_dst_set_false
     Timezone.default_dst = false
-    
+
     o1 = TimezoneOffset.new(-18000, 0, :EST)
     o2 = TimezoneOffset.new(-18000, 3600, :EDT)
-    
+
     t1 = TestTimezoneTransition.new(o2, o1, 1081062000)
     t2 = TestTimezoneTransition.new(o1, o2, 1099202400)
     t3 = TestTimezoneTransition.new(o2, o1, 1112511600)
-    
+
     p1 = TimezonePeriod.new(t1, t2)
     p2 = TimezonePeriod.new(t2, t3)
-    
+
     dt = DateTime.new(2004,10,31,1,30,0)
-    
+
     tz = TestTimezone.new('America/New_York', nil, [p1, p2], dt)
-    
+
     assert_equal(p2, tz.period_for_local(dt))
     assert_equal(p1, tz.period_for_local(dt, true))
     assert_equal(p2, tz.period_for_local(dt, false))
     assert_raises(AmbiguousTime) { tz.period_for_local(dt, nil) }
   end
-  
+
   def test_period_for_local_dst_flag_resolved
     o1 = TimezoneOffset.new(-18000, 0, :EST)
     o2 = TimezoneOffset.new(-18000, 3600, :EDT)
-    
+
     t1 = TestTimezoneTransition.new(o2, o1, 1081062000)
     t2 = TestTimezoneTransition.new(o1, o2, 1099202400)
     t3 = TestTimezoneTransition.new(o2, o1, 1112511600)
-    
+
     p1 = TimezonePeriod.new(t1, t2)
     p2 = TimezonePeriod.new(t2, t3)
-    
+
     dt = DateTime.new(2004,10,31,1,30,0)
-    
+
     tz = TestTimezone.new('America/New_York', nil, [p1, p2], dt)
 
     assert_equal(p1, tz.period_for_local(dt, true))
@@ -603,105 +603,105 @@ class TCTimezone < Minitest::Test
     assert_equal(p1, tz.period_for_local(dt, true) {|periods| raise BlockCalled, 'should not be called' })
     assert_equal(p2, tz.period_for_local(dt, false) {|periods| raise BlockCalled, 'should not be called' })
   end
-  
+
   def test_period_for_local_dst_block_called
     o1 = TimezoneOffset.new(-18000, 0, :EST)
     o2 = TimezoneOffset.new(-18000, 3600, :EDT)
-    
+
     t1 = TestTimezoneTransition.new(o2, o1, 1081062000)
     t2 = TestTimezoneTransition.new(o1, o2, 1099202400)
     t3 = TestTimezoneTransition.new(o2, o1, 1112511600)
-    
+
     p1 = TimezonePeriod.new(t1, t2)
     p2 = TimezonePeriod.new(t2, t3)
-    
+
     dt = DateTime.new(2004,10,31,1,30,0)
-    
+
     tz = TestTimezone.new('America/New_York', nil, [p1, p2], dt)
-    
+
     assert_raises(BlockCalled) {
-      tz.period_for_local(dt) {|periods|        
+      tz.period_for_local(dt) {|periods|
         assert_equal([p1, p2], periods)
-        
+
         # raise exception to test that the block was called
         raise BlockCalled, 'should be raised'
       }
     }
-    
+
     assert_equal(p1, tz.period_for_local(dt) {|periods| periods.first})
     assert_equal(p2, tz.period_for_local(dt) {|periods| periods.last})
     assert_equal(p1, tz.period_for_local(dt) {|periods| [periods.first]})
     assert_equal(p2, tz.period_for_local(dt) {|periods| [periods.last]})
   end
-  
+
   def test_period_for_local_dst_cannot_resolve
     # At midnight local time on Aug 5 1915 in Warsaw, the clocks were put back
     # 24 minutes and both periods were non-DST. Hence the block should be
     # called regardless of the value of the Boolean dst parameter.
-    
+
     o0 = TimezoneOffset.new(5040, 0, :LMT)
     o1 = TimezoneOffset.new(5040, 0, :WMT)
     o2 = TimezoneOffset.new(3600, 0, :CET)
     o3 = TimezoneOffset.new(3600, 3600, :CEST)
-    
+
     t1 = TestTimezoneTransition.new(o1, o0, DateTime.new(1879, 12, 31, 22, 36, 0))
     t2 = TestTimezoneTransition.new(o2, o1, DateTime.new(1915,  8,  4, 22, 36, 0))
     t3 = TestTimezoneTransition.new(o3, o2, DateTime.new(1916,  4, 30, 22,  0, 0))
-    
+
     p1 = TimezonePeriod.new(t1, t2)
     p2 = TimezonePeriod.new(t2, t3)
-    
+
     dt = DateTime.new(1915,8,4,23,40,0)
-    
+
     tz = TestTimezone.new('Europe/Warsaw', nil, [p1, p2], dt)
-        
+
     assert_raises(BlockCalled) {
       tz.period_for_local(dt, true) {|periods|
-        assert_equal([p1, p2], periods)        
+        assert_equal([p1, p2], periods)
         raise BlockCalled, 'should be raised'
       }
     }
-    
+
     assert_raises(BlockCalled) {
       tz.period_for_local(dt, false) {|periods|
         assert_equal([p1, p2], periods)
         raise BlockCalled, 'should be raised'
       }
-    }    
+    }
   end
-  
+
   def test_period_for_local_block_ambiguous
     o1 = TimezoneOffset.new(-18000, 0, :EST)
     o2 = TimezoneOffset.new(-18000, 3600, :EDT)
-    
+
     t1 = TestTimezoneTransition.new(o2, o1, 1081062000)
     t2 = TestTimezoneTransition.new(o1, o2, 1099202400)
     t3 = TestTimezoneTransition.new(o2, o1, 1112511600)
-    
+
     p1 = TimezonePeriod.new(t1, t2)
     p2 = TimezonePeriod.new(t2, t3)
-    
+
     dt = DateTime.new(2004,10,31,1,30,0)
-    
+
     tz = TestTimezone.new('America/New_York', nil, [p1, p2], dt)
-        
+
     assert_raises(AmbiguousTime) do
       tz.period_for_local(dt) {|periods| nil}
     end
-    
+
     assert_raises(AmbiguousTime) do
       tz.period_for_local(dt) {|periods| periods}
     end
-    
+
     assert_raises(AmbiguousTime) do
       tz.period_for_local(dt) {|periods| []}
     end
-    
+
     assert_raises(AmbiguousTime) do
       tz.period_for_local(dt) {|periods| raise AmbiguousTime, 'Ambiguous time'}
     end
   end
-   
+
   def test_utc_to_local
     dt = DateTime.new(2005,6,18,16,24,23)
     dt2 = DateTime.new(2005,6,18,16,24,23).new_offset(Rational(5,24))
@@ -712,14 +712,14 @@ class TCTimezone < Minitest::Test
     tu = Time.utc(2005,6,18,16,24,23,567000)
     tu2 = Time.local(2005,6,18,16,24,23,567000)
     ts = t.to_i
-    
+
     o1 = TimezoneOffset.new(0, 0, :GMT)
     o2 = TimezoneOffset.new(0, 3600, :BST)
-        
+
     period = TimezonePeriod.new(
       TestTimezoneTransition.new(o2, o1, 1111885200),
       TestTimezoneTransition.new(o1, o2, 1130634000))
-        
+
     assert_equal(DateTime.new(2005,6,18,17,24,23), TestTimezone.new('Europe/London', period, [], dt).utc_to_local(dt))
     assert_equal(DateTime.new(2005,6,18,17,24,23), TestTimezone.new('Europe/London', period, [], dt2).utc_to_local(dt2))
     assert_equal(DateTime.new(2005,6,18,17,24,23 + Rational(567,1000)), TestTimezone.new('Europe/London', period, [], dtu).utc_to_local(dtu))
@@ -730,7 +730,7 @@ class TCTimezone < Minitest::Test
     assert_equal(Time.utc(2005,6,18,17,24,23,567000), TestTimezone.new('Europe/London', period, [], tu2).utc_to_local(tu2))
     assert_equal(Time.utc(2005,6,18,17,24,23).to_i, TestTimezone.new('Europe/London', period, [], ts).utc_to_local(ts))
   end
-  
+
   def test_utc_to_local_offset
     dt = DateTime.new(2005,6,18,16,24,23)
     dt2 = DateTime.new(2005,6,18,16,24,23).new_offset(Rational(5,24))
@@ -740,18 +740,18 @@ class TCTimezone < Minitest::Test
     t2 = Time.local(2005,6,18,16,24,23)
     tu = Time.utc(2005,6,18,16,24,23,567000)
     tu2 = Time.local(2005,6,18,16,24,23,567000)
-    
+
     o1 = TimezoneOffset.new(0, 0, :GMT)
     o2 = TimezoneOffset.new(0, 3600, :BST)
-        
+
     period = TimezonePeriod.new(
       TestTimezoneTransition.new(o2, o1, 1111885200),
       TestTimezoneTransition.new(o1, o2, 1130634000))
-    
+
     assert_equal(0, TestTimezone.new('Europe/London', period, [], dt).utc_to_local(dt).offset)
     assert_equal(0, TestTimezone.new('Europe/London', period, [], dt2).utc_to_local(dt2).offset)
     assert_equal(0, TestTimezone.new('Europe/London', period, [], dtu).utc_to_local(dtu).offset)
-    assert_equal(0, TestTimezone.new('Europe/London', period, [], dtu2).utc_to_local(dtu2).offset)    
+    assert_equal(0, TestTimezone.new('Europe/London', period, [], dtu2).utc_to_local(dtu2).offset)
     assert_equal(0, TestTimezone.new('Europe/London', period, [], t).utc_to_local(t).utc_offset)
     assert(TestTimezone.new('Europe/London', period, [], t).utc_to_local(t).utc?)
     assert_equal(0, TestTimezone.new('Europe/London', period, [], t2).utc_to_local(t2).utc_offset)
@@ -761,7 +761,7 @@ class TCTimezone < Minitest::Test
     assert_equal(0, TestTimezone.new('Europe/London', period, [], tu2).utc_to_local(tu2).utc_offset)
     assert(TestTimezone.new('Europe/London', period, [], tu2).utc_to_local(tu2).utc?)
   end
-  
+
   def test_local_to_utc
     dt = DateTime.new(2005,6,18,16,24,23)
     dt2 = DateTime.new(2005,6,18,16,24,23).new_offset(Rational(5, 24))
@@ -772,14 +772,14 @@ class TCTimezone < Minitest::Test
     tu = Time.utc(2005,6,18,16,24,23,567000)
     tu2 = Time.local(2005,6,18,16,24,23,567000)
     ts = t.to_i
-        
+
     o1 = TimezoneOffset.new(0, 0, :GMT)
     o2 = TimezoneOffset.new(0, 3600, :BST)
-        
+
     period = TimezonePeriod.new(
       TestTimezoneTransition.new(o2, o1, 1111885200),
       TestTimezoneTransition.new(o1, o2, 1130634000))
-    
+
     assert_equal(DateTime.new(2005,6,18,15,24,23), TestTimezone.new('Europe/London', nil, [period], dt).local_to_utc(dt))
     assert_equal(DateTime.new(2005,6,18,15,24,23), TestTimezone.new('Europe/London', nil, [period], dt2).local_to_utc(dt2))
     assert_equal(DateTime.new(2005,6,18,15,24,23 + Rational(567,1000)), TestTimezone.new('Europe/London', nil, [period], dtu).local_to_utc(dtu))
@@ -790,7 +790,7 @@ class TCTimezone < Minitest::Test
     assert_equal(Time.utc(2005,6,18,15,24,23,567000), TestTimezone.new('Europe/London', nil, [period], tu2).local_to_utc(tu2))
     assert_equal(Time.utc(2005,6,18,15,24,23).to_i, TestTimezone.new('Europe/London', nil, [period], ts).local_to_utc(ts))
   end
-  
+
   def test_local_to_utc_offset
     dt = DateTime.new(2005,6,18,16,24,23)
     dt2 = DateTime.new(2005,6,18,16,24,23).new_offset(Rational(5, 24))
@@ -800,14 +800,14 @@ class TCTimezone < Minitest::Test
     t2 = Time.local(2005,6,18,16,24,23)
     tu = Time.utc(2005,6,18,16,24,23,567000)
     tu2 = Time.local(2005,6,18,16,24,23,567000)
-    
+
     o1 = TimezoneOffset.new(0, 0, :GMT)
     o2 = TimezoneOffset.new(0, 3600, :BST)
-        
+
     period = TimezonePeriod.new(
       TestTimezoneTransition.new(o2, o1, 1111885200),
       TestTimezoneTransition.new(o1, o2, 1130634000))
-    
+
     assert_equal(0, TestTimezone.new('Europe/London', nil, [period], dt).local_to_utc(dt).offset)
     assert_equal(0, TestTimezone.new('Europe/London', nil, [period], dt2).local_to_utc(dt2).offset)
     assert_equal(0, TestTimezone.new('Europe/London', nil, [period], dtu).local_to_utc(dtu).offset)
@@ -821,58 +821,58 @@ class TCTimezone < Minitest::Test
     assert_equal(0, TestTimezone.new('Europe/London', nil, [period], tu2).local_to_utc(tu2).utc_offset)
     assert(TestTimezone.new('Europe/London', nil, [period], tu2).local_to_utc(tu2).utc?)
   end
-  
+
   def test_local_to_utc_utc_local_returns_utc
     # Check that UTC time instances are always returned even if the system
     # is using UTC as the time zone.
-    
+
     # Note that this will only test will only work correctly on platforms where
     # setting the TZ environment variable has an effect. If setting TZ has no
     # effect, then this test will still pass.
-    
+
     old_tz = ENV['TZ']
     begin
       ENV['TZ'] = 'UTC'
-      
+
       tz = Timezone.get('America/New_York')
-      
+
       t = tz.local_to_utc(Time.local(2014, 1, 11, 17, 18, 41))
-      assert_equal(Time.utc(2014, 1, 11, 22, 18, 41), t)      
+      assert_equal(Time.utc(2014, 1, 11, 22, 18, 41), t)
       assert(t.utc?)
     ensure
       ENV['TZ'] = old_tz
     end
   end
-  
+
   def test_local_to_utc_invalid
     dt = DateTime.new(2004,4,4,2,30,0)
-    tz = TestTimezone.new('America/New_York', nil, [], dt)        
+    tz = TestTimezone.new('America/New_York', nil, [], dt)
     assert_raises(PeriodNotFound) { tz.local_to_utc(dt) }
-    
+
     t = Time.utc(2004,4,4,2,30,0)
-    tz = TestTimezone.new('America/New_York', nil, [], t)        
+    tz = TestTimezone.new('America/New_York', nil, [], t)
     assert_raises(PeriodNotFound) { tz.local_to_utc(t) }
-    
+
     i = Time.utc(2004,4,4,2,30,0).to_i
-    tz = TestTimezone.new('America/New_York', nil, [], i)        
-    assert_raises(PeriodNotFound) { tz.local_to_utc(i) }    
+    tz = TestTimezone.new('America/New_York', nil, [], i)
+    assert_raises(PeriodNotFound) { tz.local_to_utc(i) }
   end
-  
+
   def test_local_to_utc_ambiguous
     o1 = TimezoneOffset.new(-18000, 0, :EST)
     o2 = TimezoneOffset.new(-18000, 3600, :EDT)
-    
+
     t1 = TestTimezoneTransition.new(o2, o1, 1081062000)
     t2 = TestTimezoneTransition.new(o1, o2, 1099202400)
     t3 = TestTimezoneTransition.new(o2, o1, 1112511600)
-    
+
     p1 = TimezonePeriod.new(t1, t2)
     p2 = TimezonePeriod.new(t2, t3)
-    
-    dt = DateTime.new(2004,10,31,1,30,0)    
+
+    dt = DateTime.new(2004,10,31,1,30,0)
     tz = TestTimezone.new('America/New_York', nil, [p1, p2], dt)
     assert_raises(AmbiguousTime) { tz.local_to_utc(dt) }
-    
+
     t = Time.utc(2004,10,31,1,30,0)
     tz = TestTimezone.new('America/New_York', nil, [p1, p2], t)
     assert_raises(AmbiguousTime) { tz.local_to_utc(t) }
@@ -880,121 +880,121 @@ class TCTimezone < Minitest::Test
     i = Time.utc(2004,10,31,1,30,0).to_i
     tz = TestTimezone.new('America/New_York', nil, [p1, p2], i)
     assert_raises(AmbiguousTime) { tz.local_to_utc(i) }
-    
+
     f = Time.utc(2004,10,31,1,30,0,501).to_i
     tz = TestTimezone.new('America/New_York', nil, [p1, p2], f)
-    assert_raises(AmbiguousTime) { tz.local_to_utc(f) }  
+    assert_raises(AmbiguousTime) { tz.local_to_utc(f) }
   end
-  
+
   def test_local_to_utc_not_found
     dt = DateTime.new(2004,4,4,2,0,0)
     t = Time.utc(2004,4,4,2,30,0)
     i = Time.utc(2004,4,4,2,59,59).to_i
-    
+
     dt_tz = TestTimezone.new('America/New_York', nil, [], dt)
     t_tz = TestTimezone.new('America/New_York', nil, [], t)
     i_tz = TestTimezone.new('America/New_York', nil, [], i)
-        
+
     assert_raises(PeriodNotFound) { dt_tz.local_to_utc(dt) }
     assert_raises(PeriodNotFound) { t_tz.local_to_utc(t) }
     assert_raises(PeriodNotFound) { i_tz.local_to_utc(i) }
   end
-  
+
   def test_local_to_utc_default_dst_set_true
     Timezone.default_dst = true
-  
+
     o1 = TimezoneOffset.new(-18000, 0, :EST)
     o2 = TimezoneOffset.new(-18000, 3600, :EDT)
-    
+
     t1 = TestTimezoneTransition.new(o2, o1, 1081062000)
     t2 = TestTimezoneTransition.new(o1, o2, 1099202400)
     t3 = TestTimezoneTransition.new(o2, o1, 1112511600)
-    
+
     p1 = TimezonePeriod.new(t1, t2)
     p2 = TimezonePeriod.new(t2, t3)
-    
-    dt = DateTime.new(2004,10,31,1,30,0)    
+
+    dt = DateTime.new(2004,10,31,1,30,0)
     tz = TestTimezone.new('America/New_York', nil, [p1, p2], dt)
-    
-    assert_equal(DateTime.new(2004,10,31,5,30,0), tz.local_to_utc(dt))    
+
+    assert_equal(DateTime.new(2004,10,31,5,30,0), tz.local_to_utc(dt))
     assert_equal(DateTime.new(2004,10,31,5,30,0), tz.local_to_utc(dt, true))
     assert_equal(DateTime.new(2004,10,31,6,30,0), tz.local_to_utc(dt, false))
     assert_raises(AmbiguousTime) { tz.local_to_utc(dt, nil) }
     assert_equal(DateTime.new(2004,10,31,5,30,0), tz.local_to_utc(dt) {|periods| raise BlockCalled, 'should not be called' })
   end
-  
+
   def test_local_to_utc_default_dst_set_false
     Timezone.default_dst = false
-  
+
     o1 = TimezoneOffset.new(-18000, 0, :EST)
     o2 = TimezoneOffset.new(-18000, 3600, :EDT)
-    
+
     t1 = TestTimezoneTransition.new(o2, o1, 1081062000)
     t2 = TestTimezoneTransition.new(o1, o2, 1099202400)
     t3 = TestTimezoneTransition.new(o2, o1, 1112511600)
-    
+
     p1 = TimezonePeriod.new(t1, t2)
     p2 = TimezonePeriod.new(t2, t3)
-    
-    dt = DateTime.new(2004,10,31,1,30,0)    
+
+    dt = DateTime.new(2004,10,31,1,30,0)
     tz = TestTimezone.new('America/New_York', nil, [p1, p2], dt)
-        
+
     assert_equal(DateTime.new(2004,10,31,6,30,0), tz.local_to_utc(dt))
     assert_equal(DateTime.new(2004,10,31,6,30,0), tz.local_to_utc(dt, false))
     assert_equal(DateTime.new(2004,10,31,5,30,0), tz.local_to_utc(dt, true))
     assert_raises(AmbiguousTime) { tz.local_to_utc(dt, nil) }
     assert_equal(DateTime.new(2004,10,31,6,30,0), tz.local_to_utc(dt) {|periods| raise BlockCalled, 'should not be called' })
   end
-  
+
   def test_local_to_utc_dst_flag_resolved
     o1 = TimezoneOffset.new(-18000, 0, :EST)
     o2 = TimezoneOffset.new(-18000, 3600, :EDT)
-    
+
     t1 = TestTimezoneTransition.new(o2, o1, 1081062000)
     t2 = TestTimezoneTransition.new(o1, o2, 1099202400)
     t3 = TestTimezoneTransition.new(o2, o1, 1112511600)
-    
+
     p1 = TimezonePeriod.new(t1, t2)
     p2 = TimezonePeriod.new(t2, t3)
-    
-    dt = DateTime.new(2004,10,31,1,30,0)    
+
+    dt = DateTime.new(2004,10,31,1,30,0)
     tz = TestTimezone.new('America/New_York', nil, [p1, p2], dt)
-        
+
     assert_equal(DateTime.new(2004,10,31,5,30,0), tz.local_to_utc(dt, true))
     assert_equal(DateTime.new(2004,10,31,6,30,0), tz.local_to_utc(dt, false))
     assert_equal(DateTime.new(2004,10,31,5,30,0), tz.local_to_utc(dt, true) {|periods| raise BlockCalled, 'should not be called' })
     assert_equal(DateTime.new(2004,10,31,6,30,0), tz.local_to_utc(dt, false) {|periods| raise BlockCalled, 'should not be called' })
   end
-  
+
   def test_local_to_utc_dst_block_called
     o1 = TimezoneOffset.new(-18000, 0, :EST)
     o2 = TimezoneOffset.new(-18000, 3600, :EDT)
-    
+
     t1 = TestTimezoneTransition.new(o2, o1, 1081062000)
     t2 = TestTimezoneTransition.new(o1, o2, 1099202400)
     t3 = TestTimezoneTransition.new(o2, o1, 1112511600)
-    
+
     p1 = TimezonePeriod.new(t1, t2)
     p2 = TimezonePeriod.new(t2, t3)
-    
-    dt = DateTime.new(2004,10,31,1,30,0)    
+
+    dt = DateTime.new(2004,10,31,1,30,0)
     tz = TestTimezone.new('America/New_York', nil, [p1, p2], dt)
-    
+
     assert_raises(BlockCalled) {
       tz.local_to_utc(dt) {|periods|
-        assert_equal([p1, p2], periods)                
-        
+        assert_equal([p1, p2], periods)
+
         # raise exception to test that the block was called
         raise BlockCalled, 'should be raised'
       }
     }
-    
+
     assert_equal(DateTime.new(2004,10,31,5,30,0), tz.local_to_utc(dt) {|periods| periods.first})
     assert_equal(DateTime.new(2004,10,31,6,30,0), tz.local_to_utc(dt) {|periods| periods.last})
     assert_equal(DateTime.new(2004,10,31,5,30,0), tz.local_to_utc(dt) {|periods| [periods.first]})
     assert_equal(DateTime.new(2004,10,31,6,30,0), tz.local_to_utc(dt) {|periods| [periods.last]})
   end
-  
+
   def test_local_to_utc_dst_cannot_resolve
     # At midnight local time on Aug 5 1915 in Warsaw, the clocks were put back
     # 24 minutes and both periods were non-DST. Hence the block should be
@@ -1004,148 +1004,148 @@ class TCTimezone < Minitest::Test
     o1 = TimezoneOffset.new(5040, 0, :WMT)
     o2 = TimezoneOffset.new(3600, 0, :CET)
     o3 = TimezoneOffset.new(3600, 3600, :CEST)
-    
+
     t1 = TestTimezoneTransition.new(o1, o0, DateTime.new(1879, 12, 31, 22, 36, 0))
     t2 = TestTimezoneTransition.new(o2, o1, DateTime.new(1915,  8,  4, 22, 36, 0))
     t3 = TestTimezoneTransition.new(o3, o2, DateTime.new(1916,  4, 30, 22,  0, 0))
-    
+
     p1 = TimezonePeriod.new(t1, t2)
     p2 = TimezonePeriod.new(t2, t3)
-    
+
     dt = DateTime.new(1915,8,4,23,40,0)
-    
+
     tz = TestTimezone.new('Europe/Warsaw', nil, [p1, p2], dt)
-        
+
     assert_raises(BlockCalled) do
       tz.local_to_utc(dt, true) do |periods|
-        assert_equal([p1, p2], periods)        
+        assert_equal([p1, p2], periods)
         raise BlockCalled, 'should be raised'
       end
     end
-    
+
     assert_raises(BlockCalled) do
       tz.local_to_utc(dt, false) do |periods|
-        assert_equal([p1, p2], periods)        
+        assert_equal([p1, p2], periods)
         raise BlockCalled, 'should be raised'
       end
     end
-    
+
     assert_equal(DateTime.new(1915,8,4,22,16,0), tz.local_to_utc(dt) {|periods| periods.first})
     assert_equal(DateTime.new(1915,8,4,22,40,0), tz.local_to_utc(dt) {|periods| periods.last})
     assert_equal(DateTime.new(1915,8,4,22,16,0), tz.local_to_utc(dt) {|periods| [periods.first]})
     assert_equal(DateTime.new(1915,8,4,22,40,0), tz.local_to_utc(dt) {|periods| [periods.last]})
   end
-  
-  def test_local_to_utc_block_ambiguous    
+
+  def test_local_to_utc_block_ambiguous
     o1 = TimezoneOffset.new(-18000, 0, :EST)
     o2 = TimezoneOffset.new(-18000, 3600, :EDT)
-    
+
     t1 = TestTimezoneTransition.new(o2, o1, 1081062000)
     t2 = TestTimezoneTransition.new(o1, o2, 1099202400)
     t3 = TestTimezoneTransition.new(o2, o1, 1112511600)
-    
+
     p1 = TimezonePeriod.new(t1, t2)
     p2 = TimezonePeriod.new(t2, t3)
-    
-    dt = DateTime.new(2004,10,31,1,30,0)    
+
+    dt = DateTime.new(2004,10,31,1,30,0)
     tz = TestTimezone.new('America/New_York', nil, [p1, p2], dt)
-    
-    assert_raises(AmbiguousTime) { tz.local_to_utc(dt) {|periods| nil} }    
-    assert_raises(AmbiguousTime) { tz.local_to_utc(dt) {|periods| periods} }     
-    assert_raises(AmbiguousTime) { tz.local_to_utc(dt) {|periods| []} }    
+
+    assert_raises(AmbiguousTime) { tz.local_to_utc(dt) {|periods| nil} }
+    assert_raises(AmbiguousTime) { tz.local_to_utc(dt) {|periods| periods} }
+    assert_raises(AmbiguousTime) { tz.local_to_utc(dt) {|periods| []} }
     assert_raises(AmbiguousTime) { tz.local_to_utc(dt) {|periods| raise AmbiguousTime, 'Ambiguous time'} }
   end
-  
+
   def test_offsets_up_to
     o1 = TimezoneOffset.new(-17900, 0,    :TESTLMT)
     o2 = TimezoneOffset.new(-18000, 3600, :TESTD)
     o3 = TimezoneOffset.new(-18000, 0,    :TESTS)
     o4 = TimezoneOffset.new(-21600, 3600, :TESTD)
     o5 = TimezoneOffset.new(-21600, 0,    :TESTS)
-    
+
     t1 = TestTimezoneTransition.new(o2, o1, Time.utc(2010, 4,1,1,0,0).to_i)
     t2 = TestTimezoneTransition.new(o3, o2, Time.utc(2010,10,1,1,0,0).to_i)
     t3 = TestTimezoneTransition.new(o2, o3, Time.utc(2011, 3,1,1,0,0).to_i)
     t4 = TestTimezoneTransition.new(o4, o2, Time.utc(2011, 4,1,1,0,0).to_i)
     t5 = TestTimezoneTransition.new(o3, o4, Time.utc(2011,10,1,1,0,0).to_i)
     t6 = TestTimezoneTransition.new(o5, o3, Time.utc(2012, 3,1,1,0,0).to_i)
-    
-    assert_array_same_items([o1, o2, o3, o4, o5], 
+
+    assert_array_same_items([o1, o2, o3, o4, o5],
       OffsetsUpToTestTimezone.new('Test/Zone', Time.utc(2012,3,1,1,0,1), nil, [t1, t2, t3, t4, t5, t6]).
       offsets_up_to(Time.utc(2012,3,1,1,0,1)))
-    assert_array_same_items([o2, o3, o4, o5], 
+    assert_array_same_items([o2, o3, o4, o5],
       OffsetsUpToTestTimezone.new('Test/Zone', Time.utc(2012,3,1,1,0,1), Time.utc(2010,4,1,1,0,0), [t1, t2, t3, t4, t5, t6]).
       offsets_up_to(Time.utc(2012,3,1,1,0,1), Time.utc(2010,4,1,1,0,0)))
-    assert_array_same_items([o1, o2, o3, o4], 
+    assert_array_same_items([o1, o2, o3, o4],
       OffsetsUpToTestTimezone.new('Test/Zone', Time.utc(2012,3,1,1,0,0), nil, [t1, t2, t3, t4, t5]).
       offsets_up_to(Time.utc(2012,3,1,1,0,0)))
-    assert_array_same_items([o2, o3, o4, o5], 
+    assert_array_same_items([o2, o3, o4, o5],
       OffsetsUpToTestTimezone.new('Test/Zone', Time.utc(2012,3,1,1,0,1), Time.utc(2010,4,1,1,0,1), [t2, t3, t4, t5, t6]).
       offsets_up_to(Time.utc(2012,3,1,1,0,1), Time.utc(2010,4,1,1,0,1)))
-    assert_array_same_items([o2, o3], 
+    assert_array_same_items([o2, o3],
       OffsetsUpToTestTimezone.new('Test/Zone', Time.utc(2011,3,1,2,0,0), Time.utc(2011,3,1,0,0,0), [t3]).
       offsets_up_to(Time.utc(2011,3,1,2,0,0), Time.utc(2011,3,1,0,0,0)))
-    assert_array_same_items([o3, o4], 
+    assert_array_same_items([o3, o4],
       OffsetsUpToTestTimezone.new('Test/Zone', Time.utc(2012,3,1,1,0,0), Time.utc(2011,4,1,1,0,0), [t4, t5]).
       offsets_up_to(Time.utc(2012,3,1,1,0,0), Time.utc(2011,4,1,1,0,0)))
 
-    assert_array_same_items([o1, o2, o3, o4, o5], 
+    assert_array_same_items([o1, o2, o3, o4, o5],
       OffsetsUpToTestTimezone.new('Test/Zone', Time.utc(2012,3,1,1,0,1).to_i, nil, [t1, t2, t3, t4, t5, t6]).
       offsets_up_to(Time.utc(2012,3,1,1,0,1).to_i))
-    assert_array_same_items([o2, o3, o4, o5], 
+    assert_array_same_items([o2, o3, o4, o5],
       OffsetsUpToTestTimezone.new('Test/Zone', Time.utc(2012,3,1,1,0,1).to_i, Time.utc(2010,4,1,1,0,0).to_i, [t1, t2, t3, t4, t5, t6]).
       offsets_up_to(Time.utc(2012,3,1,1,0,1).to_i, Time.utc(2010,4,1,1,0,0).to_i))
-    assert_array_same_items([o1, o2, o3, o4], 
+    assert_array_same_items([o1, o2, o3, o4],
       OffsetsUpToTestTimezone.new('Test/Zone', Time.utc(2012,3,1,1,0,0).to_i, nil, [t1, t2, t3, t4, t5]).
       offsets_up_to(Time.utc(2012,3,1,1,0,0).to_i))
-    assert_array_same_items([o2, o3, o4, o5], 
+    assert_array_same_items([o2, o3, o4, o5],
       OffsetsUpToTestTimezone.new('Test/Zone', Time.utc(2012,3,1,1,0,1).to_i, Time.utc(2010,4,1,1,0,1).to_i, [t2, t3, t4, t5, t6]).
       offsets_up_to(Time.utc(2012,3,1,1,0,1).to_i, Time.utc(2010,4,1,1,0,1).to_i))
-    assert_array_same_items([o2, o3], 
+    assert_array_same_items([o2, o3],
       OffsetsUpToTestTimezone.new('Test/Zone', Time.utc(2011,3,1,2,0,0).to_i, Time.utc(2011,3,1,0,0,0).to_i, [t3]).
       offsets_up_to(Time.utc(2011,3,1,2,0,0).to_i, Time.utc(2011,3,1,0,0,0).to_i))
-    assert_array_same_items([o3, o4], 
+    assert_array_same_items([o3, o4],
       OffsetsUpToTestTimezone.new('Test/Zone', Time.utc(2012,3,1,1,0,0).to_i, Time.utc(2011,4,1,1,0,0).to_i, [t4, t5]).
       offsets_up_to(Time.utc(2012,3,1,1,0,0).to_i, Time.utc(2011,4,1,1,0,0).to_i))
-      
-    assert_array_same_items([o1, o2, o3, o4, o5], 
+
+    assert_array_same_items([o1, o2, o3, o4, o5],
       OffsetsUpToTestTimezone.new('Test/Zone', DateTime.new(2012,3,1,1,0,1), nil, [t1, t2, t3, t4, t5, t6]).
       offsets_up_to(DateTime.new(2012,3,1,1,0,1)))
-    assert_array_same_items([o2, o3, o4, o5], 
+    assert_array_same_items([o2, o3, o4, o5],
       OffsetsUpToTestTimezone.new('Test/Zone', DateTime.new(2012,3,1,1,0,1), DateTime.new(2010,4,1,1,0,0), [t1, t2, t3, t4, t5, t6]).
       offsets_up_to(DateTime.new(2012,3,1,1,0,1), DateTime.new(2010,4,1,1,0,0)))
-    assert_array_same_items([o1, o2, o3, o4], 
+    assert_array_same_items([o1, o2, o3, o4],
       OffsetsUpToTestTimezone.new('Test/Zone', DateTime.new(2012,3,1,1,0,0), nil, [t1, t2, t3, t4, t5]).
       offsets_up_to(DateTime.new(2012,3,1,1,0,0)))
-    assert_array_same_items([o2, o3, o4, o5], 
+    assert_array_same_items([o2, o3, o4, o5],
       OffsetsUpToTestTimezone.new('Test/Zone', DateTime.new(2012,3,1,1,0,1), DateTime.new(2010,4,1,1,0,1), [t2, t3, t4, t5, t6]).
       offsets_up_to(DateTime.new(2012,3,1,1,0,1), DateTime.new(2010,4,1,1,0,1)))
-    assert_array_same_items([o2, o3], 
+    assert_array_same_items([o2, o3],
       OffsetsUpToTestTimezone.new('Test/Zone', DateTime.new(2011,3,1,2,0,0), DateTime.new(2011,3,1,0,0,0), [t3]).
       offsets_up_to(DateTime.new(2011,3,1,2,0,0), DateTime.new(2011,3,1,0,0,0)))
-    assert_array_same_items([o3, o4], 
+    assert_array_same_items([o3, o4],
       OffsetsUpToTestTimezone.new('Test/Zone', DateTime.new(2012,3,1,1,0,0), DateTime.new(2011,4,1,1,0,0), [t4, t5]).
       offsets_up_to(DateTime.new(2012,3,1,1,0,0), DateTime.new(2011,4,1,1,0,0)))
   end
-  
+
   def test_offsets_up_to_no_transitions
     o = TimezoneOffset.new(600, 0, :LMT)
     p = TimezonePeriod.new(nil, nil, o)
-        
+
     assert_array_same_items([o],
       OffsetsUpToNoTransitionsTestTimezone.new('Test/Zone', Time.utc(2000,1,1,1,0,0), nil, p).
       offsets_up_to(Time.utc(2000,1,1,1,0,0)))
     assert_array_same_items([o],
       OffsetsUpToNoTransitionsTestTimezone.new('Test/Zone', Time.utc(2000,1,1,1,0,0), Time.utc(1990,1,1,1,0,0), p).
       offsets_up_to(Time.utc(2000,1,1,1,0,0), Time.utc(1990,1,1,1,0,0)))
-      
+
     assert_array_same_items([o],
       OffsetsUpToNoTransitionsTestTimezone.new('Test/Zone', Time.utc(2000,1,1,1,0,0).to_i, nil, p).
       offsets_up_to(Time.utc(2000,1,1,1,0,0).to_i))
     assert_array_same_items([o],
       OffsetsUpToNoTransitionsTestTimezone.new('Test/Zone', Time.utc(2000,1,1,1,0,0).to_i, Time.utc(1990,1,1,1,0,0).to_i, p).
       offsets_up_to(Time.utc(2000,1,1,1,0,0).to_i, Time.utc(1990,1,1,1,0,0).to_i))
-      
+
     assert_array_same_items([o],
       OffsetsUpToNoTransitionsTestTimezone.new('Test/Zone', DateTime.new(2000,1,1,1,0,0), nil, p).
       offsets_up_to(DateTime.new(2000,1,1,1,0,0)))
@@ -1153,97 +1153,97 @@ class TCTimezone < Minitest::Test
       OffsetsUpToNoTransitionsTestTimezone.new('Test/Zone', DateTime.new(2000,1,1,1,0,0), DateTime.new(1990,1,1,1,0,0), p).
       offsets_up_to(DateTime.new(2000,1,1,1,0,0), DateTime.new(1990,1,1,1,0,0)))
   end
-  
+
   def test_offsets_up_to_utc_to_not_greater_than_utc_from
     assert_raises(ArgumentError) do
       OffsetsUpToTestTimezone.new('Test/Zone', Time.utc(2012,8,1,0,0,0), Time.utc(2012,8,1,0,0,0), []).
         offsets_up_to(Time.utc(2012,8,1,0,0,0), Time.utc(2012,8,1,0,0,0))
     end
-    
+
     assert_raises(ArgumentError) do
       OffsetsUpToTestTimezone.new('Test/Zone', Time.utc(2012,8,1,0,0,0).to_i, Time.utc(2012,8,1,0,0,0).to_i, []).
         offsets_up_to(Time.utc(2012,8,1,0,0,0).to_i, Time.utc(2012,8,1,0,0,0).to_i)
     end
-    
+
     assert_raises(ArgumentError) do
       OffsetsUpToTestTimezone.new('Test/Zone', DateTime.new(2012,8,1,0,0,0), DateTime.new(2012,8,1,0,0,0), []).
         offsets_up_to(DateTime.new(2012,8,1,0,0,0), DateTime.new(2012,8,1,0,0,0))
     end
   end
-  
+
   def test_now
     assert_kind_of(Time, Timezone.get('Europe/London').now)
   end
-  
+
   def test_current_period
     assert_kind_of(TimezonePeriod, Timezone.get('Europe/London').current_period)
   end
-  
+
   def test_current_period_and_time
     current = Timezone.get('Europe/London').current_period_and_time
     assert_equal(2, current.length)
     assert_kind_of(Time, current[0])
     assert_kind_of(TimezonePeriod, current[1])
   end
-  
+
   def test_current_time_and_period
     current = Timezone.get('Europe/London').current_time_and_period
     assert_equal(2, current.length)
     assert_kind_of(Time, current[0])
     assert_kind_of(TimezonePeriod, current[1])
   end
-    
+
   def test_compare
     assert_equal(0, TestTimezone.new('Europe/London') <=> TestTimezone.new('Europe/London'))
     assert_equal(-1, TestTimezone.new('Europe/London') <=> TestTimezone.new('Europe/london'))
     assert_equal(-1, TestTimezone.new('Europe/London') <=> TestTimezone.new('Europe/Paris'))
     assert_equal(1, TestTimezone.new('Europe/Paris') <=> TestTimezone.new('Europe/London'))
     assert_equal(-1, TestTimezone.new('America/New_York') <=> TestTimezone.new('Europe/Paris'))
-    assert_equal(1, TestTimezone.new('Europe/Paris') <=> TestTimezone.new('America/New_York'))    
+    assert_equal(1, TestTimezone.new('Europe/Paris') <=> TestTimezone.new('America/New_York'))
   end
-  
+
   def test_compare_non_comparable
     assert_nil(TestTimezone.new('Europe/London') <=> Object.new)
   end
-  
+
   def test_equality
     assert_equal(true, TestTimezone.new('Europe/London') == TestTimezone.new('Europe/London'))
     assert_equal(false, TestTimezone.new('Europe/London') == TestTimezone.new('Europe/london'))
     assert_equal(false, TestTimezone.new('Europe/London') == TestTimezone.new('Europe/Paris'))
     assert(!(TestTimezone.new('Europe/London') == Object.new))
   end
-  
+
   def test_eql
     assert_equal(true, TestTimezone.new('Europe/London').eql?(TestTimezone.new('Europe/London')))
     assert_equal(false, TestTimezone.new('Europe/London').eql?(TestTimezone.new('Europe/london')))
     assert_equal(false, TestTimezone.new('Europe/London').eql?(TestTimezone.new('Europe/Paris')))
     assert(!TestTimezone.new('Europe/London').eql?(Object.new))
   end
-  
+
   def test_hash
     assert_equal('Europe/London'.hash, TestTimezone.new('Europe/London').hash)
     assert_equal('America/New_York'.hash, TestTimezone.new('America/New_York').hash)
   end
-  
+
   def test_marshal_data
     tz = Timezone.get('Europe/London')
     assert_kind_of(DataTimezone, tz)
-    assert_same(tz, Marshal.load(Marshal.dump(tz)))    
+    assert_same(tz, Marshal.load(Marshal.dump(tz)))
   end
-  
+
   def test_marshal_linked
     tz = Timezone.get('UTC')
-    
+
     # ZoneinfoDataSource doesn't return LinkedTimezoneInfo for any timezone.
     if DataSource.get.load_timezone_info('UTC').kind_of?(LinkedTimezoneInfo)
       assert_kind_of(LinkedTimezone, tz)
     else
       assert_kind_of(DataTimezone, tz)
     end
-    
-    assert_same(tz, Marshal.load(Marshal.dump(tz)))    
+
+    assert_same(tz, Marshal.load(Marshal.dump(tz)))
   end
-  
+
   def test_strftime_datetime
     tz = Timezone.get('Europe/London')
     assert_equal('23:12:02 BST', tz.strftime('%H:%M:%S %Z', DateTime.new(2006, 7, 15, 22, 12, 2)))
@@ -1251,7 +1251,7 @@ class TCTimezone < Minitest::Test
     assert_equal('%ZBST', tz.strftime('%%Z%Z', DateTime.new(2006, 7, 15, 22, 12, 2)))
     assert_equal('BST BST', tz.strftime('%Z %Z', DateTime.new(2006, 7, 15, 22, 12, 2)))
   end
-  
+
   def test_strftime_time
     tz = Timezone.get('Europe/London')
     assert_equal('23:12:02 BST', tz.strftime('%H:%M:%S %Z', Time.utc(2006, 7, 15, 22, 12, 2)))
@@ -1259,7 +1259,7 @@ class TCTimezone < Minitest::Test
     assert_equal('%ZBST', tz.strftime('%%Z%Z', Time.utc(2006, 7, 15, 22, 12, 2)))
     assert_equal('BST BST', tz.strftime('%Z %Z', Time.utc(2006, 7, 15, 22, 12, 2)))
   end
-  
+
   def test_strftime_int
     tz = Timezone.get('Europe/London')
     assert_equal('23:12:02 BST', tz.strftime('%H:%M:%S %Z', Time.utc(2006, 7, 15, 22, 12, 2).to_i))
@@ -1269,50 +1269,50 @@ class TCTimezone < Minitest::Test
     assert_equal('BST %Z %BST %%Z %%BST', tz.strftime('%Z %%Z %%%Z %%%%Z %%%%%Z', 0))
     assert_equal('+0100 +01:00 +01:00:00 +01 %::::z', tz.strftime('%z %:z %::z %:::z %::::z', 0))
   end
-  
+
   def test_get_missing_data_source
     DataSource.set(DataSource.new)
-    
+
     assert_raises(InvalidDataSource) do
       Timezone.get('Europe/London')
     end
   end
-  
+
   def test_new_missing_data_source
     DataSource.set(DataSource.new)
-    
+
     assert_raises(InvalidDataSource) do
       Timezone.new('Europe/London')
     end
   end
-  
+
   def test_all_missing_data_source
     DataSource.set(DataSource.new)
-    
+
     assert_raises(InvalidDataSource) do
       Timezone.all
     end
   end
-  
+
   def test_all_identifiers_missing_data_source
     DataSource.set(DataSource.new)
-    
+
     assert_raises(InvalidDataSource) do
       Timezone.all_identifiers
     end
   end
-  
+
   def test_all_data_zones_missing_data_source
     DataSource.set(DataSource.new)
-    
+
     assert_raises(InvalidDataSource) do
       Timezone.all_data_zones
     end
   end
-  
+
   def test_all_data_zone_identifiers_missing_data_source
     DataSource.set(DataSource.new)
-    
+
     assert_raises(InvalidDataSource) do
       Timezone.all_data_zone_identifiers
     end
@@ -1320,7 +1320,7 @@ class TCTimezone < Minitest::Test
 
   def test_all_linked_zones_missing_data_source
     DataSource.set(DataSource.new)
-    
+
     assert_raises(InvalidDataSource) do
       Timezone.all_linked_zones
     end
@@ -1328,9 +1328,9 @@ class TCTimezone < Minitest::Test
 
   def test_all_linked_zone_identifiers_missing_data_source
     DataSource.set(DataSource.new)
-    
+
     assert_raises(InvalidDataSource) do
       Timezone.all_linked_zone_identifiers
     end
-  end  
+  end
 end

--- a/test/tc_timezone_definition.rb
+++ b/test/tc_timezone_definition.rb
@@ -6,108 +6,108 @@ class TCTimezoneDefinition < Minitest::Test
 
   module DataTest
     include TimezoneDefinition
-    
+
     timezone 'Test/Data/Zone' do |tz|
       tz.offset :o0, -75, 0, :LMT
       tz.offset :o1,   0, 0, :GMT
-      
-      tz.transition 1847, 12, :o1, 2760187969, 1152 
+
+      tz.transition 1847, 12, :o1, 2760187969, 1152
     end
   end
-  
+
   module LinkedTest
     include TimezoneDefinition
-    
+
     linked_timezone 'Test/Linked/Zone', 'Test/Linked_To/Zone'
   end
-  
+
   module DoubleDataTest
     include TimezoneDefinition
-    
+
     timezone 'Test/Data/Zone1' do |tz|
       tz.offset :o0, -75, 0, :LMT
       tz.offset :o1,   0, 0, :GMT
-      
-      tz.transition 1847, 12, :o1, 2760187969, 1152 
+
+      tz.transition 1847, 12, :o1, 2760187969, 1152
     end
-    
+
     timezone 'Test/Data/Zone2' do |tz|
       tz.offset :o0, 75, 0, :LMT
       tz.offset :o1,  0, 0, :GMT
-      
-      tz.transition 1847, 12, :o1, 2760187969, 1152 
+
+      tz.transition 1847, 12, :o1, 2760187969, 1152
     end
   end
-  
+
   module DoubleLinkedTest
     include TimezoneDefinition
-    
+
     linked_timezone 'Test/Linked/Zone1', 'Test/Linked_To/Zone1'
     linked_timezone 'Test/Linked/Zone2', 'Test/Linked_To/Zone2'
   end
-  
+
   module DataLinkedTest
     include TimezoneDefinition
-    
+
     timezone 'Test/Data/Zone1' do |tz|
       tz.offset :o0, -75, 0, :LMT
       tz.offset :o1,   0, 0, :GMT
-      
-      tz.transition 1847, 12, :o1, 2760187969, 1152 
-    end 
-    
+
+      tz.transition 1847, 12, :o1, 2760187969, 1152
+    end
+
     linked_timezone 'Test/Linked/Zone2', 'Test/Linked_To/Zone2'
   end
-  
+
   module LinkedDataTest
     include TimezoneDefinition
-    
+
     linked_timezone 'Test/Linked/Zone1', 'Test/Linked_To/Zone1'
-    
+
     timezone 'Test/Data/Zone2' do |tz|
       tz.offset :o0, -75, 0, :LMT
       tz.offset :o1,   0, 0, :GMT
-      
-      tz.transition 1847, 12, :o1, 2760187969, 1152 
-    end    
+
+      tz.transition 1847, 12, :o1, 2760187969, 1152
+    end
   end
-    
+
   def test_data
     assert_kind_of(TransitionDataTimezoneInfo, DataTest.get)
     assert_equal('Test/Data/Zone', DataTest.get.identifier)
     assert_equal(:LMT, DataTest.get.period_for_utc(DateTime.new(1847,12,1,0,1,14)).abbreviation)
     assert_equal(:GMT, DataTest.get.period_for_utc(DateTime.new(1847,12,1,0,1,15)).abbreviation)
   end
-  
+
   def test_linked
     assert_kind_of(LinkedTimezoneInfo, LinkedTest.get)
     assert_equal('Test/Linked/Zone', LinkedTest.get.identifier)
-    assert_equal('Test/Linked_To/Zone', LinkedTest.get.link_to_identifier)    
+    assert_equal('Test/Linked_To/Zone', LinkedTest.get.link_to_identifier)
   end
-  
+
   def test_double_data
     assert_kind_of(TransitionDataTimezoneInfo, DoubleDataTest.get)
     assert_equal('Test/Data/Zone2', DoubleDataTest.get.identifier)
     assert_equal(:LMT, DoubleDataTest.get.period_for_utc(DateTime.new(1847,12,1,0,1,14)).abbreviation)
     assert_equal(:GMT, DoubleDataTest.get.period_for_utc(DateTime.new(1847,12,1,0,1,15)).abbreviation)
   end
-  
+
   def test_double_linked
     assert_kind_of(LinkedTimezoneInfo, DoubleLinkedTest.get)
     assert_equal('Test/Linked/Zone2', DoubleLinkedTest.get.identifier)
-    assert_equal('Test/Linked_To/Zone2', DoubleLinkedTest.get.link_to_identifier)    
+    assert_equal('Test/Linked_To/Zone2', DoubleLinkedTest.get.link_to_identifier)
   end
-  
+
   def test_data_linked
     assert_kind_of(LinkedTimezoneInfo, DataLinkedTest.get)
     assert_equal('Test/Linked/Zone2', DataLinkedTest.get.identifier)
-    assert_equal('Test/Linked_To/Zone2', DataLinkedTest.get.link_to_identifier)    
+    assert_equal('Test/Linked_To/Zone2', DataLinkedTest.get.link_to_identifier)
   end
-  
+
   def test_linked_data
     assert_kind_of(TransitionDataTimezoneInfo, LinkedDataTest.get)
     assert_equal('Test/Data/Zone2', LinkedDataTest.get.identifier)
     assert_equal(:LMT, LinkedDataTest.get.period_for_utc(DateTime.new(1847,12,1,0,1,14)).abbreviation)
     assert_equal(:GMT, LinkedDataTest.get.period_for_utc(DateTime.new(1847,12,1,0,1,15)).abbreviation)
-  end  
+  end
 end

--- a/test/tc_timezone_index_definition.rb
+++ b/test/tc_timezone_index_definition.rb
@@ -3,71 +3,71 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 include TZInfo
 
 class TCTimezoneIndexDefinition < Minitest::Test
-  
+
   module TimezonesTest1
     include TimezoneIndexDefinition
-    
+
     timezone 'Test/One'
     timezone 'Test/Two'
     linked_timezone 'Test/Three'
     timezone 'Another/Zone'
     linked_timezone 'And/Yet/Another'
   end
-  
+
   module TimezonesTest2
     include TimezoneIndexDefinition
-    
+
     timezone 'Test/A/One'
     timezone 'Test/A/Two'
     timezone 'Test/A/Three'
   end
-  
+
   module TimezonesTest3
     include TimezoneIndexDefinition
-    
+
     linked_timezone 'Test/B/One'
     linked_timezone 'Test/B/Two'
     linked_timezone 'Test/B/Three'
   end
-  
+
   module TimezonesTest4
     include TimezoneIndexDefinition
-    
+
   end
-  
+
   def test_timezones
-    assert_equal(['Test/One', 'Test/Two', 'Test/Three', 'Another/Zone', 'And/Yet/Another'], TimezonesTest1.timezones)            
+    assert_equal(['Test/One', 'Test/Two', 'Test/Three', 'Another/Zone', 'And/Yet/Another'], TimezonesTest1.timezones)
     assert_equal(['Test/A/One', 'Test/A/Two', 'Test/A/Three'], TimezonesTest2.timezones)
     assert_equal(['Test/B/One', 'Test/B/Two', 'Test/B/Three'], TimezonesTest3.timezones)
     assert_equal([], TimezonesTest4.timezones)
-      
+
     assert_equal(true, TimezonesTest1.timezones.frozen?)
     assert_equal(true, TimezonesTest2.timezones.frozen?)
     assert_equal(true, TimezonesTest3.timezones.frozen?)
     assert_equal(true, TimezonesTest4.timezones.frozen?)
-  end   
-  
+  end
+
   def test_data_timezones
     assert_equal(['Test/One', 'Test/Two', 'Another/Zone'], TimezonesTest1.data_timezones)
     assert_equal(['Test/A/One', 'Test/A/Two', 'Test/A/Three'], TimezonesTest2.data_timezones)
     assert_equal([], TimezonesTest3.data_timezones)
     assert_equal([], TimezonesTest4.data_timezones)
-    
+
     assert_equal(true, TimezonesTest1.data_timezones.frozen?)
     assert_equal(true, TimezonesTest2.data_timezones.frozen?)
     assert_equal(true, TimezonesTest3.data_timezones.frozen?)
     assert_equal(true, TimezonesTest4.data_timezones.frozen?)
   end
-  
+
   def test_linked_timezones
     assert_equal(['Test/Three', 'And/Yet/Another'], TimezonesTest1.linked_timezones)
     assert_equal([], TimezonesTest2.linked_timezones)
     assert_equal(['Test/B/One', 'Test/B/Two', 'Test/B/Three'], TimezonesTest3.linked_timezones)
     assert_equal([], TimezonesTest4.linked_timezones)
-    
+
     assert_equal(true, TimezonesTest1.linked_timezones.frozen?)
     assert_equal(true, TimezonesTest2.linked_timezones.frozen?)
     assert_equal(true, TimezonesTest3.linked_timezones.frozen?)
     assert_equal(true, TimezonesTest4.linked_timezones.frozen?)
-  end  
+  end
 end

--- a/test/tc_timezone_info.rb
+++ b/test/tc_timezone_info.rb
@@ -3,7 +3,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 include TZInfo
 
 class TCTimezoneInfo < Minitest::Test
-  
+
   def test_identifier
     ti = TimezoneInfo.new('Test/Zone')
     assert_equal('Test/Zone', ti.identifier)

--- a/test/tc_timezone_london.rb
+++ b/test/tc_timezone_london.rb
@@ -8,47 +8,47 @@ class TCTimezoneLondon < Minitest::Test
     #Europe/London  Sun Mar 28 01:00:00 2004 UTC = Sun Mar 28 02:00:00 2004 BST isdst=1 gmtoff=3600
     #Europe/London  Sun Oct 31 00:59:59 2004 UTC = Sun Oct 31 01:59:59 2004 BST isdst=1 gmtoff=3600
     #Europe/London  Sun Oct 31 01:00:00 2004 UTC = Sun Oct 31 01:00:00 2004 GMT isdst=0 gmtoff=0
-    
+
     tz = Timezone.get('Europe/London')
     assert_equal(DateTime.new(2004,3,28,0,59,59), tz.utc_to_local(DateTime.new(2004,3,28,0,59,59)))
-    assert_equal(DateTime.new(2004,3,28,2,0,0), tz.utc_to_local(DateTime.new(2004,3,28,1,0,0)))    
+    assert_equal(DateTime.new(2004,3,28,2,0,0), tz.utc_to_local(DateTime.new(2004,3,28,1,0,0)))
     assert_equal(DateTime.new(2004,10,31,1,59,59), tz.utc_to_local(DateTime.new(2004,10,31,0,59,59)))
     assert_equal(DateTime.new(2004,10,31,1,0,0), tz.utc_to_local(DateTime.new(2004,10,31,1,0,0)))
-    
+
     assert_equal(DateTime.new(2004,3,28,0,59,59), tz.local_to_utc(DateTime.new(2004,3,28,0,59,59)))
     assert_equal(DateTime.new(2004,3,28,1,0,0), tz.local_to_utc(DateTime.new(2004,3,28,2,0,0)))
     assert_equal(DateTime.new(2004,10,31,0,59,59), tz.local_to_utc(DateTime.new(2004,10,31,1,59,59), true))
     assert_equal(DateTime.new(2004,10,31,1,59,59), tz.local_to_utc(DateTime.new(2004,10,31,1,59,59), false))
     assert_equal(DateTime.new(2004,10,31,0,0,0), tz.local_to_utc(DateTime.new(2004,10,31,1,0,0), true))
     assert_equal(DateTime.new(2004,10,31,1,0,0), tz.local_to_utc(DateTime.new(2004,10,31,1,0,0), false))
-    
+
     assert_raises(PeriodNotFound) { tz.local_to_utc(DateTime.new(2004,3,28,1,0,0)) }
     assert_raises(AmbiguousTime) { tz.local_to_utc(DateTime.new(2004,10,31,1,0,0)) }
-    
+
     assert_equal(:GMT, tz.period_for_utc(DateTime.new(2004,3,28,0,59,59)).zone_identifier)
     assert_equal(:BST, tz.period_for_utc(DateTime.new(2004,3,28,1,0,0)).zone_identifier)
     assert_equal(:BST, tz.period_for_utc(DateTime.new(2004,10,31,0,59,59)).zone_identifier)
     assert_equal(:GMT, tz.period_for_utc(DateTime.new(2004,10,31,1,0,0)).zone_identifier)
-    
+
     assert_equal(:GMT, tz.period_for_local(DateTime.new(2004,3,28,0,59,59)).zone_identifier)
     assert_equal(:BST, tz.period_for_local(DateTime.new(2004,3,28,2,0,0)).zone_identifier)
     assert_equal(:BST, tz.period_for_local(DateTime.new(2004,10,31,1,59,59), true).zone_identifier)
     assert_equal(:GMT, tz.period_for_local(DateTime.new(2004,10,31,1,59,59), false).zone_identifier)
     assert_equal(:BST, tz.period_for_local(DateTime.new(2004,10,31,1,0,0), true).zone_identifier)
     assert_equal(:GMT, tz.period_for_local(DateTime.new(2004,10,31,1,0,0), false).zone_identifier)
-    
+
     assert_equal(0, tz.period_for_utc(DateTime.new(2004,3,28,0,59,59)).utc_total_offset)
     assert_equal(3600, tz.period_for_utc(DateTime.new(2004,3,28,1,0,0)).utc_total_offset)
     assert_equal(3600, tz.period_for_utc(DateTime.new(2004,10,31,0,59,59)).utc_total_offset)
     assert_equal(0, tz.period_for_utc(DateTime.new(2004,10,31,1,0,0)).utc_total_offset)
-    
+
     assert_equal(0, tz.period_for_local(DateTime.new(2004,3,28,0,59,59)).utc_total_offset)
     assert_equal(3600, tz.period_for_local(DateTime.new(2004,3,28,2,0,0)).utc_total_offset)
     assert_equal(3600, tz.period_for_local(DateTime.new(2004,10,31,1,59,59), true).utc_total_offset)
     assert_equal(0, tz.period_for_local(DateTime.new(2004,10,31,1,59,59), false).utc_total_offset)
     assert_equal(3600, tz.period_for_local(DateTime.new(2004,10,31,1,0,0), true).utc_total_offset)
     assert_equal(0, tz.period_for_local(DateTime.new(2004,10,31,1,0,0), false).utc_total_offset)
-    
+
     transitions = tz.transitions_up_to(DateTime.new(2005,1,1,0,0,0), DateTime.new(2004,1,1,0,0,0))
     assert_equal(2, transitions.length)
     assert_equal(TimeOrDateTime.new(DateTime.new(2004,3,28,1,0,0)), transitions[0].at)
@@ -57,63 +57,63 @@ class TCTimezoneLondon < Minitest::Test
     assert_equal(TimeOrDateTime.new(DateTime.new(2004,10,31,1,0,0)), transitions[1].at)
     assert_equal(TimezoneOffset.new(0, 3600, :BST), transitions[1].previous_offset)
     assert_equal(TimezoneOffset.new(0, 0, :GMT), transitions[1].offset)
-    
+
     offsets = tz.offsets_up_to(DateTime.new(2005,1,1,0,0,0), DateTime.new(2004,1,1,0,0,0))
     assert_array_same_items([TimezoneOffset.new(0, 0, :GMT), TimezoneOffset.new(0, 3600, :BST)], offsets)
-  end 
-  
+  end
+
   def test_1961
     # This test cannot be run when using ZoneinfoDataSource on platforms
-    # that don't support Times before the epoch (i.e. Ruby < 1.9 on Windows) 
+    # that don't support Times before the epoch (i.e. Ruby < 1.9 on Windows)
     # because it relates to the year 1961.
-    
+
     if !DataSource.get.kind_of?(ZoneinfoDataSource) || RubyCoreSupport.time_supports_negative
       #Europe/London  Sun Mar 26 01:59:59 1961 UTC = Sun Mar 26 01:59:59 1961 GMT isdst=0 gmtoff=0
       #Europe/London  Sun Mar 26 02:00:00 1961 UTC = Sun Mar 26 03:00:00 1961 BST isdst=1 gmtoff=3600
       #Europe/London  Sun Oct 29 01:59:59 1961 UTC = Sun Oct 29 02:59:59 1961 BST isdst=1 gmtoff=3600
       #Europe/London  Sun Oct 29 02:00:00 1961 UTC = Sun Oct 29 02:00:00 1961 GMT isdst=0 gmtoff=0
-      
+
       tz = Timezone.get('Europe/London')
       assert_equal(DateTime.new(1961,3,26,1,59,59), tz.utc_to_local(DateTime.new(1961,3,26,1,59,59)))
-      assert_equal(DateTime.new(1961,3,26,3,0,0), tz.utc_to_local(DateTime.new(1961,3,26,2,0,0)))    
+      assert_equal(DateTime.new(1961,3,26,3,0,0), tz.utc_to_local(DateTime.new(1961,3,26,2,0,0)))
       assert_equal(DateTime.new(1961,10,29,2,59,59), tz.utc_to_local(DateTime.new(1961,10,29,1,59,59)))
       assert_equal(DateTime.new(1961,10,29,2,0,0), tz.utc_to_local(DateTime.new(1961,10,29,2,0,0)))
-      
+
       assert_equal(DateTime.new(1961,3,26,1,59,59), tz.local_to_utc(DateTime.new(1961,3,26,1,59,59)))
       assert_equal(DateTime.new(1961,3,26,2,0,0), tz.local_to_utc(DateTime.new(1961,3,26,3,0,0)))
       assert_equal(DateTime.new(1961,10,29,1,59,59), tz.local_to_utc(DateTime.new(1961,10,29,2,59,59), true))
       assert_equal(DateTime.new(1961,10,29,2,59,59), tz.local_to_utc(DateTime.new(1961,10,29,2,59,59), false))
       assert_equal(DateTime.new(1961,10,29,1,0,0), tz.local_to_utc(DateTime.new(1961,10,29,2,0,0), true))
       assert_equal(DateTime.new(1961,10,29,2,0,0), tz.local_to_utc(DateTime.new(1961,10,29,2,0,0), false))
-      
+
       assert_raises(PeriodNotFound) { tz.local_to_utc(DateTime.new(1961,3,26,2,0,0)) }
       assert_raises(AmbiguousTime) { tz.local_to_utc(DateTime.new(1961,10,29,2,0,0)) }
-      
+
       assert_equal(:GMT, tz.period_for_utc(DateTime.new(1961,3,26,1,59,59)).zone_identifier)
       assert_equal(:BST, tz.period_for_utc(DateTime.new(1961,3,26,2,0,0)).zone_identifier)
       assert_equal(:BST, tz.period_for_utc(DateTime.new(1961,10,29,1,59,59)).zone_identifier)
       assert_equal(:GMT, tz.period_for_utc(DateTime.new(1961,10,29,2,0,0)).zone_identifier)
-      
+
       assert_equal(:GMT, tz.period_for_local(DateTime.new(1961,3,26,1,59,59)).zone_identifier)
       assert_equal(:BST, tz.period_for_local(DateTime.new(1961,3,26,3,0,0)).zone_identifier)
       assert_equal(:BST, tz.period_for_local(DateTime.new(1961,10,29,2,59,59), true).zone_identifier)
       assert_equal(:GMT, tz.period_for_local(DateTime.new(1961,10,29,2,59,59), false).zone_identifier)
       assert_equal(:BST, tz.period_for_local(DateTime.new(1961,10,29,2,0,0), true).zone_identifier)
       assert_equal(:GMT, tz.period_for_local(DateTime.new(1961,10,29,2,0,0), false).zone_identifier)
-      
+
       assert_equal(0, tz.period_for_utc(DateTime.new(1961,3,26,1,59,59)).utc_total_offset)
       assert_equal(3600, tz.period_for_utc(DateTime.new(1961,3,26,2,0,0)).utc_total_offset)
       assert_equal(3600, tz.period_for_utc(DateTime.new(1961,10,29,1,59,59)).utc_total_offset)
       assert_equal(0, tz.period_for_utc(DateTime.new(1961,10,29,2,0,0)).utc_total_offset)
-      
+
       assert_equal(0, tz.period_for_local(DateTime.new(1961,3,26,1,59,59)).utc_total_offset)
       assert_equal(3600, tz.period_for_local(DateTime.new(1961,3,26,3,0,0)).utc_total_offset)
       assert_equal(3600, tz.period_for_local(DateTime.new(1961,10,29,2,59,59), true).utc_total_offset)
       assert_equal(0, tz.period_for_local(DateTime.new(1961,10,29,2,59,59), false).utc_total_offset)
       assert_equal(3600, tz.period_for_local(DateTime.new(1961,10,29,2,0,0), true).utc_total_offset)
       assert_equal(0, tz.period_for_local(DateTime.new(1961,10,29,2,0,0), false).utc_total_offset)
-      
-      
+
+
       transitions = tz.transitions_up_to(DateTime.new(1962,1,1,0,0,0), DateTime.new(1961,1,1,0,0,0))
       assert_equal(2, transitions.length)
       assert_equal(TimeOrDateTime.new(DateTime.new(1961,3,26,2,0,0)), transitions[0].at)
@@ -122,16 +122,16 @@ class TCTimezoneLondon < Minitest::Test
       assert_equal(TimeOrDateTime.new(DateTime.new(1961,10,29,2,0,0)), transitions[1].at)
       assert_equal(TimezoneOffset.new(0, 3600, :BST), transitions[1].previous_offset)
       assert_equal(TimezoneOffset.new(0, 0, :GMT), transitions[1].offset)
-      
+
       offsets = tz.offsets_up_to(DateTime.new(1962,1,1,0,0,0), DateTime.new(1961,1,1,0,0,0))
       assert_array_same_items([TimezoneOffset.new(0, 0, :GMT), TimezoneOffset.new(0, 3600, :BST)], offsets)
     end
-  end 
-  
+  end
+
   def test_time_boundary
     #Europe/London  Sat Oct 26 23:00:00 1968 UTC = Sun Oct 27 00:00:00 1968 GMT isdst=0 gmtoff=3600
     #Europe/London  Sun Oct 31 01:59:59 1971 UTC = Sun Oct 31 02:59:59 1971 GMT isdst=0 gmtoff=3600
-    
+
     tz = Timezone.get('Europe/London')
     assert_equal(DateTime.new(1970,1,1,1,0,0), tz.utc_to_local(DateTime.new(1970,1,1,0,0,0)))
     assert_equal(DateTime.new(1970,1,1,0,0,0), tz.local_to_utc(DateTime.new(1970,1,1,1,0,0)))

--- a/test/tc_timezone_melbourne.rb
+++ b/test/tc_timezone_melbourne.rb
@@ -8,47 +8,47 @@ class TCTimezoneMelbourne < Minitest::Test
     #Australia/Melbourne  Sat Mar 27 16:00:00 2004 UTC = Sun Mar 28 02:00:00 2004 AEST isdst=0 gmtoff=36000
     #Australia/Melbourne  Sat Oct 30 15:59:59 2004 UTC = Sun Oct 31 01:59:59 2004 AEST isdst=0 gmtoff=36000
     #Australia/Melbourne  Sat Oct 30 16:00:00 2004 UTC = Sun Oct 31 03:00:00 2004 AEDT isdst=1 gmtoff=39600
-    
+
     tz = Timezone.get('Australia/Melbourne')
     assert_equal(DateTime.new(2004,3,28,2,59,59), tz.utc_to_local(DateTime.new(2004,3,27,15,59,59)))
-    assert_equal(DateTime.new(2004,3,28,2,0,0), tz.utc_to_local(DateTime.new(2004,3,27,16,0,0)))    
+    assert_equal(DateTime.new(2004,3,28,2,0,0), tz.utc_to_local(DateTime.new(2004,3,27,16,0,0)))
     assert_equal(DateTime.new(2004,10,31,1,59,59), tz.utc_to_local(DateTime.new(2004,10,30,15,59,59)))
     assert_equal(DateTime.new(2004,10,31,3,0,0), tz.utc_to_local(DateTime.new(2004,10,30,16,0,0)))
-    
+
     assert_equal(DateTime.new(2004,3,27,15,59,59), tz.local_to_utc(DateTime.new(2004,3,28,2,59,59), true))
     assert_equal(DateTime.new(2004,3,27,16,59,59), tz.local_to_utc(DateTime.new(2004,3,28,2,59,59), false))
     assert_equal(DateTime.new(2004,3,27,15,0,0), tz.local_to_utc(DateTime.new(2004,3,28,2,0,0), true))
-    assert_equal(DateTime.new(2004,3,27,16,0,0), tz.local_to_utc(DateTime.new(2004,3,28,2,0,0), false))   
+    assert_equal(DateTime.new(2004,3,27,16,0,0), tz.local_to_utc(DateTime.new(2004,3,28,2,0,0), false))
     assert_equal(DateTime.new(2004,10,30,15,59,59), tz.local_to_utc(DateTime.new(2004,10,31,1,59,59)))
     assert_equal(DateTime.new(2004,10,30,16,0,0), tz.local_to_utc(DateTime.new(2004,10,31,3,0,0)))
-    
+
     assert_raises(PeriodNotFound) { tz.local_to_utc(DateTime.new(2004,10,31,2,0,0)) }
     assert_raises(AmbiguousTime) { tz.local_to_utc(DateTime.new(2004,3,28,2,0,0)) }
-    
+
     assert_equal(:AEDT, tz.period_for_utc(DateTime.new(2004,3,27,15,59,59)).zone_identifier)
     assert_equal(:AEST, tz.period_for_utc(DateTime.new(2004,3,27,16,0,0)).zone_identifier)
     assert_equal(:AEST, tz.period_for_utc(DateTime.new(2004,10,30,15,59,59)).zone_identifier)
     assert_equal(:AEDT, tz.period_for_utc(DateTime.new(2004,10,30,16,0,0)).zone_identifier)
-    
+
     assert_equal(:AEDT, tz.period_for_local(DateTime.new(2004,3,28,2,59,59), true).zone_identifier)
     assert_equal(:AEST, tz.period_for_local(DateTime.new(2004,3,28,2,59,59), false).zone_identifier)
     assert_equal(:AEDT, tz.period_for_local(DateTime.new(2004,3,28,2,0,0), true).zone_identifier)
     assert_equal(:AEST, tz.period_for_local(DateTime.new(2004,3,28,2,0,0), false).zone_identifier)
     assert_equal(:AEST, tz.period_for_local(DateTime.new(2004,10,31,1,59,59)).zone_identifier)
     assert_equal(:AEDT, tz.period_for_local(DateTime.new(2004,10,31,3,0,0)).zone_identifier)
-    
+
     assert_equal(39600, tz.period_for_utc(DateTime.new(2004,3,27,15,59,59)).utc_total_offset)
     assert_equal(36000, tz.period_for_utc(DateTime.new(2004,3,27,16,0,0)).utc_total_offset)
     assert_equal(36000, tz.period_for_utc(DateTime.new(2004,10,30,15,59,59)).utc_total_offset)
     assert_equal(39600, tz.period_for_utc(DateTime.new(2004,10,30,16,0,0)).utc_total_offset)
-    
+
     assert_equal(39600, tz.period_for_local(DateTime.new(2004,3,28,2,59,59), true).utc_total_offset)
     assert_equal(36000, tz.period_for_local(DateTime.new(2004,3,28,2,59,59), false).utc_total_offset)
     assert_equal(39600, tz.period_for_local(DateTime.new(2004,3,28,2,0,0), true).utc_total_offset)
     assert_equal(36000, tz.period_for_local(DateTime.new(2004,3,28,2,0,0), false).utc_total_offset)
     assert_equal(36000, tz.period_for_local(DateTime.new(2004,10,31,1,59,59)).utc_total_offset)
     assert_equal(39600, tz.period_for_local(DateTime.new(2004,10,31,3,0,0)).utc_total_offset)
-    
+
     transitions = tz.transitions_up_to(DateTime.new(2005,1,1,0,0,0), DateTime.new(2004,1,1,0,0,0))
     assert_equal(2, transitions.length)
     assert_equal(TimeOrDateTime.new(DateTime.new(2004,3,27,16,0,0)), transitions[0].at)
@@ -57,62 +57,62 @@ class TCTimezoneMelbourne < Minitest::Test
     assert_equal(TimeOrDateTime.new(DateTime.new(2004,10,30,16,0,0)), transitions[1].at)
     assert_equal(TimezoneOffset.new(36000, 0, :AEST), transitions[1].previous_offset)
     assert_equal(TimezoneOffset.new(36000, 3600, :AEDT), transitions[1].offset)
-    
+
     offsets = tz.offsets_up_to(DateTime.new(2005,1,1,0,0,0), DateTime.new(2004,1,1,0,0,0))
     assert_array_same_items([TimezoneOffset.new(36000, 0, :AEST), TimezoneOffset.new(36000, 3600, :AEDT)], offsets)
-  end  
+  end
 
   def test_1942
     # This test cannot be run when using ZoneinfoDataSource on platforms
-    # that don't support Times before the epoch (i.e. Ruby < 1.9 on Windows) 
+    # that don't support Times before the epoch (i.e. Ruby < 1.9 on Windows)
     # because it relates to the year 1942.
-    
+
     if !DataSource.get.kind_of?(ZoneinfoDataSource) || RubyCoreSupport.time_supports_negative
       #Australia/Melbourne  Sat Mar 28 14:59:59 1942 UTC = Sun Mar 29 01:59:59 1942 AEDT isdst=1 gmtoff=39600
       #Australia/Melbourne  Sat Mar 28 15:00:00 1942 UTC = Sun Mar 29 01:00:00 1942 AEST isdst=0 gmtoff=36000
       #Australia/Melbourne  Sat Sep 26 15:59:59 1942 UTC = Sun Sep 27 01:59:59 1942 AEST isdst=0 gmtoff=36000
       #Australia/Melbourne  Sat Sep 26 16:00:00 1942 UTC = Sun Sep 27 03:00:00 1942 AEDT isdst=1 gmtoff=39600
-      
+
       tz = Timezone.get('Australia/Melbourne')
       assert_equal(DateTime.new(1942,3,29,1,59,59), tz.utc_to_local(DateTime.new(1942,3,28,14,59,59)))
-      assert_equal(DateTime.new(1942,3,29,1,0,0), tz.utc_to_local(DateTime.new(1942,3,28,15,0,0)))    
+      assert_equal(DateTime.new(1942,3,29,1,0,0), tz.utc_to_local(DateTime.new(1942,3,28,15,0,0)))
       assert_equal(DateTime.new(1942,9,27,1,59,59), tz.utc_to_local(DateTime.new(1942,9,26,15,59,59)))
       assert_equal(DateTime.new(1942,9,27,3,0,0), tz.utc_to_local(DateTime.new(1942,9,26,16,0,0)))
-      
+
       assert_equal(DateTime.new(1942,3,28,14,59,59), tz.local_to_utc(DateTime.new(1942,3,29,1,59,59), true))
       assert_equal(DateTime.new(1942,3,28,15,59,59), tz.local_to_utc(DateTime.new(1942,3,29,1,59,59), false))
       assert_equal(DateTime.new(1942,3,28,14,0,0), tz.local_to_utc(DateTime.new(1942,3,29,1,0,0), true))
-      assert_equal(DateTime.new(1942,3,28,15,0,0), tz.local_to_utc(DateTime.new(1942,3,29,1,0,0), false))   
+      assert_equal(DateTime.new(1942,3,28,15,0,0), tz.local_to_utc(DateTime.new(1942,3,29,1,0,0), false))
       assert_equal(DateTime.new(1942,9,26,15,59,59), tz.local_to_utc(DateTime.new(1942,9,27,1,59,59)))
       assert_equal(DateTime.new(1942,9,26,16,0,0), tz.local_to_utc(DateTime.new(1942,9,27,3,0,0)))
-      
+
       assert_raises(PeriodNotFound) { tz.local_to_utc(DateTime.new(1942,9,27,2,0,0)) }
       assert_raises(AmbiguousTime) { tz.local_to_utc(DateTime.new(1942,3,29,1,0,0)) }
-      
+
       assert_equal(:AEDT, tz.period_for_utc(DateTime.new(1942,3,28,14,59,59)).zone_identifier)
       assert_equal(:AEST, tz.period_for_utc(DateTime.new(1942,3,28,15,0,0)).zone_identifier)
       assert_equal(:AEST, tz.period_for_utc(DateTime.new(1942,9,26,15,59,59)).zone_identifier)
       assert_equal(:AEDT, tz.period_for_utc(DateTime.new(1942,9,26,16,0,0)).zone_identifier)
-      
+
       assert_equal(:AEDT, tz.period_for_local(DateTime.new(1942,3,29,1,59,59), true).zone_identifier)
       assert_equal(:AEST, tz.period_for_local(DateTime.new(1942,3,29,1,59,59), false).zone_identifier)
       assert_equal(:AEDT, tz.period_for_local(DateTime.new(1942,3,29,1,0,0), true).zone_identifier)
       assert_equal(:AEST, tz.period_for_local(DateTime.new(1942,3,29,1,0,0), false).zone_identifier)
       assert_equal(:AEST, tz.period_for_local(DateTime.new(1942,9,27,1,59,59)).zone_identifier)
       assert_equal(:AEDT, tz.period_for_local(DateTime.new(1942,9,27,3,0,0)).zone_identifier)
-      
+
       assert_equal(39600, tz.period_for_utc(DateTime.new(1942,3,28,14,59,59)).utc_total_offset)
       assert_equal(36000, tz.period_for_utc(DateTime.new(1942,3,28,15,0,0)).utc_total_offset)
       assert_equal(36000, tz.period_for_utc(DateTime.new(1942,9,26,15,59,59)).utc_total_offset)
       assert_equal(39600, tz.period_for_utc(DateTime.new(1942,9,26,16,0,0)).utc_total_offset)
-      
+
       assert_equal(39600, tz.period_for_local(DateTime.new(1942,3,29,1,59,59), true).utc_total_offset)
       assert_equal(36000, tz.period_for_local(DateTime.new(1942,3,29,1,59,59), false).utc_total_offset)
       assert_equal(39600, tz.period_for_local(DateTime.new(1942,3,29,1,0,0), true).utc_total_offset)
       assert_equal(36000, tz.period_for_local(DateTime.new(1942,3,29,1,0,0), false).utc_total_offset)
       assert_equal(36000, tz.period_for_local(DateTime.new(1942,9,27,1,59,59)).utc_total_offset)
       assert_equal(39600, tz.period_for_local(DateTime.new(1942,9,27,3,0,0)).utc_total_offset)
-      
+
       transitions = tz.transitions_up_to(DateTime.new(1943,1,1,0,0,0), DateTime.new(1942,1,1,0,0,0))
       assert_equal(2, transitions.length)
       assert_equal(TimeOrDateTime.new(DateTime.new(1942,3,28,15,0,0)), transitions[0].at)
@@ -121,7 +121,7 @@ class TCTimezoneMelbourne < Minitest::Test
       assert_equal(TimeOrDateTime.new(DateTime.new(1942,9,26,16,0,0)), transitions[1].at)
       assert_equal(TimezoneOffset.new(36000, 0, :AEST), transitions[1].previous_offset)
       assert_equal(TimezoneOffset.new(36000, 3600, :AEDT), transitions[1].offset)
-      
+
       offsets = tz.offsets_up_to(DateTime.new(1943,1,1,0,0,0), DateTime.new(1942,1,1,0,0,0))
       assert_array_same_items([TimezoneOffset.new(36000, 0, :AEST), TimezoneOffset.new(36000, 3600, :AEDT)], offsets)
     end
@@ -130,13 +130,13 @@ class TCTimezoneMelbourne < Minitest::Test
   def test_time_boundary
     #Australia/Melbourne  Sat Mar 25 15:00:00 1944 UTC = Sun Mar 26 01:00:00 1944 AEST isdst=0 gmtoff=36000
     #Australia/Melbourne  Sat Oct 30 15:59:59 1971 UTC = Sun Oct 31 01:59:59 1971 AEST isdst=0 gmtoff=36000
-    
-    tz = Timezone.get('Australia/Melbourne')    
+
+    tz = Timezone.get('Australia/Melbourne')
     assert_equal(DateTime.new(1970,1,1,10,0,0), tz.utc_to_local(DateTime.new(1970,1,1,0,0,0)))
     assert_equal(DateTime.new(1970,1,1,0,0,0), tz.local_to_utc(DateTime.new(1970,1,1,10,0,0)))
     assert_equal(Time.utc(1970,1,1,10,0,0), tz.utc_to_local(Time.utc(1970,1,1,0,0,0)))
     assert_equal(Time.utc(1970,1,1,0,0,0), tz.local_to_utc(Time.utc(1970,1,1,10,0,0)))
     assert_equal(36000, tz.utc_to_local(0))
     assert_equal(0, tz.local_to_utc(36000))
-  end  
+  end
 end

--- a/test/tc_timezone_new_york.rb
+++ b/test/tc_timezone_new_york.rb
@@ -8,47 +8,47 @@ class TCTimezoneNewYork < Minitest::Test
     #America/New_York  Sun Apr  4 07:00:00 2004 UTC = Sun Apr  4 03:00:00 2004 EDT isdst=1 gmtoff=-14400
     #America/New_York  Sun Oct 31 05:59:59 2004 UTC = Sun Oct 31 01:59:59 2004 EDT isdst=1 gmtoff=-14400
     #America/New_York  Sun Oct 31 06:00:00 2004 UTC = Sun Oct 31 01:00:00 2004 EST isdst=0 gmtoff=-18000
-    
+
     tz = Timezone.get('America/New_York')
     assert_equal(DateTime.new(2004,4,4,1,59,59), tz.utc_to_local(DateTime.new(2004,4,4,6,59,59)))
-    assert_equal(DateTime.new(2004,4,4,3,0,0), tz.utc_to_local(DateTime.new(2004,4,4,7,0,0)))    
+    assert_equal(DateTime.new(2004,4,4,3,0,0), tz.utc_to_local(DateTime.new(2004,4,4,7,0,0)))
     assert_equal(DateTime.new(2004,10,31,1,59,59), tz.utc_to_local(DateTime.new(2004,10,31,5,59,59)))
     assert_equal(DateTime.new(2004,10,31,1,0,0), tz.utc_to_local(DateTime.new(2004,10,31,6,0,0)))
-    
+
     assert_equal(DateTime.new(2004,4,4,6,59,59), tz.local_to_utc(DateTime.new(2004,4,4,1,59,59)))
     assert_equal(DateTime.new(2004,4,4,7,0,0), tz.local_to_utc(DateTime.new(2004,4,4,3,0,0)))
     assert_equal(DateTime.new(2004,10,31,5,59,59), tz.local_to_utc(DateTime.new(2004,10,31,1,59,59), true))
     assert_equal(DateTime.new(2004,10,31,6,59,59), tz.local_to_utc(DateTime.new(2004,10,31,1,59,59), false))
     assert_equal(DateTime.new(2004,10,31,5,0,0), tz.local_to_utc(DateTime.new(2004,10,31,1,0,0), true))
     assert_equal(DateTime.new(2004,10,31,6,0,0), tz.local_to_utc(DateTime.new(2004,10,31,1,0,0), false))
-    
+
     assert_raises(PeriodNotFound) { tz.local_to_utc(DateTime.new(2004,4,4,2,0,0)) }
     assert_raises(AmbiguousTime) { tz.local_to_utc(DateTime.new(2004,10,31,1,0,0)) }
-    
+
     assert_equal(:EST, tz.period_for_utc(DateTime.new(2004,4,4,6,59,59)).zone_identifier)
     assert_equal(:EDT, tz.period_for_utc(DateTime.new(2004,4,4,7,0,0)).zone_identifier)
     assert_equal(:EDT, tz.period_for_utc(DateTime.new(2004,10,31,5,59,59)).zone_identifier)
     assert_equal(:EST, tz.period_for_utc(DateTime.new(2004,10,31,6,0,0)).zone_identifier)
-    
+
     assert_equal(:EST, tz.period_for_local(DateTime.new(2004,4,4,1,59,59)).zone_identifier)
     assert_equal(:EDT, tz.period_for_local(DateTime.new(2004,4,4,3,0,0)).zone_identifier)
     assert_equal(:EDT, tz.period_for_local(DateTime.new(2004,10,31,1,59,59), true).zone_identifier)
     assert_equal(:EST, tz.period_for_local(DateTime.new(2004,10,31,1,59,59), false).zone_identifier)
     assert_equal(:EDT, tz.period_for_local(DateTime.new(2004,10,31,1,0,0), true).zone_identifier)
     assert_equal(:EST, tz.period_for_local(DateTime.new(2004,10,31,1,0,0), false).zone_identifier)
-    
+
     assert_equal(-18000, tz.period_for_utc(DateTime.new(2004,4,4,6,59,59)).utc_total_offset)
     assert_equal(-14400, tz.period_for_utc(DateTime.new(2004,4,4,7,0,0)).utc_total_offset)
     assert_equal(-14400, tz.period_for_utc(DateTime.new(2004,10,31,5,59,59)).utc_total_offset)
     assert_equal(-18000, tz.period_for_utc(DateTime.new(2004,10,31,6,0,0)).utc_total_offset)
-    
+
     assert_equal(-18000, tz.period_for_local(DateTime.new(2004,4,4,1,59,59)).utc_total_offset)
     assert_equal(-14400, tz.period_for_local(DateTime.new(2004,4,4,3,0,0)).utc_total_offset)
     assert_equal(-14400, tz.period_for_local(DateTime.new(2004,10,31,1,59,59), true).utc_total_offset)
     assert_equal(-18000, tz.period_for_local(DateTime.new(2004,10,31,1,59,59), false).utc_total_offset)
     assert_equal(-14400, tz.period_for_local(DateTime.new(2004,10,31,1,0,0), true).utc_total_offset)
     assert_equal(-18000, tz.period_for_local(DateTime.new(2004,10,31,1,0,0), false).utc_total_offset)
-    
+
     transitions = tz.transitions_up_to(DateTime.new(2005,1,1,0,0,0), DateTime.new(2004,1,1,0,0,0))
     assert_equal(2, transitions.length)
     assert_equal(TimeOrDateTime.new(DateTime.new(2004,4,4,7,0,0)), transitions[0].at)
@@ -57,62 +57,62 @@ class TCTimezoneNewYork < Minitest::Test
     assert_equal(TimeOrDateTime.new(DateTime.new(2004,10,31,6,0,0)), transitions[1].at)
     assert_equal(TimezoneOffset.new(-18000, 3600, :EDT), transitions[1].previous_offset)
     assert_equal(TimezoneOffset.new(-18000, 0, :EST), transitions[1].offset)
-    
+
     offsets = tz.offsets_up_to(DateTime.new(2005,1,1,0,0,0), DateTime.new(2004,1,1,0,0,0))
     assert_array_same_items([TimezoneOffset.new(-18000, 0, :EST), TimezoneOffset.new(-18000, 3600, :EDT)], offsets)
-  end     
+  end
 
   def test_1957
     # This test cannot be run when using ZoneinfoDataSource on platforms
-    # that don't support Times before the epoch (i.e. Ruby < 1.9 on Windows) 
+    # that don't support Times before the epoch (i.e. Ruby < 1.9 on Windows)
     # because it relates to the year 1957.
-    
+
     if !DataSource.get.kind_of?(ZoneinfoDataSource) || RubyCoreSupport.time_supports_negative
       #America/New_York  Sun Apr 28 06:59:59 1957 UTC = Sun Apr 28 01:59:59 1957 EST isdst=0 gmtoff=-18000
       #America/New_York  Sun Apr 28 07:00:00 1957 UTC = Sun Apr 28 03:00:00 1957 EDT isdst=1 gmtoff=-14400
       #America/New_York  Sun Oct 27 05:59:59 1957 UTC = Sun Oct 27 01:59:59 1957 EDT isdst=1 gmtoff=-14400
       #America/New_York  Sun Oct 27 06:00:00 1957 UTC = Sun Oct 27 01:00:00 1957 EST isdst=0 gmtoff=-18000
-      
+
       tz = Timezone.get('America/New_York')
       assert_equal(DateTime.new(1957,4,28,1,59,59), tz.utc_to_local(DateTime.new(1957,4,28,6,59,59)))
-      assert_equal(DateTime.new(1957,4,28,3,0,0), tz.utc_to_local(DateTime.new(1957,4,28,7,0,0)))    
+      assert_equal(DateTime.new(1957,4,28,3,0,0), tz.utc_to_local(DateTime.new(1957,4,28,7,0,0)))
       assert_equal(DateTime.new(1957,10,27,1,59,59), tz.utc_to_local(DateTime.new(1957,10,27,5,59,59)))
       assert_equal(DateTime.new(1957,10,27,1,0,0), tz.utc_to_local(DateTime.new(1957,10,27,6,0,0)))
-      
+
       assert_equal(DateTime.new(1957,4,28,6,59,59), tz.local_to_utc(DateTime.new(1957,4,28,1,59,59)))
       assert_equal(DateTime.new(1957,4,28,7,0,0), tz.local_to_utc(DateTime.new(1957,4,28,3,0,0)))
       assert_equal(DateTime.new(1957,10,27,5,59,59), tz.local_to_utc(DateTime.new(1957,10,27,1,59,59), true))
       assert_equal(DateTime.new(1957,10,27,6,59,59), tz.local_to_utc(DateTime.new(1957,10,27,1,59,59), false))
       assert_equal(DateTime.new(1957,10,27,5,0,0), tz.local_to_utc(DateTime.new(1957,10,27,1,0,0), true))
       assert_equal(DateTime.new(1957,10,27,6,0,0), tz.local_to_utc(DateTime.new(1957,10,27,1,0,0), false))
-      
+
       assert_raises(PeriodNotFound) { tz.local_to_utc(DateTime.new(1957,4,28,2,0,0)) }
       assert_raises(AmbiguousTime) { tz.local_to_utc(DateTime.new(1957,10,27,1,0,0)) }
-      
+
       assert_equal(:EST, tz.period_for_utc(DateTime.new(1957,4,28,6,59,59)).zone_identifier)
       assert_equal(:EDT, tz.period_for_utc(DateTime.new(1957,4,28,7,0,0)).zone_identifier)
       assert_equal(:EDT, tz.period_for_utc(DateTime.new(1957,10,27,5,59,59)).zone_identifier)
       assert_equal(:EST, tz.period_for_utc(DateTime.new(1957,10,27,6,0,0)).zone_identifier)
-      
+
       assert_equal(:EST, tz.period_for_local(DateTime.new(1957,4,28,1,59,59)).zone_identifier)
       assert_equal(:EDT, tz.period_for_local(DateTime.new(1957,4,28,3,0,0)).zone_identifier)
       assert_equal(:EDT, tz.period_for_local(DateTime.new(1957,10,27,1,59,59), true).zone_identifier)
       assert_equal(:EST, tz.period_for_local(DateTime.new(1957,10,27,1,59,59), false).zone_identifier)
       assert_equal(:EDT, tz.period_for_local(DateTime.new(1957,10,27,1,0,0), true).zone_identifier)
       assert_equal(:EST, tz.period_for_local(DateTime.new(1957,10,27,1,0,0), false).zone_identifier)
-      
+
       assert_equal(-18000, tz.period_for_utc(DateTime.new(1957,4,28,6,59,59)).utc_total_offset)
       assert_equal(-14400, tz.period_for_utc(DateTime.new(1957,4,28,7,0,0)).utc_total_offset)
       assert_equal(-14400, tz.period_for_utc(DateTime.new(1957,10,27,5,59,59)).utc_total_offset)
       assert_equal(-18000, tz.period_for_utc(DateTime.new(1957,10,27,6,0,0)).utc_total_offset)
-      
+
       assert_equal(-18000, tz.period_for_local(DateTime.new(1957,4,28,1,59,59)).utc_total_offset)
       assert_equal(-14400, tz.period_for_local(DateTime.new(1957,4,28,3,0,0)).utc_total_offset)
       assert_equal(-14400, tz.period_for_local(DateTime.new(1957,10,27,1,59,59), true).utc_total_offset)
       assert_equal(-18000, tz.period_for_local(DateTime.new(1957,10,27,1,59,59), false).utc_total_offset)
       assert_equal(-14400, tz.period_for_local(DateTime.new(1957,10,27,1,0,0), true).utc_total_offset)
       assert_equal(-18000, tz.period_for_local(DateTime.new(1957,10,27,1,0,0), false).utc_total_offset)
-      
+
       transitions = tz.transitions_up_to(DateTime.new(1958,1,1,0,0,0), DateTime.new(1957,1,1,0,0,0))
       assert_equal(2, transitions.length)
       assert_equal(TimeOrDateTime.new(DateTime.new(1957,4,28,7,0,0)), transitions[0].at)
@@ -121,17 +121,17 @@ class TCTimezoneNewYork < Minitest::Test
       assert_equal(TimeOrDateTime.new(DateTime.new(1957,10,27,6,0,0)), transitions[1].at)
       assert_equal(TimezoneOffset.new(-18000, 3600, :EDT), transitions[1].previous_offset)
       assert_equal(TimezoneOffset.new(-18000, 0, :EST), transitions[1].offset)
-      
+
       offsets = tz.offsets_up_to(DateTime.new(1958,1,1,0,0,0), DateTime.new(1957,1,1,0,0,0))
       assert_array_same_items([TimezoneOffset.new(-18000, 0, :EST), TimezoneOffset.new(-18000, 3600, :EDT)], offsets)
     end
   end
-  
+
   def test_time_boundary
     #America/New_York  Sun Oct 26 06:00:00 1969 UTC = Sun Oct 26 01:00:00 1969 EST isdst=0 gmtoff=-18000
     #America/New_York  Sun Apr 26 06:59:59 1970 UTC = Sun Apr 26 01:59:59 1970 EST isdst=0 gmtoff=-18000
-    
-    tz = Timezone.get('America/New_York')    
+
+    tz = Timezone.get('America/New_York')
     assert_equal(DateTime.new(1970,1,1,0,0,0), tz.utc_to_local(DateTime.new(1970,1,1,5,0,0)))
     assert_equal(DateTime.new(1970,1,1,5,0,0), tz.local_to_utc(DateTime.new(1970,1,1,0,0,0)))
     assert_equal(Time.utc(1970,1,1,0,0,0), tz.utc_to_local(Time.utc(1970,1,1,5,0,0)))

--- a/test/tc_timezone_offset.rb
+++ b/test/tc_timezone_offset.rb
@@ -3,51 +3,51 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 include TZInfo
 
 class TCTimezoneOffset < Minitest::Test
-  
+
   def test_utc_offset
     o1 = TimezoneOffset.new(18000, 0, :TEST)
     o2 = TimezoneOffset.new(-3600, 3600, :TEST2)
-    
+
     assert_equal(18000, o1.utc_offset)
     assert_equal(-3600, o2.utc_offset)
   end
-  
+
   def test_std_offset
     o1 = TimezoneOffset.new(18000, 0, :TEST)
     o2 = TimezoneOffset.new(-3600, 3600, :TEST2)
-    
+
     assert_equal(0, o1.std_offset)
     assert_equal(3600, o2.std_offset)
   end
-  
+
   def test_utc_total_offset
     o1 = TimezoneOffset.new(18000, 0, :TEST)
     o2 = TimezoneOffset.new(-3600, 3600, :TEST2)
-    
+
     assert_equal(18000, o1.utc_total_offset)
     assert_equal(0, o2.utc_total_offset)
   end
-  
+
   def test_abbreviation
     o1 = TimezoneOffset.new(18000, 0, :TEST)
     o2 = TimezoneOffset.new(-3600, 3600, :TEST2)
-    
+
     assert_equal(:TEST, o1.abbreviation)
     assert_equal(:TEST2, o2.abbreviation)
   end
-  
+
   def test_dst
     o1 = TimezoneOffset.new(18000, 0, :TEST)
     o2 = TimezoneOffset.new(-3600, 3600, :TEST2)
-    
+
     assert_equal(false, o1.dst?)
     assert_equal(true, o2.dst?)
   end
-  
+
   def test_to_local
     o1 = TimezoneOffset.new(18000, 0, :TEST)
     o2 = TimezoneOffset.new(-3600, 3600, :TEST2)
-    
+
     assert_equal(1148949080, o1.to_local(1148931080))
     assert_equal(Time.utc(2006, 5, 30, 0, 31, 20), o1.to_local(Time.utc(2006, 5, 29, 19, 31, 20)))
     assert_equal(Time.utc(2006, 5, 30, 0, 31, 20, 782000), o1.to_local(Time.utc(2006, 5, 29, 19, 31, 20, 782000)))
@@ -55,7 +55,7 @@ class TCTimezoneOffset < Minitest::Test
     assert_equal(DateTime.new(2006, 5, 30, 0, 31, 20 + Rational(782, 1000)), o1.to_local(DateTime.new(2006, 5, 29, 19, 31, 20 + Rational(782, 1000))))
     assert_equal(1148949080, o1.to_local(1148931080))
     assert(TimeOrDateTime.new(1148949080).eql?(o1.to_local(TimeOrDateTime.new(1148931080))))
-    
+
     assert_equal(1148931080, o2.to_local(1148931080))
     assert_equal(Time.utc(2006, 5, 29, 19, 31, 20), o2.to_local(Time.utc(2006, 5, 29, 19, 31, 20)))
     assert_equal(Time.utc(2006, 5, 29, 19, 31, 20, 123000), o2.to_local(Time.utc(2006, 5, 29, 19, 31, 20, 123000)))
@@ -64,11 +64,11 @@ class TCTimezoneOffset < Minitest::Test
     assert_equal(1148931080, o2.to_local(1148931080))
     assert(TimeOrDateTime.new(1148931080).eql?(o2.to_local(TimeOrDateTime.new(1148931080))))
   end
-  
+
   def test_to_utc
     o1 = TimezoneOffset.new(18000, 0, :TEST)
     o2 = TimezoneOffset.new(-3600, 3600, :TEST2)
-    
+
     assert_equal(1148913080, o1.to_utc(1148931080))
     assert_equal(Time.utc(2006, 5, 29, 14, 31, 20), o1.to_utc(Time.utc(2006, 5, 29, 19, 31, 20)))
     assert_equal(Time.utc(2006, 5, 29, 14, 31, 20, 913000), o1.to_utc(Time.utc(2006, 5, 29, 19, 31, 20, 913000)))
@@ -76,23 +76,23 @@ class TCTimezoneOffset < Minitest::Test
     assert_equal(DateTime.new(2006, 5, 29, 14, 31, 20 + Rational(913,1000)), o1.to_utc(DateTime.new(2006, 5, 29, 19, 31, 20 + Rational(913,1000))))
     assert_equal(1148913080, o1.to_utc(1148931080))
     assert(TimeOrDateTime.new(1148913080).eql?(o1.to_utc(TimeOrDateTime.new(1148931080))))
-    
+
     assert_equal(1148931080, o2.to_local(1148931080))
     assert_equal(Time.utc(2006, 5, 29, 19, 31, 20), o2.to_local(Time.utc(2006, 5, 29, 19, 31, 20)))
     assert_equal(Time.utc(2006, 5, 29, 19, 31, 20, 323000), o2.to_local(Time.utc(2006, 5, 29, 19, 31, 20, 323000)))
     assert_equal(DateTime.new(2006, 5, 29, 19, 31, 20), o2.to_local(DateTime.new(2006, 5, 29, 19, 31, 20)))
     assert_equal(DateTime.new(2006, 5, 29, 19, 31, 20 + Rational(323, 1000)), o2.to_local(DateTime.new(2006, 5, 29, 19, 31, 20 + Rational(323, 1000))))
     assert_equal(1148931080, o2.to_utc(1148931080))
-    assert(TimeOrDateTime.new(1148931080).eql?(o2.to_local(TimeOrDateTime.new(1148931080))))    
+    assert(TimeOrDateTime.new(1148931080).eql?(o2.to_local(TimeOrDateTime.new(1148931080))))
   end
-  
+
   def test_equality
     o1 = TimezoneOffset.new(18000, 0, :TEST)
     o2 = TimezoneOffset.new(18000, 0, :TEST)
     o3 = TimezoneOffset.new(18001, 0, :TEST)
     o4 = TimezoneOffset.new(18000, 1, :TEST)
     o5 = TimezoneOffset.new(18000, 0, :TEST2)
-    
+
     assert_equal(true, o1 == o1)
     assert_equal(true, o1 == o2)
     assert_equal(false, o1 == o3)
@@ -100,14 +100,14 @@ class TCTimezoneOffset < Minitest::Test
     assert_equal(false, o1 == o5)
     assert_equal(false, o1 == Object.new)
   end
-  
+
   def test_eql
     o1 = TimezoneOffset.new(18000, 0, :TEST)
     o2 = TimezoneOffset.new(18000, 0, :TEST)
     o3 = TimezoneOffset.new(18001, 0, :TEST)
     o4 = TimezoneOffset.new(18000, 1, :TEST)
     o5 = TimezoneOffset.new(18000, 0, :TEST2)
-    
+
     assert_equal(true, o1.eql?(o1))
     assert_equal(true, o1.eql?(o2))
     assert_equal(false, o1.eql?(o3))
@@ -115,11 +115,11 @@ class TCTimezoneOffset < Minitest::Test
     assert_equal(false, o1.eql?(o5))
     assert_equal(false, o1.eql?(Object.new))
   end
-  
+
   def test_hash
     o1 = TimezoneOffset.new(18000, 0, :TEST)
     o2 = TimezoneOffset.new(-3600, 3600, :TEST2)
-    
+
     assert_equal(18000.hash ^ 0.hash ^ :TEST.hash, o1.hash)
     assert_equal(-3600.hash ^ 3600.hash ^ :TEST2.hash, o2.hash)
   end

--- a/test/tc_timezone_period.rb
+++ b/test/tc_timezone_period.rb
@@ -3,26 +3,26 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 include TZInfo
 
 class TCTimezonePeriod < Minitest::Test
-  
+
   class TestTimezoneTransition < TimezoneTransition
     def initialize(offset, previous_offset, at)
       super(offset, previous_offset)
       @at = TimeOrDateTime.wrap(at)
     end
-    
+
     def at
       @at
     end
   end
-  
+
   def test_initialize_start_end
     std = TimezoneOffset.new(-7200, 0, :TEST)
     dst = TimezoneOffset.new(-7200, 3600, :TEST)
     start_t = TestTimezoneTransition.new(dst, std, 1136073600)
     end_t = TestTimezoneTransition.new(std, dst, 1136160000)
-      
+
     p = TimezonePeriod.new(start_t, end_t)
-    
+
     assert_same(start_t, p.start_transition)
     assert_same(end_t, p.end_transition)
     assert_same(dst, p.offset)
@@ -35,30 +35,30 @@ class TCTimezonePeriod < Minitest::Test
     assert_equal(-3600, p.utc_total_offset)
     assert_equal(Rational(-3600, 86400), p.utc_total_offset_rational)
     assert_equal(:TEST, p.zone_identifier)
-    assert_equal(:TEST, p.abbreviation)    
+    assert_equal(:TEST, p.abbreviation)
     assert_equal(DateTime.new(2005,12,31,23,0,0), p.local_start)
     assert_equal(Time.utc(2005,12,31,23,0,0), p.local_start_time)
     assert_equal(DateTime.new(2006,1,1,23,0,0), p.local_end)
     assert_equal(Time.utc(2006,1,1,23,0,0), p.local_end_time)
   end
-  
+
   def test_initialize_start_end_offset
     std = TimezoneOffset.new(-7200, 0, :TEST)
     dst = TimezoneOffset.new(-7200, 3600, :TEST)
     special = TimezoneOffset.new(0, 0, :SPECIAL)
     start_t = TestTimezoneTransition.new(dst, std, 1136073600)
     end_t = TestTimezoneTransition.new(std, dst, 1136160000)
-      
+
     assert_raises(ArgumentError) { TimezonePeriod.new(start_t, end_t, special) }
   end
-  
+
   def test_initialize_start
     std = TimezoneOffset.new(-7200, 0, :TEST)
     dst = TimezoneOffset.new(-7200, 3600, :TEST)
     start_t = TestTimezoneTransition.new(dst, std, 1136073600)
-      
+
     p = TimezonePeriod.new(start_t, nil)
-    
+
     assert_same(start_t, p.start_transition)
     assert_nil(p.end_transition)
     assert_same(dst, p.offset)
@@ -71,29 +71,29 @@ class TCTimezonePeriod < Minitest::Test
     assert_equal(-3600, p.utc_total_offset)
     assert_equal(Rational(-3600, 86400), p.utc_total_offset_rational)
     assert_equal(:TEST, p.zone_identifier)
-    assert_equal(:TEST, p.abbreviation)    
+    assert_equal(:TEST, p.abbreviation)
     assert_equal(DateTime.new(2005,12,31,23,0,0), p.local_start)
     assert_equal(Time.utc(2005,12,31,23,0,0), p.local_start_time)
     assert_nil(p.local_end)
     assert_nil(p.local_end_time)
   end
-  
+
   def test_initialize_start_offset
     std = TimezoneOffset.new(-7200, 0, :TEST)
     dst = TimezoneOffset.new(-7200, 3600, :TEST)
     special = TimezoneOffset.new(0, 0, :SPECIAL)
     start_t = TestTimezoneTransition.new(dst, std, 1136073600)
-      
+
     assert_raises(ArgumentError) { TimezonePeriod.new(start_t, nil, special) }
   end
-  
+
   def test_initialize_end
     std = TimezoneOffset.new(-7200, 0, :TEST)
-    dst = TimezoneOffset.new(-7200, 3600, :TEST)    
+    dst = TimezoneOffset.new(-7200, 3600, :TEST)
     end_t = TestTimezoneTransition.new(std, dst, 1136160000)
-      
+
     p = TimezonePeriod.new(nil, end_t)
-    
+
     assert_nil(p.start_transition)
     assert_same(end_t, p.end_transition)
     assert_same(dst, p.offset)
@@ -106,31 +106,31 @@ class TCTimezonePeriod < Minitest::Test
     assert_equal(-3600, p.utc_total_offset)
     assert_equal(Rational(-3600, 86400), p.utc_total_offset_rational)
     assert_equal(:TEST, p.zone_identifier)
-    assert_equal(:TEST, p.abbreviation)    
+    assert_equal(:TEST, p.abbreviation)
     assert_nil(p.local_start)
     assert_nil(p.local_start_time)
     assert_equal(DateTime.new(2006,1,1,23,0,0), p.local_end)
     assert_equal(Time.utc(2006,1,1,23,0,0), p.local_end_time)
   end
-  
+
   def test_initialize_end_offset
     std = TimezoneOffset.new(-7200, 0, :TEST)
-    dst = TimezoneOffset.new(-7200, 3600, :TEST)    
+    dst = TimezoneOffset.new(-7200, 3600, :TEST)
     special = TimezoneOffset.new(0, 0, :SPECIAL)
     end_t = TestTimezoneTransition.new(std, dst, 1136160000)
-      
-    assert_raises(ArgumentError) { TimezonePeriod.new(nil, end_t, special) }    
+
+    assert_raises(ArgumentError) { TimezonePeriod.new(nil, end_t, special) }
   end
-  
+
   def test_initialize
     assert_raises(ArgumentError) { TimezonePeriod.new(nil, nil) }
   end
-  
+
   def test_initialize_offset
     special = TimezoneOffset.new(0, 0, :SPECIAL)
-      
+
     p = TimezonePeriod.new(nil, nil, special)
-    
+
     assert_nil(p.start_transition)
     assert_nil(p.end_transition)
     assert_same(special, p.offset)
@@ -143,40 +143,40 @@ class TCTimezonePeriod < Minitest::Test
     assert_equal(0, p.utc_total_offset)
     assert_equal(Rational(0, 86400), p.utc_total_offset_rational)
     assert_equal(:SPECIAL, p.zone_identifier)
-    assert_equal(:SPECIAL, p.abbreviation)    
+    assert_equal(:SPECIAL, p.abbreviation)
     assert_nil(p.local_start)
     assert_nil(p.local_start_time)
     assert_nil(p.local_end)
     assert_nil(p.local_end_time)
   end
-  
-  def test_dst    
+
+  def test_dst
     p1 = TimezonePeriod.new(nil, nil, TimezoneOffset.new(-14400, 3600, :TEST))
     p2 = TimezonePeriod.new(nil, nil, TimezoneOffset.new(-14400, 0, :TEST))
     p3 = TimezonePeriod.new(nil, nil, TimezoneOffset.new(-14400, -3600, :TEST))
     p4 = TimezonePeriod.new(nil, nil, TimezoneOffset.new(-14400, 7200, :TEST))
     p5 = TimezonePeriod.new(nil, nil, TimezoneOffset.new(-14400, -7200, :TEST))
-    
+
     assert_equal(true, p1.dst?)
     assert_equal(false, p2.dst?)
     assert_equal(true, p3.dst?)
     assert_equal(true, p4.dst?)
     assert_equal(true, p5.dst?)
   end
-  
+
   def test_valid_for_utc
     offset = TimezoneOffset.new(-7200, 3600, :TEST)
     t1 = TestTimezoneTransition.new(offset, offset, 1104541261)
     t2 = TestTimezoneTransition.new(offset, offset, 1107309722)
     t3 = TestTimezoneTransition.new(offset, offset, DateTime.new(1960, 1, 1, 1, 1, 1))
     t4 = TestTimezoneTransition.new(offset, offset, DateTime.new(1960, 2, 2, 2, 2, 2))
-    
+
     p1 = TimezonePeriod.new(t1, t2)
     p2 = TimezonePeriod.new(nil, t2)
     p3 = TimezonePeriod.new(t1, nil)
     p4 = TimezonePeriod.new(nil, nil, offset)
     p5 = TimezonePeriod.new(t3, t4)
-    
+
     assert_equal(true, p1.valid_for_utc?(DateTime.new(2005,1,1,1,1,1)))
     assert_equal(true, p1.valid_for_utc?(Time.utc(2005,2,2,2,2,1)))
     assert_equal(true, p1.valid_for_utc?(1104541262))
@@ -185,16 +185,16 @@ class TCTimezonePeriod < Minitest::Test
     assert_equal(false, p1.valid_for_utc?(DateTime.new(2005,2,2,2,2,3)))
     assert_equal(false, p1.valid_for_utc?(DateTime.new(1960,1,1,1,1,0)))
     assert_equal(false, p1.valid_for_utc?(DateTime.new(2040,1,1,1,1,0)))
-    
+
     assert_equal(true, p2.valid_for_utc?(DateTime.new(2005,1,1,1,1,1)))
     assert_equal(true, p2.valid_for_utc?(Time.utc(2005,2,2,2,2,1)))
     assert_equal(true, p2.valid_for_utc?(1104541262))
     assert_equal(true, p2.valid_for_utc?(DateTime.new(2005,2,2,2,2,0)))
-    assert_equal(true, p2.valid_for_utc?(DateTime.new(2005,1,1,1,1,0)))    
+    assert_equal(true, p2.valid_for_utc?(DateTime.new(2005,1,1,1,1,0)))
     assert_equal(false, p2.valid_for_utc?(DateTime.new(2005,2,2,2,2,3)))
     assert_equal(true, p2.valid_for_utc?(DateTime.new(1960,1,1,1,1,0)))
     assert_equal(false, p2.valid_for_utc?(DateTime.new(2040,1,1,1,1,0)))
-    
+
     assert_equal(true, p3.valid_for_utc?(DateTime.new(2005,1,1,1,1,1)))
     assert_equal(true, p3.valid_for_utc?(Time.utc(2005,2,2,2,2,1)))
     assert_equal(true, p3.valid_for_utc?(1104541262))
@@ -203,7 +203,7 @@ class TCTimezonePeriod < Minitest::Test
     assert_equal(true, p3.valid_for_utc?(DateTime.new(2005,2,2,2,2,3)))
     assert_equal(false, p3.valid_for_utc?(DateTime.new(1960,1,1,1,1,0)))
     assert_equal(true, p3.valid_for_utc?(DateTime.new(2040,1,1,1,1,0)))
-    
+
     assert_equal(true, p4.valid_for_utc?(DateTime.new(2005,1,1,1,1,1)))
     assert_equal(true, p4.valid_for_utc?(Time.utc(2005,2,2,2,2,1)))
     assert_equal(true, p4.valid_for_utc?(1104541262))
@@ -212,61 +212,61 @@ class TCTimezonePeriod < Minitest::Test
     assert_equal(true, p4.valid_for_utc?(DateTime.new(2005,2,2,2,2,3)))
     assert_equal(true, p4.valid_for_utc?(DateTime.new(1960,1,1,1,1,0)))
     assert_equal(true, p4.valid_for_utc?(DateTime.new(2040,1,1,1,1,0)))
-    
+
     assert_equal(false, p5.valid_for_utc?(Time.utc(2005,1,1,1,1,1)))
     assert_equal(false, p5.valid_for_utc?(1104541262))
   end
-  
+
   def test_utc_after_start
     offset = TimezoneOffset.new(-7200, 3600, :TEST)
     t1 = TestTimezoneTransition.new(offset, offset, 1104541261)
     t2 = TestTimezoneTransition.new(offset, offset, 1107309722)
     t3 = TestTimezoneTransition.new(offset, offset, DateTime.new(1945, 1, 1, 1, 1, 1))
     t4 = TestTimezoneTransition.new(offset, offset, DateTime.new(1945, 2, 2, 2, 2, 2))
-    
+
     p1 = TimezonePeriod.new(t1, t2)
     p2 = TimezonePeriod.new(nil, t2)
     p3 = TimezonePeriod.new(t3, t4)
 
-    assert_equal(true, p1.utc_after_start?(DateTime.new(2005,1,1,1,1,1)))    
+    assert_equal(true, p1.utc_after_start?(DateTime.new(2005,1,1,1,1,1)))
     assert_equal(true, p1.utc_after_start?(Time.utc(2005,1,1,1,1,2)))
     assert_equal(false, p1.utc_after_start?(1104541260))
     assert_equal(true, p1.utc_after_start?(DateTime.new(2045,1,1,1,1,0)))
     assert_equal(false, p1.utc_after_start?(DateTime.new(1955,1,1,1,1,0)))
 
-    assert_equal(true, p2.utc_after_start?(DateTime.new(2005,1,1,1,1,1)))    
+    assert_equal(true, p2.utc_after_start?(DateTime.new(2005,1,1,1,1,1)))
     assert_equal(true, p2.utc_after_start?(Time.utc(2005,1,1,1,1,2)))
-    assert_equal(true, p2.utc_after_start?(1104541260)) 
-    
+    assert_equal(true, p2.utc_after_start?(1104541260))
+
     assert_equal(true, p3.utc_after_start?(Time.utc(2005,1,2,1,1,1)))
     assert_equal(true, p3.utc_after_start?(1104627661))
   end
-  
+
   def test_utc_before_end
     offset = TimezoneOffset.new(-7200, 3600, :TEST)
     t1 = TestTimezoneTransition.new(offset, offset, 1104541261)
     t2 = TestTimezoneTransition.new(offset, offset, 1107309722)
     t3 = TestTimezoneTransition.new(offset, offset, DateTime.new(1945, 1, 1, 1, 1, 1))
     t4 = TestTimezoneTransition.new(offset, offset, DateTime.new(1945, 2, 2, 2, 2, 2))
-    
+
     p1 = TimezonePeriod.new(t1, t2)
     p2 = TimezonePeriod.new(t1, nil)
     p3 = TimezonePeriod.new(t3, t4)
-    
-    assert_equal(true, p1.utc_before_end?(DateTime.new(2005,2,2,2,2,1)))    
-    assert_equal(true, p1.utc_before_end?(Time.utc(2005,2,2,2,2,0)))   
+
+    assert_equal(true, p1.utc_before_end?(DateTime.new(2005,2,2,2,2,1)))
+    assert_equal(true, p1.utc_before_end?(Time.utc(2005,2,2,2,2,0)))
     assert_equal(false, p1.utc_before_end?(1107309723))
     assert_equal(false, p1.utc_before_end?(DateTime.new(2045,1,1,1,1,0)))
     assert_equal(true, p1.utc_before_end?(DateTime.new(1955,1,1,1,1,0)))
-    
-    assert_equal(true, p2.utc_before_end?(DateTime.new(2005,2,2,2,2,1)))    
-    assert_equal(true, p2.utc_before_end?(Time.utc(2005,2,2,2,2,0)))   
+
+    assert_equal(true, p2.utc_before_end?(DateTime.new(2005,2,2,2,2,1)))
+    assert_equal(true, p2.utc_before_end?(Time.utc(2005,2,2,2,2,0)))
     assert_equal(true, p2.utc_before_end?(1107309723))
-    
+
     assert_equal(false, p3.utc_before_end?(Time.utc(2005,1,2,1,1,1)))
     assert_equal(false, p3.utc_before_end?(1104627661))
   end
-  
+
   def test_valid_for_local
     offset = TimezoneOffset.new(-7200, 3600, :TEST)
     t1 = TestTimezoneTransition.new(offset, offset, 1104544861)
@@ -274,13 +274,13 @@ class TCTimezonePeriod < Minitest::Test
     t3 = TestTimezoneTransition.new(offset, offset, 1104544861)
     t4 = TestTimezoneTransition.new(offset, offset, DateTime.new(1960, 1, 1, 1, 1, 1))
     t5 = TestTimezoneTransition.new(offset, offset, DateTime.new(1960, 2, 2, 2, 2, 2))
-    
+
     p1 = TimezonePeriod.new(t1, t2)
     p2 = TimezonePeriod.new(nil, t2)
     p3 = TimezonePeriod.new(t3, nil)
     p4 = TimezonePeriod.new(nil, nil, offset)
     p5 = TimezonePeriod.new(t4, t5)
-    
+
     assert_equal(true, p1.valid_for_local?(DateTime.new(2005,1,1,1,1,1)))
     assert_equal(true, p1.valid_for_local?(Time.utc(2005,2,2,2,2,1)))
     assert_equal(true, p1.valid_for_local?(1104541262))
@@ -289,7 +289,7 @@ class TCTimezonePeriod < Minitest::Test
     assert_equal(false, p1.valid_for_local?(DateTime.new(2005,2,2,2,2,3)))
     assert_equal(false, p1.valid_for_local?(DateTime.new(1960,1,1,1,1,0)))
     assert_equal(false, p1.valid_for_local?(DateTime.new(2040,1,1,1,1,0)))
-    
+
     assert_equal(true, p2.valid_for_local?(DateTime.new(2005,1,1,1,1,1)))
     assert_equal(true, p2.valid_for_local?(DateTime.new(2005,2,2,2,2,1)))
     assert_equal(true, p2.valid_for_local?(1104541262))
@@ -298,7 +298,7 @@ class TCTimezonePeriod < Minitest::Test
     assert_equal(false, p2.valid_for_local?(DateTime.new(2005,2,2,2,2,3)))
     assert_equal(true, p2.valid_for_local?(DateTime.new(1960,1,1,1,1,0)))
     assert_equal(false, p2.valid_for_local?(DateTime.new(2040,1,1,1,1,0)))
-    
+
     assert_equal(true, p3.valid_for_local?(DateTime.new(2005,1,1,1,1,1)))
     assert_equal(true, p3.valid_for_local?(DateTime.new(2005,2,2,2,2,1)))
     assert_equal(true, p3.valid_for_local?(1104541262))
@@ -307,7 +307,7 @@ class TCTimezonePeriod < Minitest::Test
     assert_equal(true, p3.valid_for_local?(DateTime.new(2005,2,2,2,2,3)))
     assert_equal(false, p3.valid_for_local?(DateTime.new(1960,1,1,1,1,0)))
     assert_equal(true, p3.valid_for_local?(DateTime.new(2040,1,1,1,1,0)))
-    
+
     assert_equal(true, p4.valid_for_local?(DateTime.new(2005,1,1,1,1,1)))
     assert_equal(true, p4.valid_for_local?(DateTime.new(2005,2,2,2,2,1)))
     assert_equal(true, p4.valid_for_local?(1104541262))
@@ -316,115 +316,115 @@ class TCTimezonePeriod < Minitest::Test
     assert_equal(true, p4.valid_for_local?(DateTime.new(2005,2,2,2,2,3)))
     assert_equal(true, p4.valid_for_local?(DateTime.new(1960,1,1,1,1,0)))
     assert_equal(true, p4.valid_for_local?(DateTime.new(2040,1,1,1,1,0)))
-    
+
     assert_equal(false, p5.valid_for_utc?(Time.utc(2005,1,1,1,1,1)))
     assert_equal(false, p5.valid_for_utc?(1104541262))
   end
-  
+
   def test_local_after_start
     offset = TimezoneOffset.new(-7200, 3600, :TEST)
     t1 = TestTimezoneTransition.new(offset, offset, 1104544861)
     t2 = TestTimezoneTransition.new(offset, offset, 1107313322)
     t3 = TestTimezoneTransition.new(offset, offset, DateTime.new(1945, 1, 1, 1, 1, 1))
     t4 = TestTimezoneTransition.new(offset, offset, DateTime.new(1945, 2, 2, 2, 2, 2))
-    
+
     p1 = TimezonePeriod.new(t1, t2)
     p2 = TimezonePeriod.new(nil, t2)
     p3 = TimezonePeriod.new(t3, t4)
 
-    assert_equal(true, p1.local_after_start?(DateTime.new(2005,1,1,1,1,1)))    
+    assert_equal(true, p1.local_after_start?(DateTime.new(2005,1,1,1,1,1)))
     assert_equal(true, p1.local_after_start?(Time.utc(2005,1,1,1,1,2)))
     assert_equal(false, p1.local_after_start?(1104541260))
     assert_equal(true, p1.local_after_start?(DateTime.new(2045,1,1,1,1,0)))
     assert_equal(false, p1.local_after_start?(DateTime.new(1955,1,1,1,1,0)))
 
-    assert_equal(true, p2.local_after_start?(DateTime.new(2005,1,1,1,1,1)))    
+    assert_equal(true, p2.local_after_start?(DateTime.new(2005,1,1,1,1,1)))
     assert_equal(true, p2.local_after_start?(Time.utc(2005,1,1,1,1,2)))
-    assert_equal(true, p2.local_after_start?(1104541260))    
-    
+    assert_equal(true, p2.local_after_start?(1104541260))
+
     assert_equal(true, p3.local_after_start?(Time.utc(2005,1,2,1,1,1)))
     assert_equal(true, p3.local_after_start?(1104627661))
   end
-  
+
   def test_local_before_end
     offset = TimezoneOffset.new(-7200, 3600, :TEST)
     t1 = TestTimezoneTransition.new(offset, offset, 1104544861)
     t2 = TestTimezoneTransition.new(offset, offset, 1107313322)
     t3 = TestTimezoneTransition.new(offset, offset, DateTime.new(1945, 1, 1, 1, 1, 1))
     t4 = TestTimezoneTransition.new(offset, offset, DateTime.new(1945, 2, 2, 2, 2, 2))
-    
-    p1 = TimezonePeriod.new(t1, t2)    
+
+    p1 = TimezonePeriod.new(t1, t2)
     p2 = TimezonePeriod.new(t1, nil)
-    p3 = TimezonePeriod.new(t3, t4)    
-        
-    assert_equal(true, p1.local_before_end?(DateTime.new(2005,2,2,2,2,1)))    
-    assert_equal(true, p1.local_before_end?(Time.utc(2005,2,2,2,2,0)))   
+    p3 = TimezonePeriod.new(t3, t4)
+
+    assert_equal(true, p1.local_before_end?(DateTime.new(2005,2,2,2,2,1)))
+    assert_equal(true, p1.local_before_end?(Time.utc(2005,2,2,2,2,0)))
     assert_equal(false, p1.local_before_end?(1107309723))
     assert_equal(false, p1.local_before_end?(DateTime.new(2045,1,1,1,1,0)))
     assert_equal(true, p1.local_before_end?(DateTime.new(1955,1,1,1,1,0)))
-    
-    assert_equal(true, p2.local_before_end?(DateTime.new(2005,2,2,2,2,1)))    
-    assert_equal(true, p2.local_before_end?(Time.utc(2005,2,2,2,2,0)))   
+
+    assert_equal(true, p2.local_before_end?(DateTime.new(2005,2,2,2,2,1)))
+    assert_equal(true, p2.local_before_end?(Time.utc(2005,2,2,2,2,0)))
     assert_equal(true, p2.local_before_end?(1107309723))
-    
+
     assert_equal(false, p3.local_before_end?(Time.utc(2005,1,2,1,1,1)))
     assert_equal(false, p3.local_before_end?(1104627661))
   end
-  
+
   def test_to_local
     p1 = TimezonePeriod.new(nil, nil, TimezoneOffset.new(-14400, 3600, :TEST))
     p2 = TimezonePeriod.new(nil, nil, TimezoneOffset.new(-14400, 0, :TEST))
     p3 = TimezonePeriod.new(nil, nil, TimezoneOffset.new(7200, 3600, :TEST))
-        
+
     assert_equal(DateTime.new(2005,1,19,22,0,0), p1.to_local(DateTime.new(2005,1,20,1,0,0)))
     assert_equal(DateTime.new(2005,1,19,22,0,0 + Rational(512,1000)), p1.to_local(DateTime.new(2005,1,20,1,0,0 + Rational(512,1000))))
     assert_equal(Time.utc(2005,1,19,21,0,0), p2.to_local(Time.utc(2005,1,20,1,0,0)))
     assert_equal(Time.utc(2005,1,19,21,0,0,512000), p2.to_local(Time.utc(2005,1,20,1,0,0,512000)))
     assert_equal(1106193600, p3.to_local(1106182800))
   end
-  
+
   def test_to_utc
     p1 = TimezonePeriod.new(nil, nil, TimezoneOffset.new(-14400, 3600, :TEST))
     p2 = TimezonePeriod.new(nil, nil, TimezoneOffset.new(-14400, 0, :TEST))
     p3 = TimezonePeriod.new(nil, nil, TimezoneOffset.new(7200, 3600, :TEST))
-        
+
     assert_equal(DateTime.new(2005,1,20,4,0,0), p1.to_utc(DateTime.new(2005,1,20,1,0,0)))
     assert_equal(DateTime.new(2005,1,20,4,0,0 + Rational(571,1000)), p1.to_utc(DateTime.new(2005,1,20,1,0,0 + Rational(571,1000))))
     assert_equal(Time.utc(2005,1,20,5,0,0), p2.to_utc(Time.utc(2005,1,20,1,0,0)))
     assert_equal(Time.utc(2005,1,20,5,0,0,571000), p2.to_utc(Time.utc(2005,1,20,1,0,0,571000)))
     assert_equal(1106172000, p3.to_utc(1106182800))
   end
-  
+
   def test_time_boundary_start
     o1 = TimezoneOffset.new(-3600, 0, :TEST)
     o2 = TimezoneOffset.new(-3600, 3600, :TEST)
     t1 = TestTimezoneTransition.new(o1, o2, 0)
-    
+
     p1 = TimezonePeriod.new(t1, nil)
-    
+
     assert_equal(DateTime.new(1969,12,31,23,0,0), p1.local_start)
-    
+
     # Conversion to Time will fail on systems that don't support negative times.
     if RubyCoreSupport.time_supports_negative
       assert_equal(Time.utc(1969,12,31,23,0,0), p1.local_start_time)
     end
   end
-  
+
   def test_time_boundary_end
     o1 = TimezoneOffset.new(0, 3600, :TEST)
     o2 = TimezoneOffset.new(0, 0, :TEST)
     t1 = TestTimezoneTransition.new(o2, o1, 2147482800)
-    
+
     p1 = TimezonePeriod.new(nil, t1)
-    
+
     assert_equal(DateTime.new(2038,1,19,4,0,0), p1.local_end)
-    
+
     # Conversion to Time will fail on systems that don't support 64-bit times
     if RubyCoreSupport.time_supports_64bit
       assert_equal(Time.utc(2038,1,19,4,0,0), p1.local_end_time)
     end
   end
-  
+
   def test_equality
     o1 = TimezoneOffset.new(0, 3600, :TEST)
     o2 = TimezoneOffset.new(0, 0, :TEST)
@@ -432,7 +432,7 @@ class TCTimezonePeriod < Minitest::Test
     t2 = TestTimezoneTransition.new(o1, o2, DateTime.new(2006, 6, 3, 21, 0, 0))
     t3 = TestTimezoneTransition.new(o1, o2, 1149454800)
     t4 = TestTimezoneTransition.new(o1, o2, 1149541200)
-    
+
     p1 = TimezonePeriod.new(t1, t3)
     p2 = TimezonePeriod.new(t1, t3)
     p3 = TimezonePeriod.new(t2, t3)
@@ -445,7 +445,7 @@ class TCTimezonePeriod < Minitest::Test
     p10 = TimezonePeriod.new(nil, nil, o1)
     p11 = TimezonePeriod.new(nil, nil, o1)
     p12 = TimezonePeriod.new(nil, nil, o2)
-    
+
     assert_equal(true, p1 == p1)
     assert_equal(true, p1 == p2)
     assert_equal(true, p1 == p3)
@@ -459,23 +459,23 @@ class TCTimezonePeriod < Minitest::Test
     assert_equal(false, p1 == p11)
     assert_equal(false, p1 == p12)
     assert_equal(false, p1 == Object.new)
-    
+
     assert_equal(true, p4 == p4)
     assert_equal(true, p4 == p5)
     assert_equal(false, p4 == p6)
     assert_equal(false, p4 == Object.new)
-    
+
     assert_equal(true, p7 == p7)
     assert_equal(true, p7 == p8)
     assert_equal(false, p7 == p9)
     assert_equal(false, p7 == Object.new)
-    
+
     assert_equal(true, p10 == p10)
     assert_equal(true, p10 == p11)
     assert_equal(false, p10 == p12)
     assert_equal(false, p10 == Object.new)
   end
-  
+
   def test_eql
     o1 = TimezoneOffset.new(0, 3600, :TEST)
     o2 = TimezoneOffset.new(0, 0, :TEST)
@@ -483,7 +483,7 @@ class TCTimezonePeriod < Minitest::Test
     t2 = TestTimezoneTransition.new(o1, o2, DateTime.new(2006, 6, 3, 21, 0, 0))
     t3 = TestTimezoneTransition.new(o1, o2, 1149454800)
     t4 = TestTimezoneTransition.new(o1, o2, 1149541200)
-    
+
     p1 = TimezonePeriod.new(t1, t3)
     p2 = TimezonePeriod.new(t1, t3)
     p3 = TimezonePeriod.new(t2, t3)
@@ -496,7 +496,7 @@ class TCTimezonePeriod < Minitest::Test
     p10 = TimezonePeriod.new(nil, nil, o1)
     p11 = TimezonePeriod.new(nil, nil, o1)
     p12 = TimezonePeriod.new(nil, nil, o2)
-    
+
     assert_equal(true, p1.eql?(p1))
     assert_equal(true, p1.eql?(p2))
     assert_equal(false, p1.eql?(p3))
@@ -510,23 +510,23 @@ class TCTimezonePeriod < Minitest::Test
     assert_equal(false, p1.eql?(p11))
     assert_equal(false, p1.eql?(p12))
     assert_equal(false, p1.eql?(Object.new))
-    
+
     assert_equal(true, p4.eql?(p4))
     assert_equal(true, p4.eql?(p5))
     assert_equal(false, p4.eql?(p6))
     assert_equal(false, p4.eql?(Object.new))
-    
+
     assert_equal(true, p7.eql?(p7))
     assert_equal(true, p7.eql?(p8))
     assert_equal(false, p7.eql?(p9))
     assert_equal(false, p7.eql?(Object.new))
-    
+
     assert_equal(true, p10.eql?(p10))
     assert_equal(true, p10.eql?(p11))
     assert_equal(false, p10.eql?(p12))
     assert_equal(false, p10.eql?(Object.new))
   end
-  
+
   def test_hash
     o1 = TimezoneOffset.new(0, 3600, :TEST)
     o2 = TimezoneOffset.new(0, 0, :TEST)
@@ -534,8 +534,8 @@ class TCTimezonePeriod < Minitest::Test
     t2 = TestTimezoneTransition.new(o1, o2, DateTime.new(2006, 6, 3, 21, 0, 0))
     t3 = TestTimezoneTransition.new(o1, o2, 1149454800)
     t4 = TestTimezoneTransition.new(o1, o2, 1149541200)
-    
-    p1 = TimezonePeriod.new(t1, t3)    
+
+    p1 = TimezonePeriod.new(t1, t3)
     p2 = TimezonePeriod.new(t2, nil)
     p3 = TimezonePeriod.new(nil, t4)
     p4 = TimezonePeriod.new(nil, nil, o1)
@@ -543,6 +543,6 @@ class TCTimezonePeriod < Minitest::Test
     assert_equal(t1.hash ^ t3.hash, p1.hash)
     assert_equal(t2.hash ^ nil.hash, p2.hash)
     assert_equal(nil.hash ^ t4.hash, p3.hash)
-    assert_equal(nil.hash ^ nil.hash ^ o1.hash, p4.hash)    
+    assert_equal(nil.hash ^ nil.hash ^ o1.hash, p4.hash)
   end
 end

--- a/test/tc_timezone_proxy.rb
+++ b/test/tc_timezone_proxy.rb
@@ -17,18 +17,18 @@ class TCTimezoneProxy < Minitest::Test
     assert_raises(InvalidTimezoneIdentifier) { proxy.canonical_identifier }
     assert_raises(InvalidTimezoneIdentifier) { proxy.canonical_zone }
   end
-  
+
   def test_valid
     proxy = TimezoneProxy.new('Europe/London')
     assert_equal('Europe/London', proxy.identifier)
-    
+
     assert_nothing_raised { proxy.now }
     assert_nothing_raised { proxy.current_period }
     assert_nothing_raised { proxy.current_period_and_time }
     assert_nothing_raised { proxy.current_time_and_period }
-    
+
     real = Timezone.get('Europe/London')
-    
+
     assert_equal(real.utc_to_local(DateTime.new(2005,8,1,0,0,0)), proxy.utc_to_local(DateTime.new(2005,8,1,0,0,0)))
     assert_equal(real.local_to_utc(DateTime.new(2005,8,1,0,0,0)), proxy.local_to_utc(DateTime.new(2005,8,1,0,0,0)))
     assert_equal(real.period_for_utc(DateTime.new(2005,8,1,0,0,0)), proxy.period_for_utc(DateTime.new(2005,8,1,0,0,0)))
@@ -41,46 +41,46 @@ class TCTimezoneProxy < Minitest::Test
     assert_equal(real.friendly_identifier, proxy.friendly_identifier)
     assert_equal(real.canonical_identifier, proxy.canonical_identifier)
     assert_same(real.canonical_zone, proxy.canonical_zone)
-    
+
     assert_equal('Europe/London', proxy.identifier)
-    
+
     assert(real == proxy)
     assert(proxy == real)
     assert_equal(0, real <=> proxy)
     assert_equal(0, proxy <=> real)
   end
-  
+
   def test_canonical_linked
     # Test that the implementation of canonical_zone and canonical_identifier
     # are actually calling the real timezone and not just returning it and
     # its identifier.
-    
+
     real = Timezone.get('UTC')
     proxy = TimezoneProxy.new('UTC')
-    
-    # ZoneinfoDataSource doesn't return LinkedTimezoneInfo instances for any 
+
+    # ZoneinfoDataSource doesn't return LinkedTimezoneInfo instances for any
     # timezone.
     if real.kind_of?(LinkedTimezone)
       assert_equal('Etc/UTC', proxy.canonical_identifier)
       assert_same(Timezone.get('Etc/UTC'), proxy.canonical_zone)
-    else    
+    else
       if DataSource.get.kind_of?(RubyDataSource)
         # Not got a LinkedTimezone despite using a DataSource that supports it.
         # Raise an exception as this shouldn't happen.
         raise 'Non-LinkedTimezone instance returned for UTC using RubyDataSource'
       end
-      
+
       assert_equal('UTC', proxy.canonical_identifier)
       assert_same(Timezone.get('UTC'), proxy.canonical_zone)
     end
   end
-  
+
   def test_equals
     assert_equal(true, TimezoneProxy.new('Europe/London') == TimezoneProxy.new('Europe/London'))
     assert_equal(false, TimezoneProxy.new('Europe/London') == TimezoneProxy.new('Europe/Paris'))
     assert(!(TimezoneProxy.new('Europe/London') == Object.new))
   end
-  
+
   def test_compare
     assert_equal(0, TimezoneProxy.new('Europe/London') <=> TimezoneProxy.new('Europe/London'))
     assert_equal(0, Timezone.get('Europe/London') <=> TimezoneProxy.new('Europe/London'))
@@ -98,15 +98,15 @@ class TCTimezoneProxy < Minitest::Test
     assert_equal(1, Timezone.get('Europe/Paris') <=> TimezoneProxy.new('America/New_York'))
     assert_equal(1, TimezoneProxy.new('Europe/Paris') <=> Timezone.get('America/New_York'))
   end
-  
+
   def test_kind
     assert_kind_of(Timezone, TimezoneProxy.new('America/New_York'))
   end
-  
+
   def test_marshal
     tp = TimezoneProxy.new('Europe/London')
     tp2 = Marshal.load(Marshal.dump(tp))
-    
+
     assert_kind_of(TimezoneProxy, tp2)
     assert_equal('Europe/London', tp2.identifier)
   end

--- a/test/tc_timezone_transition.rb
+++ b/test/tc_timezone_transition.rb
@@ -4,32 +4,32 @@ require 'date'
 include TZInfo
 
 class TCTimezoneTransition < Minitest::Test
-  
+
   class TestTimezoneTransition < TimezoneTransition
     def initialize(offset, previous_offset, at)
       super(offset, previous_offset)
       @at = TimeOrDateTime.wrap(at)
     end
-    
+
     def at
       @at
     end
   end
-  
+
   def test_offset
     t = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 1148949080)
-    
+
     assert_equal(TimezoneOffset.new(3600, 3600, :TDT), t.offset)
   end
-  
+
   def test_previous_offset
     t = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 1148949080)
-    
+
     assert_equal(TimezoneOffset.new(3600, 0, :TST), t.previous_offset)
   end
-  
+
   def test_datetime
     t1 = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 1148949080)
@@ -37,12 +37,12 @@ class TCTimezoneTransition < Minitest::Test
       TimezoneOffset.new(3600, 0, :TST), DateTime.new(2006, 5, 30, 0, 31, 20))
     t3 = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), Time.utc(2006, 5, 30, 0, 31, 20))
-      
+
     assert_equal(DateTime.new(2006, 5, 30, 0, 31, 20), t1.datetime)
     assert_equal(DateTime.new(2006, 5, 30, 0, 31, 20), t2.datetime)
     assert_equal(DateTime.new(2006, 5, 30, 0, 31, 20), t3.datetime)
   end
-  
+
   def test_time
     t1 = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 1148949080)
@@ -50,12 +50,12 @@ class TCTimezoneTransition < Minitest::Test
       TimezoneOffset.new(3600, 0, :TST), DateTime.new(2006, 5, 30, 0, 31, 20))
     t3 = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), Time.utc(2006, 5, 30, 0, 31, 20))
-      
+
     assert_equal(Time.utc(2006, 5, 30, 0, 31, 20), t1.time)
     assert_equal(Time.utc(2006, 5, 30, 0, 31, 20), t2.time)
     assert_equal(Time.utc(2006, 5, 30, 0, 31, 20), t3.time)
   end
-  
+
   def test_local_end_at
     t1 = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 1148949080)
@@ -63,12 +63,12 @@ class TCTimezoneTransition < Minitest::Test
       TimezoneOffset.new(3600, 0, :TST), DateTime.new(2006, 5, 30, 0, 31, 20))
     t3 = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), Time.utc(2006, 5, 30, 0, 31, 20))
-      
+
     assert(TimeOrDateTime.new(1148952680).eql?(t1.local_end_at))
     assert(TimeOrDateTime.new(DateTime.new(2006, 5, 30, 1, 31, 20)).eql?(t2.local_end_at))
     assert(TimeOrDateTime.new(Time.utc(2006, 5, 30, 1, 31, 20)).eql?(t3.local_end_at))
   end
-  
+
   def test_local_end
     t1 = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 1148949080)
@@ -76,12 +76,12 @@ class TCTimezoneTransition < Minitest::Test
       TimezoneOffset.new(3600, 0, :TST), DateTime.new(2006, 5, 30, 0, 31, 20))
     t3 = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), Time.utc(2006, 5, 30, 0, 31, 20))
-      
+
     assert_equal(DateTime.new(2006, 5, 30, 1, 31, 20), t1.local_end)
     assert_equal(DateTime.new(2006, 5, 30, 1, 31, 20), t2.local_end)
     assert_equal(DateTime.new(2006, 5, 30, 1, 31, 20), t3.local_end)
   end
-  
+
   def test_local_end_time
     t1 = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 1148949080)
@@ -89,12 +89,12 @@ class TCTimezoneTransition < Minitest::Test
       TimezoneOffset.new(3600, 0, :TST), DateTime.new(2006, 5, 30, 0, 31, 20))
     t3 = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), Time.utc(2006, 5, 30, 0, 31, 20))
-      
+
     assert_equal(Time.utc(2006, 5, 30, 1, 31, 20), t1.local_end_time)
     assert_equal(Time.utc(2006, 5, 30, 1, 31, 20), t2.local_end_time)
     assert_equal(Time.utc(2006, 5, 30, 1, 31, 20), t3.local_end_time)
   end
-  
+
   def test_local_start_at
     t1 = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 1148949080)
@@ -102,12 +102,12 @@ class TCTimezoneTransition < Minitest::Test
       TimezoneOffset.new(3600, 0, :TST), DateTime.new(2006, 5, 30, 0, 31, 20))
     t3 = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), Time.utc(2006, 5, 30, 0, 31, 20))
-      
+
     assert(TimeOrDateTime.new(1148956280).eql?(t1.local_start_at))
     assert(TimeOrDateTime.new(DateTime.new(2006, 5, 30, 2, 31, 20)).eql?(t2.local_start_at))
     assert(TimeOrDateTime.new(Time.utc(2006, 5, 30, 2, 31, 20)).eql?(t3.local_start_at))
   end
-  
+
   def test_local_start
     t1 = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 1148949080)
@@ -115,12 +115,12 @@ class TCTimezoneTransition < Minitest::Test
       TimezoneOffset.new(3600, 0, :TST), DateTime.new(2006, 5, 30, 0, 31, 20))
     t3 = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), Time.utc(2006, 5, 30, 0, 31, 20))
-      
+
     assert_equal(DateTime.new(2006, 5, 30, 2, 31, 20), t1.local_start)
     assert_equal(DateTime.new(2006, 5, 30, 2, 31, 20), t2.local_start)
     assert_equal(DateTime.new(2006, 5, 30, 2, 31, 20), t3.local_start)
   end
-  
+
   def test_local_start_time
     t1 = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 1148949080)
@@ -128,12 +128,12 @@ class TCTimezoneTransition < Minitest::Test
       TimezoneOffset.new(3600, 0, :TST), DateTime.new(2006, 5, 30, 0, 31, 20))
     t3 = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), Time.utc(2006, 5, 30, 0, 31, 20))
-      
+
     assert_equal(Time.utc(2006, 5, 30, 2, 31, 20), t1.local_start_time)
     assert_equal(Time.utc(2006, 5, 30, 2, 31, 20), t2.local_start_time)
     assert_equal(Time.utc(2006, 5, 30, 2, 31, 20), t3.local_start_time)
   end
-  
+
   if RubyCoreSupport.time_supports_negative
     def test_local_end_at_before_negative_32bit
       t = TestTimezoneTransition.new(TimezoneOffset.new(-7200, 3600, :TDT),
@@ -145,7 +145,7 @@ class TCTimezoneTransition < Minitest::Test
         assert(TimeOrDateTime.new(DateTime.new(1901, 12, 13, 19, 0, 0)).eql?(t.local_end_at))
       end
     end
-  
+
     def test_local_start_at_before_negative_32bit
       t = TestTimezoneTransition.new(TimezoneOffset.new(-7200, 3600, :TDT),
         TimezoneOffset.new(-7200, 0, :TST), -2147482800)
@@ -157,51 +157,51 @@ class TCTimezoneTransition < Minitest::Test
       end
     end
   end
-  
+
   def test_local_end_at_before_epoch
     t = TestTimezoneTransition.new(TimezoneOffset.new(-7200, 3600, :TDT),
       TimezoneOffset.new(-7200, 0, :TST), 1800)
-      
+
     if RubyCoreSupport.time_supports_negative
       assert(TimeOrDateTime.new(-5400).eql?(t.local_end_at))
     else
       assert(TimeOrDateTime.new(DateTime.new(1969, 12, 31, 22, 30, 0)).eql?(t.local_end_at))
     end
   end
-  
+
   def test_local_start_at_before_epoch
     t = TestTimezoneTransition.new(TimezoneOffset.new(-7200, 3600, :TDT),
       TimezoneOffset.new(-7200, 0, :TST), 1800)
-    
+
     if RubyCoreSupport.time_supports_negative
       assert(TimeOrDateTime.new(-1800).eql?(t.local_start_at))
     else
       assert(TimeOrDateTime.new(DateTime.new(1969, 12, 31, 23, 30, 0)).eql?(t.local_start_at))
     end
   end
-  
+
   def test_local_end_at_after_32bit
     t = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 2147482800)
-      
+
     if RubyCoreSupport.time_supports_64bit
       assert(TimeOrDateTime.new(2147486400).eql?(t.local_end_at))
     else
       assert(TimeOrDateTime.new(DateTime.new(2038, 1, 19, 4, 0, 0)).eql?(t.local_end_at))
     end
   end
-  
+
   def test_local_start_at_after_32bit
     t = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 2147482800)
-      
+
     if RubyCoreSupport.time_supports_64bit
       assert(TimeOrDateTime.new(2147490000).eql?(t.local_start_at))
-    else    
+    else
       assert(TimeOrDateTime.new(DateTime.new(2038, 1, 19, 5, 0, 0)).eql?(t.local_start_at))
     end
   end
-  
+
   def test_equality_timestamp
     t1 = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 1148949080)
@@ -221,7 +221,7 @@ class TCTimezoneTransition < Minitest::Test
       TimezoneOffset.new(3600, 0, :TST), 1148949080)
     t9 = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3601, 0, :TST), 1148949080)
-      
+
     assert_equal(true, t1 == t1)
     assert_equal(true, t1 == t2)
     assert_equal(true, t1 == t3)
@@ -232,7 +232,7 @@ class TCTimezoneTransition < Minitest::Test
     assert_equal(false, t1 == t8)
     assert_equal(false, t1 == t9)
     assert_equal(false, t1 == Object.new)
-    
+
     assert_equal(true, t1.eql?(t1))
     assert_equal(true, t1.eql?(t2))
     assert_equal(false, t1.eql?(t3))
@@ -244,7 +244,7 @@ class TCTimezoneTransition < Minitest::Test
     assert_equal(false, t1.eql?(t9))
     assert_equal(false, t1.eql?(Object.new))
   end
-  
+
   def test_equality_datetime
     t1 = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), DateTime.new(2006, 5, 30, 0, 31, 20))
@@ -264,7 +264,7 @@ class TCTimezoneTransition < Minitest::Test
       TimezoneOffset.new(3600, 0, :TST), DateTime.new(2006, 5, 30, 0, 31, 20))
     t9 = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3601, 0, :TST), DateTime.new(2006, 5, 30, 0, 31, 20))
-      
+
     assert_equal(true, t1 == t1)
     assert_equal(true, t1 == t2)
     assert_equal(true, t1 == t3)
@@ -275,7 +275,7 @@ class TCTimezoneTransition < Minitest::Test
     assert_equal(false, t1 == t8)
     assert_equal(false, t1 == t9)
     assert_equal(false, t1 == Object.new)
-    
+
     assert_equal(true, t1.eql?(t1))
     assert_equal(true, t1.eql?(t2))
     assert_equal(false, t1.eql?(t3))
@@ -287,7 +287,7 @@ class TCTimezoneTransition < Minitest::Test
     assert_equal(false, t1.eql?(t9))
     assert_equal(false, t1.eql?(Object.new))
   end
-  
+
   def test_equality_time
     t1 = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), Time.utc(2006, 5, 30, 0, 31, 20))
@@ -304,10 +304,10 @@ class TCTimezoneTransition < Minitest::Test
     t7 = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 1148949081)
     t8 = TestTimezoneTransition.new(TimezoneOffset.new(3601, 3600, :TDT),
-      TimezoneOffset.new(3600, 0, :TST), 1148949080) 
+      TimezoneOffset.new(3600, 0, :TST), 1148949080)
     t9 = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3601, 0, :TST), 1148949080)
-      
+
     assert_equal(true, t1 == t1)
     assert_equal(true, t1 == t2)
     assert_equal(true, t1 == t3)
@@ -318,7 +318,7 @@ class TCTimezoneTransition < Minitest::Test
     assert_equal(false, t1 == t8)
     assert_equal(false, t1 == t9)
     assert_equal(false, t1 == Object.new)
-    
+
     assert_equal(true, t1.eql?(t1))
     assert_equal(true, t1.eql?(t2))
     assert_equal(false, t1.eql?(t3))
@@ -330,7 +330,7 @@ class TCTimezoneTransition < Minitest::Test
     assert_equal(false, t1.eql?(t9))
     assert_equal(false, t1.eql?(Object.new))
   end
-  
+
   def test_hash
     t1 = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDTA),
       TimezoneOffset.new(3600, 0, :TSTA), 1148949080)
@@ -338,7 +338,7 @@ class TCTimezoneTransition < Minitest::Test
       TimezoneOffset.new(3600, 0, :TSTB), DateTime.new(2006, 5, 30, 1, 31, 20))
     t3 = TestTimezoneTransition.new(TimezoneOffset.new(3600, 3600, :TDTC),
       TimezoneOffset.new(3600, 0, :TSTC), Time.utc(2006, 5, 30, 1, 31, 20))
-      
+
     assert_equal(TimezoneOffset.new(3600, 3600, :TDTA).hash ^
       TimezoneOffset.new(3600, 0, :TSTA).hash ^ TimeOrDateTime.new(1148949080).hash,
       t1.hash)

--- a/test/tc_timezone_transition_definition.rb
+++ b/test/tc_timezone_transition_definition.rb
@@ -10,21 +10,21 @@ class TCTimezoneTransitionDefinition < Minitest::Test
         TimezoneOffset.new(3600, 0, :TST), 1148949080)
     end
   end
-  
+
   def test_initialize_timestamp_and_datetime
     assert_nothing_raised do
       TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
         TimezoneOffset.new(3600, 0, :TST), 1148949080, 5300392727, 2160)
     end
   end
-  
+
   def test_initialize_datetime_only
     assert_nothing_raised do
       TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
         TimezoneOffset.new(3600, 0, :TST), 5300392727, 2160)
     end
   end
-  
+
   def test_at
     t1 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 1148949080)
@@ -32,45 +32,45 @@ class TCTimezoneTransitionDefinition < Minitest::Test
       TimezoneOffset.new(3600, 0, :TST), 5300392727, 2160)
     t3 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 1148949080, 5300392727, 2160)
-      
+
     assert(TimeOrDateTime.new(1148949080).eql?(t1.at))
     assert(TimeOrDateTime.new(DateTime.new(2006, 5, 30, 0, 31, 20)).eql?(t2.at))
     assert(TimeOrDateTime.new(1148949080).eql?(t3.at))
   end
-  
+
   def test_at_before_negative_32_bit
     t = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), -2147483649, 69573092117, 28800)
-      
+
     if RubyCoreSupport.time_supports_negative && RubyCoreSupport.time_supports_64bit
       assert(TimeOrDateTime.new(-2147483649).eql?(t.at))
     else
       assert(TimeOrDateTime.new(DateTime.new(1901, 12, 13, 20, 45, 51)).eql?(t.at))
     end
   end
-  
+
   def test_at_before_epoch
     t = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), -1, 210866759999, 86400)
-      
+
     if RubyCoreSupport.time_supports_negative
       assert(TimeOrDateTime.new(-1).eql?(t.at))
     else
       assert(TimeOrDateTime.new(DateTime.new(1969, 12, 31, 23, 59, 59)).eql?(t.at))
     end
   end
-  
+
   def test_at_after_32bit
     t = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 2147483648, 3328347557, 1350)
-      
+
     if RubyCoreSupport.time_supports_64bit
       assert(TimeOrDateTime.new(2147483648).eql?(t.at))
     else
       assert(TimeOrDateTime.new(DateTime.new(2038, 1, 19, 3, 14, 8)).eql?(t.at))
     end
   end
-  
+
   def test_eql_timestamp
     t1 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 1148949080)
@@ -83,69 +83,69 @@ class TCTimezoneTransitionDefinition < Minitest::Test
     t5 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 1148949081)
     t6 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3601, 3600, :TDT),
-      TimezoneOffset.new(3600, 0, :TST), 1148949080) 
+      TimezoneOffset.new(3600, 0, :TST), 1148949080)
     t7 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3601, 0, :TST), 1148949080)
-      
+
     assert_equal(true, t1.eql?(t1))
     assert_equal(true, t1.eql?(t2))
     assert_equal(false, t1.eql?(t3))
     assert_equal(true, t1.eql?(t4))
     assert_equal(false, t1.eql?(t5))
     assert_equal(false, t1.eql?(t6))
-    assert_equal(false, t1.eql?(t7))    
+    assert_equal(false, t1.eql?(t7))
     assert_equal(false, t1.eql?(Object.new))
   end
-  
+
   def test_eql_datetime
     t1 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 5300392727, 2160)
     t2 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 5300392727, 2160)
-    t3 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),    
+    t3 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 1148949080)
     t4 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 1148949080, 5300392727, 2160)
     t5 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 7852433803, 3200)
     t6 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3601, 3600, :TDT),
-      TimezoneOffset.new(3600, 0, :TST), 5300392727, 2160) 
+      TimezoneOffset.new(3600, 0, :TST), 5300392727, 2160)
     t7 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3601, 0, :TST), 5300392727, 2160)
-      
+
     assert_equal(true, t1.eql?(t1))
     assert_equal(true, t1.eql?(t2))
     assert_equal(false, t1.eql?(t3))
     assert_equal(false, t1.eql?(t4))
     assert_equal(false, t1.eql?(t5))
     assert_equal(false, t1.eql?(t6))
-    assert_equal(false, t1.eql?(t7))    
+    assert_equal(false, t1.eql?(t7))
     assert_equal(false, t1.eql?(Object.new))
   end
-  
+
   def test_eql_timestamp_and_datetime
     t1 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 1148949080, 5300392727, 2160)
     t2 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 1148949080, 5300392727, 2160)
-    t3 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),    
+    t3 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 1148949080)
     t4 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 5300392727, 2160)
     t5 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 1148952681, 7852433803, 3200)
     t6 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3601, 3600, :TDT),
-      TimezoneOffset.new(3600, 0, :TST), 1148949080, 5300392727, 2160) 
+      TimezoneOffset.new(3600, 0, :TST), 1148949080, 5300392727, 2160)
     t7 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3601, 0, :TST), 1148949080, 5300392727, 2160)
-      
+
     assert_equal(true, t1.eql?(t1))
     assert_equal(true, t1.eql?(t2))
     assert_equal(true, t1.eql?(t3))
     assert_equal(false, t1.eql?(t4))
     assert_equal(false, t1.eql?(t5))
     assert_equal(false, t1.eql?(t6))
-    assert_equal(false, t1.eql?(t7))    
+    assert_equal(false, t1.eql?(t7))
     assert_equal(false, t1.eql?(Object.new))
   end
 
@@ -154,14 +154,14 @@ class TCTimezoneTransitionDefinition < Minitest::Test
       TimezoneOffset.new(3600, 0, :TST), -2147483649, 69573092117, 28800)
     t2 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), -2147483649, 69573092117, 28800)
-    t3 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),    
+    t3 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), -2147483649)
     t4 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 69573092117, 28800)
-      
+
     assert_equal(true, t1.eql?(t1))
     assert_equal(true, t1.eql?(t2))
-    
+
     if RubyCoreSupport.time_supports_negative && RubyCoreSupport.time_supports_64bit
       assert_equal(true, t1.eql?(t3))
       assert_equal(false, t1.eql?(t4))
@@ -174,20 +174,20 @@ class TCTimezoneTransitionDefinition < Minitest::Test
       assert_equal(true, t4.eql?(t1))
     end
   end
-  
+
   def test_eql_timestamp_and_datetime_before_epoch
     t1 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), -1, 210866759999, 86400)
     t2 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), -1, 210866759999, 86400)
-    t3 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),    
+    t3 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), -1)
     t4 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 210866759999, 86400)
-      
+
     assert_equal(true, t1.eql?(t1))
     assert_equal(true, t1.eql?(t2))
-    
+
     if RubyCoreSupport.time_supports_negative
       assert_equal(true, t1.eql?(t3))
       assert_equal(false, t1.eql?(t4))
@@ -200,20 +200,20 @@ class TCTimezoneTransitionDefinition < Minitest::Test
       assert_equal(true, t4.eql?(t1))
     end
   end
-  
+
   def test_eql_timestamp_and_datetime_after_32bit
     t1 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 2147483648, 3328347557, 1350)
     t2 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 2147483648, 3328347557, 1350)
-    t3 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),    
+    t3 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 2147483648)
     t4 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 3328347557, 1350)
-      
+
     assert_equal(true, t1.eql?(t1))
     assert_equal(true, t1.eql?(t2))
-    
+
     if RubyCoreSupport.time_supports_64bit
       assert_equal(true, t1.eql?(t3))
       assert_equal(false, t1.eql?(t4))
@@ -226,7 +226,7 @@ class TCTimezoneTransitionDefinition < Minitest::Test
       assert_equal(true, t4.eql?(t1))
     end
   end
-  
+
   def test_hash
     t1 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 1148949080)
@@ -240,44 +240,44 @@ class TCTimezoneTransitionDefinition < Minitest::Test
       TimezoneOffset.new(3600, 0, :TST), -1, 210866759999, 86400)
     t6 = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
       TimezoneOffset.new(3600, 0, :TST), 2147483648, 3328347557, 1350)
-      
+
     assert_equal(TimezoneOffset.new(3600, 3600, :TDT).hash ^
-      TimezoneOffset.new(3600, 0, :TST).hash ^ 1148949080.hash ^ nil.hash, 
+      TimezoneOffset.new(3600, 0, :TST).hash ^ 1148949080.hash ^ nil.hash,
       t1.hash)
     assert_equal(TimezoneOffset.new(3600, 3600, :TDT).hash ^
-      TimezoneOffset.new(3600, 0, :TST).hash ^ 5300392727.hash ^ 2160.hash, 
+      TimezoneOffset.new(3600, 0, :TST).hash ^ 5300392727.hash ^ 2160.hash,
       t2.hash)
     assert_equal(TimezoneOffset.new(3600, 3600, :TDT).hash ^
-      TimezoneOffset.new(3600, 0, :TST).hash ^ 1148949080.hash ^ nil.hash, 
+      TimezoneOffset.new(3600, 0, :TST).hash ^ 1148949080.hash ^ nil.hash,
       t3.hash)
-      
+
     if RubyCoreSupport.time_supports_negative && RubyCoreSupport.time_supports_64bit
       assert_equal(TimezoneOffset.new(3600, 3600, :TDT).hash ^
-        TimezoneOffset.new(3600, 0, :TST).hash ^ -2147483649.hash ^ nil.hash, 
+        TimezoneOffset.new(3600, 0, :TST).hash ^ -2147483649.hash ^ nil.hash,
         t4.hash)
     else
       assert_equal(TimezoneOffset.new(3600, 3600, :TDT).hash ^
-        TimezoneOffset.new(3600, 0, :TST).hash ^ 69573092117.hash ^ 28800.hash, 
+        TimezoneOffset.new(3600, 0, :TST).hash ^ 69573092117.hash ^ 28800.hash,
         t4.hash)
     end
-    
+
     if RubyCoreSupport.time_supports_negative
       assert_equal(TimezoneOffset.new(3600, 3600, :TDT).hash ^
-        TimezoneOffset.new(3600, 0, :TST).hash ^ -1.hash ^ nil.hash, 
+        TimezoneOffset.new(3600, 0, :TST).hash ^ -1.hash ^ nil.hash,
         t5.hash)
     else
       assert_equal(TimezoneOffset.new(3600, 3600, :TDT).hash ^
-        TimezoneOffset.new(3600, 0, :TST).hash ^ 210866759999.hash ^ 86400.hash, 
+        TimezoneOffset.new(3600, 0, :TST).hash ^ 210866759999.hash ^ 86400.hash,
         t5.hash)
     end
-    
+
     if RubyCoreSupport.time_supports_64bit
       assert_equal(TimezoneOffset.new(3600, 3600, :TDT).hash ^
-        TimezoneOffset.new(3600, 0, :TST).hash ^ 2147483648.hash ^ nil.hash, 
+        TimezoneOffset.new(3600, 0, :TST).hash ^ 2147483648.hash ^ nil.hash,
         t6.hash)
     else
       assert_equal(TimezoneOffset.new(3600, 3600, :TDT).hash ^
-        TimezoneOffset.new(3600, 0, :TST).hash ^ 3328347557.hash ^ 1350.hash, 
+        TimezoneOffset.new(3600, 0, :TST).hash ^ 3328347557.hash ^ 1350.hash,
         t6.hash)
     end
   end

--- a/test/tc_timezone_utc.rb
+++ b/test/tc_timezone_utc.rb
@@ -3,25 +3,25 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 include TZInfo
 
 class TCTimezoneUTC < Minitest::Test
-  def test_2004        
+  def test_2004
     tz = Timezone.get('UTC')
-    
+
     assert_equal(DateTime.new(2004,1,1,0,0,0), tz.utc_to_local(DateTime.new(2004,1,1,0,0,0)))
     assert_equal(DateTime.new(2004,12,31,23,59,59), tz.utc_to_local(DateTime.new(2004,12,31,23,59,59)))
-    
+
     assert_equal(DateTime.new(2004,1,1,0,0,0), tz.local_to_utc(DateTime.new(2004,1,1,0,0,0)))
     assert_equal(DateTime.new(2004,12,31,23,59,59), tz.local_to_utc(DateTime.new(2004,12,31,23,59,59)))
-        
-    assert_equal(:UTC, tz.period_for_utc(DateTime.new(2004,1,1,0,0,0)).zone_identifier)    
+
+    assert_equal(:UTC, tz.period_for_utc(DateTime.new(2004,1,1,0,0,0)).zone_identifier)
     assert_equal(:UTC, tz.period_for_utc(DateTime.new(2004,12,31,23,59,59)).zone_identifier)
-    
-    assert_equal(:UTC, tz.period_for_local(DateTime.new(2004,1,1,0,0,0)).zone_identifier)    
+
+    assert_equal(:UTC, tz.period_for_local(DateTime.new(2004,1,1,0,0,0)).zone_identifier)
     assert_equal(:UTC, tz.period_for_local(DateTime.new(2004,12,31,23,59,59)).zone_identifier)
-        
-    assert_equal(0, tz.period_for_utc(DateTime.new(2004,1,1,0,0,0)).utc_total_offset)    
+
+    assert_equal(0, tz.period_for_utc(DateTime.new(2004,1,1,0,0,0)).utc_total_offset)
     assert_equal(0, tz.period_for_utc(DateTime.new(2004,12,31,23,59,59)).utc_total_offset)
-    
-    assert_equal(0, tz.period_for_local(DateTime.new(2004,1,1,0,0,0)).utc_total_offset)    
-    assert_equal(0, tz.period_for_local(DateTime.new(2004,12,31,23,59,59)).utc_total_offset)    
-  end    
+
+    assert_equal(0, tz.period_for_local(DateTime.new(2004,1,1,0,0,0)).utc_total_offset)
+    assert_equal(0, tz.period_for_local(DateTime.new(2004,12,31,23,59,59)).utc_total_offset)
+  end
 end

--- a/test/tc_transition_data_timezone_info.rb
+++ b/test/tc_transition_data_timezone_info.rb
@@ -3,7 +3,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 include TZInfo
 
 class TCTransitionDataTimezoneInfo < Minitest::Test
-  
+
   def test_identifier
     dti = TransitionDataTimezoneInfo.new('Test/Zone')
     assert_equal('Test/Zone', dti.identifier)
@@ -11,87 +11,87 @@ class TCTransitionDataTimezoneInfo < Minitest::Test
 
   def test_offset
     dti = TransitionDataTimezoneInfo.new('Test/Zone')
-    
+
     assert_nothing_raised do
       dti.offset :o1, -18000, 3600, :TEST
     end
   end
-  
+
   def test_offset_already_defined
     dti = TransitionDataTimezoneInfo.new('Test/Zone')
     dti.offset :o1, 3600, 0, :TEST
     dti.offset :o2, 1800, 0, :TEST2
-    
+
     assert_raises(ArgumentError) { dti.offset :o1, 3600, 3600, :TESTD }
   end
-  
+
   def test_transition_timestamp
     dti = TransitionDataTimezoneInfo.new('Test/Zone')
     dti.offset :o1, -18000, 3600, :TEST
-    
+
     assert_nothing_raised do
       dti.transition 2006, 6, :o1, 1149368400
     end
   end
-  
+
   def test_transition_datetime
     dti = TransitionDataTimezoneInfo.new('Test/Zone')
     dti.offset :o1, -18000, 3600, :TEST
-    
+
     assert_nothing_raised do
       dti.transition 2006, 6, :o1, 19631123, 8
     end
   end
-  
+
   def test_transition_timestamp_and_datetime
     dti = TransitionDataTimezoneInfo.new('Test/Zone')
     dti.offset :o1, -18000, 3600, :TEST
-    
+
     assert_nothing_raised do
       dti.transition 2006, 6, :o1, 1149368400, 19631123, 8
     end
   end
-  
+
   def test_transition_invalid_offset
     dti = TransitionDataTimezoneInfo.new('Test/Zone')
     dti.offset :o1, -18000, 3600, :TEST
-    
+
     dti.transition 2006, 6, :o1, 1149368400
-    
-    assert_raises(ArgumentError) { dti.transition 2006, 6, :o2, 1149454800 }    
+
+    assert_raises(ArgumentError) { dti.transition 2006, 6, :o2, 1149454800 }
   end
-  
+
   def test_transition_no_offsets
     dti = TransitionDataTimezoneInfo.new('Test/Zone')
-    
+
     assert_raises(ArgumentError) { dti.transition 2006, 6, :o1, 1149368400 }
   end
-  
+
   def test_transition_invalid_order_month
     dti = TransitionDataTimezoneInfo.new('Test/Zone')
     dti.offset :o1, -18000, 3600, :TEST
-    
+
     dti.transition 2006, 6, :o1, 1149368400
-    
+
     assert_raises(ArgumentError) { dti.transition 2006, 5, :o2, 1146690000 }
   end
-  
+
   def test_transition_invalid_order_year
     dti = TransitionDataTimezoneInfo.new('Test/Zone')
     dti.offset :o1, -18000, 3600, :TEST
-    
+
     dti.transition 2006, 6, :o1, 1149368400
-    
+
     assert_raises(ArgumentError) { dti.transition 2005, 7, :o2, 1120424400 }
-  end   
-  
+  end
+
   def test_period_for_utc
     dti = TransitionDataTimezoneInfo.new('Test/Zone')
     dti.offset :o1, -17900,    0, :TESTLMT
     dti.offset :o2, -18000, 3600, :TESTD
     dti.offset :o3, -18000,    0, :TESTS
     dti.offset :o4, -21600, 3600, :TESTD
-    
+
     dti.transition 2000,  4, :o2, Time.utc(2000, 4,1,1,0,0).to_i
     dti.transition 2000, 10, :o3, Time.utc(2000,10,1,1,0,0).to_i
     dti.transition 2001,  3, :o2, 58847269, 24                    # (2001, 3,1,1,0,0)
@@ -100,12 +100,12 @@ class TCTransitionDataTimezoneInfo < Minitest::Test
     dti.transition 2002, 10, :o3, Time.utc(2002,10,1,1,0,0).to_i
     dti.transition 2003,  2, :o2, Time.utc(2003, 2,1,1,0,0).to_i
     dti.transition 2003,  3, :o3, Time.utc(2003, 3,1,1,0,0).to_i
-    
+
     o1 = TimezoneOffset.new(-17900, 0,    :TESTLMT)
     o2 = TimezoneOffset.new(-18000, 3600, :TESTD)
     o3 = TimezoneOffset.new(-18000, 0,    :TESTS)
     o4 = TimezoneOffset.new(-21600, 3600, :TESTD)
-    
+
     t1 = TimezoneTransitionDefinition.new(o2, o1, Time.utc(2000, 4,1,1,0,0).to_i)
     t2 = TimezoneTransitionDefinition.new(o3, o2, Time.utc(2000,10,1,1,0,0).to_i)
     t3 = TimezoneTransitionDefinition.new(o2, o3, Time.utc(2001, 3,1,1,0,0).to_i)
@@ -114,12 +114,12 @@ class TCTransitionDataTimezoneInfo < Minitest::Test
     t6 = TimezoneTransitionDefinition.new(o3, o3, Time.utc(2002,10,1,1,0,0).to_i)
     t7 = TimezoneTransitionDefinition.new(o2, o3, Time.utc(2003, 2,1,1,0,0).to_i)
     t8 = TimezoneTransitionDefinition.new(o3, o2, Time.utc(2003, 3,1,1,0,0).to_i)
-    
+
     assert_equal(TimezonePeriod.new(nil, t1), dti.period_for_utc(DateTime.new(1960, 1,1,1, 0, 0)))
     assert_equal(TimezonePeriod.new(nil, t1), dti.period_for_utc(DateTime.new(1999,12,1,0, 0, 0)))
     assert_equal(TimezonePeriod.new(nil, t1), dti.period_for_utc(Time.utc(    2000, 4,1,0,59,59)))
     assert_equal(TimezonePeriod.new(t1, t2),  dti.period_for_utc(DateTime.new(2000, 4,1,1, 0, 0)))
-    assert_equal(TimezonePeriod.new(t1, t2),  dti.period_for_utc(Time.utc(    2000,10,1,0,59,59).to_i))      
+    assert_equal(TimezonePeriod.new(t1, t2),  dti.period_for_utc(Time.utc(    2000,10,1,0,59,59).to_i))
     assert_equal(TimezonePeriod.new(t2, t3),  dti.period_for_utc(Time.utc(    2000,10,1,1, 0, 0)))
     assert_equal(TimezonePeriod.new(t2, t3),  dti.period_for_utc(Time.utc(    2001, 3,1,0,59,59)))
     assert_equal(TimezonePeriod.new(t3, t4),  dti.period_for_utc(Time.utc(    2001, 3,1,1, 0, 0)))
@@ -135,36 +135,36 @@ class TCTransitionDataTimezoneInfo < Minitest::Test
     assert_equal(TimezonePeriod.new(t7, t8),  dti.period_for_utc(Time.utc(    2003, 3,1,0,59,59)))
     assert_equal(TimezonePeriod.new(t8, nil), dti.period_for_utc(Time.utc(    2003, 3,1,1, 0, 0)))
     assert_equal(TimezonePeriod.new(t8, nil), dti.period_for_utc(Time.utc(    2004, 1,1,1, 0, 0)))
-    assert_equal(TimezonePeriod.new(t8, nil), dti.period_for_utc(DateTime.new(2050, 1,1,1, 0, 0)))        
+    assert_equal(TimezonePeriod.new(t8, nil), dti.period_for_utc(DateTime.new(2050, 1,1,1, 0, 0)))
   end
-    
+
   def test_period_for_utc_no_transitions
     dti = TransitionDataTimezoneInfo.new('Test/Zone')
     dti.offset :o1, -17900, 0, :TESTLMT
     dti.offset :o2, -18000, 0, :TEST
-    
+
     o1 = TimezoneOffset.new(-17900, 0, :TESTLMT)
-    
+
     assert_equal(TimezonePeriod.new(nil, nil, o1), dti.period_for_utc(DateTime.new(2005,1,1,0,0,0)))
     assert_equal(TimezonePeriod.new(nil, nil, o1), dti.period_for_utc(Time.utc(2005,1,1,0,0,0)))
-    assert_equal(TimezonePeriod.new(nil, nil, o1), dti.period_for_utc(Time.utc(2005,1,1,0,0,0).to_i))       
+    assert_equal(TimezonePeriod.new(nil, nil, o1), dti.period_for_utc(Time.utc(2005,1,1,0,0,0).to_i))
   end
-    
+
   def test_period_for_utc_no_offsets
     dti = TransitionDataTimezoneInfo.new('Test/Zone')
-    
+
     assert_raises(NoOffsetsDefined) { dti.period_for_utc(DateTime.new(2005,1,1,0,0,0)) }
     assert_raises(NoOffsetsDefined) { dti.period_for_utc(Time.utc(2005,1,1,0,0,0)) }
     assert_raises(NoOffsetsDefined) { dti.period_for_utc(Time.utc(2005,1,1,0,0,0).to_i) }
   end
-  
+
   def test_periods_for_local
     dti = TransitionDataTimezoneInfo.new('Test/Zone')
     dti.offset :o1, -17900,    0, :TESTLMT
     dti.offset :o2, -18000, 3600, :TESTD
     dti.offset :o3, -18000,    0, :TESTS
     dti.offset :o4, -21600, 3600, :TESTD
-    
+
     dti.transition 2000,  4, :o2, 58839277, 24                   # 2000,4,2,1,0,0
     dti.transition 2000, 10, :o3, Time.utc(2000,10,2,1,0,0).to_i, 58843669, 24
     dti.transition 2001,  3, :o2, Time.utc(2001, 3,2,1,0,0).to_i
@@ -172,12 +172,12 @@ class TCTransitionDataTimezoneInfo < Minitest::Test
     dti.transition 2001, 10, :o3, Time.utc(2001,10,2,1,0,0).to_i
     dti.transition 2002, 10, :o3, 58861189, 24                   # 2002,10,2,1,0,0
     dti.transition 2003,  2, :o2, Time.utc(2003, 2,2,1,0,0).to_i
-    
+
     o1 = TimezoneOffset.new(-17900,    0, :TESTLMT)
     o2 = TimezoneOffset.new(-18000, 3600, :TESTD)
     o3 = TimezoneOffset.new(-18000,    0, :TESTS)
     o4 = TimezoneOffset.new(-21600, 3600, :TESTD)
-    
+
     t1 = TimezoneTransitionDefinition.new(o2, o1, Time.utc(2000, 4,2,1,0,0).to_i)
     t2 = TimezoneTransitionDefinition.new(o3, o2, Time.utc(2000,10,2,1,0,0).to_i)
     t3 = TimezoneTransitionDefinition.new(o2, o3, Time.utc(2001, 3,2,1,0,0).to_i)
@@ -185,8 +185,8 @@ class TCTransitionDataTimezoneInfo < Minitest::Test
     t5 = TimezoneTransitionDefinition.new(o3, o4, Time.utc(2001,10,2,1,0,0).to_i)
     t6 = TimezoneTransitionDefinition.new(o3, o3, Time.utc(2002,10,2,1,0,0).to_i)
     t7 = TimezoneTransitionDefinition.new(o2, o3, Time.utc(2003, 2,2,1,0,0).to_i)
-    
-    
+
+
     assert_equal([TimezonePeriod.new(nil, t1)], dti.periods_for_local(DateTime.new(1960, 1, 1, 1, 0, 0)))
     assert_equal([TimezonePeriod.new(nil, t1)], dti.periods_for_local(DateTime.new(1999,12, 1, 0, 0, 0)))
     assert_equal([TimezonePeriod.new(nil, t1)], dti.periods_for_local(Time.utc(    2000, 1, 1,10, 0, 0)))
@@ -196,7 +196,7 @@ class TCTransitionDataTimezoneInfo < Minitest::Test
     assert_equal([TimezonePeriod.new(t1,  t2)], dti.periods_for_local(Time.utc(    2000, 4, 1,21, 0, 0)))
     assert_equal([TimezonePeriod.new(t1,  t2)], dti.periods_for_local(DateTime.new(2000,10, 1,19,59,59)))
     assert_equal([TimezonePeriod.new(t1,  t2),
-                  TimezonePeriod.new(t2,  t3)], dti.periods_for_local(Time.utc(    2000,10, 1,20, 0, 0).to_i))   
+                  TimezonePeriod.new(t2,  t3)], dti.periods_for_local(Time.utc(    2000,10, 1,20, 0, 0).to_i))
     assert_equal([TimezonePeriod.new(t1,  t2),
                   TimezonePeriod.new(t2,  t3)], dti.periods_for_local(DateTime.new(2000,10, 1,20,59,59)))
     assert_equal([TimezonePeriod.new(t2,  t3)], dti.periods_for_local(Time.utc(    2000,10, 1,21, 0, 0)))
@@ -209,7 +209,7 @@ class TCTransitionDataTimezoneInfo < Minitest::Test
     assert_equal([TimezonePeriod.new(t3,  t4),
                   TimezonePeriod.new(t4,  t5)], dti.periods_for_local(DateTime.new(2001, 4, 1,20, 0, 0)))
     assert_equal([TimezonePeriod.new(t3,  t4),
-                  TimezonePeriod.new(t4,  t5)], dti.periods_for_local(Time.utc(    2001, 4, 1,20,59,59)))                  
+                  TimezonePeriod.new(t4,  t5)], dti.periods_for_local(Time.utc(    2001, 4, 1,20,59,59)))
     assert_equal([TimezonePeriod.new(t4,  t5)], dti.periods_for_local(Time.utc(    2001, 4, 1,21, 0, 0)))
     assert_equal([TimezonePeriod.new(t4,  t5)], dti.periods_for_local(Time.utc(    2001,10, 1,19,59,59)))
     assert_equal([TimezonePeriod.new(t5,  t6)], dti.periods_for_local(Time.utc(    2001,10, 1,20, 0, 0)))
@@ -223,97 +223,97 @@ class TCTransitionDataTimezoneInfo < Minitest::Test
     assert_equal([TimezonePeriod.new(t7, nil)], dti.periods_for_local(Time.utc(    2004, 2, 1,20, 0, 0)))
     assert_equal([TimezonePeriod.new(t7, nil)], dti.periods_for_local(DateTime.new(2040, 2, 1,20, 0, 0)))
   end
-      
+
   def test_periods_for_local_warsaw
     dti = TransitionDataTimezoneInfo.new('Test/Europe/Warsaw')
     dti.offset :o1, 5040,    0, :LMT
     dti.offset :o2, 5040,    0, :WMT
     dti.offset :o3, 3600,    0, :CET
     dti.offset :o4, 3600, 3600, :CEST
-    
+
     dti.transition 1879, 12, :o2, 288925853, 120  # 1879,12,31,22,36,0
     dti.transition 1915,  8, :o3, 290485733, 120  # 1915, 8, 4,22,36,0
     dti.transition 1916,  4, :o4,  29051813,  12  # 1916, 4,30,22, 0,0
-    
+
     o1 = TimezoneOffset.new(5040,    0, :LMT)
     o2 = TimezoneOffset.new(5040,    0, :WMT)
     o3 = TimezoneOffset.new(3600,    0, :CET)
     o4 = TimezoneOffset.new(3600, 3600, :CEST)
-    
+
     t1 = TimezoneTransitionDefinition.new(o2, o1, 288925853, 120)
     t2 = TimezoneTransitionDefinition.new(o3, o2, 290485733, 120)
     t3 = TimezoneTransitionDefinition.new(o4, o3,  29051813,  12)
-    
+
     assert_equal([TimezonePeriod.new(t1, t2),
-                  TimezonePeriod.new(t2, t3)], dti.periods_for_local(DateTime.new(1915,8,4,23,40,0)))      
+                  TimezonePeriod.new(t2, t3)], dti.periods_for_local(DateTime.new(1915,8,4,23,40,0)))
   end
-    
+
   def test_periods_for_local_boundary
     dti = TransitionDataTimezoneInfo.new('Test/Zone')
     dti.offset :o1, -3600, 0, :TESTD
     dti.offset :o2, -3600, 0, :TESTS
-    
+
     dti.transition 2000, 7, :o2, Time.utc(2000,7,1,0,0,0).to_i
-    
+
     o1 = TimezoneOffset.new(-3600, 0, :TESTD)
     o2 = TimezoneOffset.new(-3600, 0, :TESTS)
-    
+
     t1 = TimezoneTransitionDefinition.new(o2, o1, Time.utc(2000,7,1,0,0,0).to_i)
-                
+
     # 2000-07-01 00:00:00 UTC is 2000-06-30 23:00:00 UTC-1
     # hence to find periods for local times between 2000-06-30 23:00:00
     # and 2000-07-01 00:00:00 a search has to be carried out in the next half
     # year to the one containing the date we are looking for
-    
+
     assert_equal([TimezonePeriod.new(nil, t1)], dti.periods_for_local(Time.utc(2000,6,30,22,59,59)))
     assert_equal([TimezonePeriod.new(t1, nil)], dti.periods_for_local(Time.utc(2000,6,30,23, 0, 0)))
-    assert_equal([TimezonePeriod.new(t1, nil)], dti.periods_for_local(Time.utc(2000,7, 1, 0, 0, 0)))    
+    assert_equal([TimezonePeriod.new(t1, nil)], dti.periods_for_local(Time.utc(2000,7, 1, 0, 0, 0)))
   end
-    
+
   def test_periods_for_local_no_transitions
     dti = TransitionDataTimezoneInfo.new('Test/Zone')
     dti.offset :o1, -17900, 0, :TESTLMT
     dti.offset :o2, -18000, 0, :TEST
-    
+
     o1 = TimezoneOffset.new(-17900, 0, :TESTLMT)
-    
+
     assert_equal([TimezonePeriod.new(nil, nil, o1)], dti.periods_for_local(DateTime.new(2005,1,1,0,0,0)))
     assert_equal([TimezonePeriod.new(nil, nil, o1)], dti.periods_for_local(Time.utc(2005,1,1,0,0,0)))
-    assert_equal([TimezonePeriod.new(nil, nil, o1)], dti.periods_for_local(Time.utc(2005,1,1,0,0,0).to_i))       
+    assert_equal([TimezonePeriod.new(nil, nil, o1)], dti.periods_for_local(Time.utc(2005,1,1,0,0,0).to_i))
   end
-    
+
   def test_periods_for_local_no_offsets
     dti = TransitionDataTimezoneInfo.new('Test/Zone')
-    
+
     assert_raises(NoOffsetsDefined) { dti.periods_for_local(DateTime.new(2005,1,1,0,0,0)) }
     assert_raises(NoOffsetsDefined) { dti.periods_for_local(Time.utc(2005,1,1,0,0,0)) }
     assert_raises(NoOffsetsDefined) { dti.periods_for_local(Time.utc(2005,1,1,0,0,0).to_i) }
   end
-  
+
   def test_transitions_up_to
     dti = TransitionDataTimezoneInfo.new('Test/Zone')
     dti.offset :o1, -17900,    0, :TESTLMT
     dti.offset :o2, -18000, 3600, :TESTD
     dti.offset :o3, -18000,    0, :TESTS
     dti.offset :o4, -21600, 3600, :TESTD
-    
+
     dti.transition 2010,  4, :o2, Time.utc(2010, 4,1,1,0,0).to_i
     dti.transition 2010, 10, :o3, Time.utc(2010,10,1,1,0,0).to_i
     dti.transition 2011,  3, :o2, 58934917, 24                    # (2011, 3,1,1,0,0)
     dti.transition 2011,  4, :o4, Time.utc(2011, 4,1,1,0,0).to_i, 58935661, 24
     dti.transition 2011, 10, :o3, Time.utc(2011,10,1,1,0,0).to_i
-    
+
     o1 = TimezoneOffset.new(-17900, 0,    :TESTLMT)
     o2 = TimezoneOffset.new(-18000, 3600, :TESTD)
     o3 = TimezoneOffset.new(-18000, 0,    :TESTS)
     o4 = TimezoneOffset.new(-21600, 3600, :TESTD)
-    
+
     t1 = TimezoneTransitionDefinition.new(o2, o1, Time.utc(2010, 4,1,1,0,0).to_i)
     t2 = TimezoneTransitionDefinition.new(o3, o2, Time.utc(2010,10,1,1,0,0).to_i)
     t3 = TimezoneTransitionDefinition.new(o2, o3, Time.utc(2011, 3,1,1,0,0).to_i)
     t4 = TimezoneTransitionDefinition.new(o4, o2, Time.utc(2011, 4,1,1,0,0).to_i)
     t5 = TimezoneTransitionDefinition.new(o3, o4, Time.utc(2011,10,1,1,0,0).to_i)
-    
+
     assert_equal([], dti.transitions_up_to(Time.utc(2010,4,1,1,0,0)))
     assert_equal([], dti.transitions_up_to(Time.utc(2010,4,1,1,0,0), Time.utc(2000,1,1,0,0,0)))
     assert_equal([t1], dti.transitions_up_to(Time.utc(2010,4,1,1,0,1)))
@@ -345,7 +345,7 @@ class TCTransitionDataTimezoneInfo < Minitest::Test
     assert_equal([t2,t3,t4,t5], dti.transitions_up_to(Time.utc(2011,10,1,1,0,1).to_i, Time.utc(2010,4,1,1,0,1).to_i))
     assert_equal([t5], dti.transitions_up_to(Time.utc(2015,1,1,0,0,0).to_i, Time.utc(2011,10,1,1,0,0).to_i))
     assert_equal([], dti.transitions_up_to(Time.utc(2015,1,1,0,0,0).to_i, Time.utc(2011,10,1,1,0,1).to_i))
-    
+
     assert_equal([], dti.transitions_up_to(DateTime.new(2010,4,1,1,0,0)))
     assert_equal([], dti.transitions_up_to(DateTime.new(2010,4,1,1,0,0), DateTime.new(2000,1,1,0,0,0)))
     assert_equal([t1], dti.transitions_up_to(DateTime.new(2010,4,1,1,0,1)))
@@ -363,57 +363,57 @@ class TCTransitionDataTimezoneInfo < Minitest::Test
     assert_equal([t5], dti.transitions_up_to(DateTime.new(2015,1,1,0,0,0), DateTime.new(2011,10,1,1,0,0)))
     assert_equal([], dti.transitions_up_to(DateTime.new(2015,1,1,0,0,0), DateTime.new(2011,10,1,1,0,1)))
   end
-  
+
   def test_transitions_up_to_no_transitions
     dti = TransitionDataTimezoneInfo.new('Test/Zone')
     dti.offset :o1, -17900, 0, :TESTLMT
-        
+
     assert_equal([], dti.transitions_up_to(Time.utc(2015,1,1,0,0,0)))
     assert_equal([], dti.transitions_up_to(Time.utc(2015,1,1,0,0,0).to_i))
     assert_equal([], dti.transitions_up_to(DateTime.new(2015,1,1,0,0,0)))
   end
-  
+
   def test_transitions_up_to_utc_to_not_greater_than_utc_from
     dti = TransitionDataTimezoneInfo.new('Test/Zone')
     dti.offset :o1, -17900, 0, :TESTLMT
-    
+
     assert_raises(ArgumentError) do
       dti.transitions_up_to(Time.utc(2012,8,1,0,0,0), Time.utc(2013,8,1,0,0,0))
     end
-    
+
     assert_raises(ArgumentError) do
       dti.transitions_up_to(Time.utc(2012,8,1,0,0,0).to_i, Time.utc(2012,8,1,0,0,0).to_i)
     end
-    
+
     assert_raises(ArgumentError) do
       dti.transitions_up_to(DateTime.new(2012,8,1,0,0,0), DateTime.new(2012,8,1,0,0,0))
     end
   end
-  
+
   def test_datetime_and_timestamp_use
     dti = TransitionDataTimezoneInfo.new('Test/Zone')
     dti.offset :o1, 0,    0, :TESTS
-    dti.offset :o2, 0, 3600, :TESTD    
-    
+    dti.offset :o2, 0, 3600, :TESTD
+
     dti.transition 1901, 12, :o2, -2147483649, 69573092117, 28800
     dti.transition 1969, 12, :o1, -1, 210866759999, 86400
     dti.transition 2001,  9, :o2, 1000000000, 529666909, 216
     dti.transition 2038,  1, :o1, 2147483648, 3328347557, 1350
-    
+
     if RubyCoreSupport.time_supports_negative && RubyCoreSupport.time_supports_64bit
       assert(dti.period_for_utc(DateTime.new(1901,12,13,20,45,51)).start_transition.at.eql?(TimeOrDateTime.new(-2147483649)))
     else
       assert(dti.period_for_utc(DateTime.new(1901,12,13,20,45,51)).start_transition.at.eql?(TimeOrDateTime.new(DateTime.new(1901,12,13,20,45,51))))
     end
-    
-    if RubyCoreSupport.time_supports_negative          
+
+    if RubyCoreSupport.time_supports_negative
       assert(dti.period_for_utc(DateTime.new(1969,12,31,23,59,59)).start_transition.at.eql?(TimeOrDateTime.new(-1)))
     else
       assert(dti.period_for_utc(DateTime.new(1969,12,31,23,59,59)).start_transition.at.eql?(TimeOrDateTime.new(DateTime.new(1969,12,31,23,59,59))))
     end
-    
+
     assert(dti.period_for_utc(DateTime.new(2001,9,9,2,46,40)).start_transition.at.eql?(TimeOrDateTime.new(1000000000)))
-        
+
     if RubyCoreSupport.time_supports_64bit
       assert(dti.period_for_utc(DateTime.new(2038,1,19,3,14,8)).start_transition.at.eql?(TimeOrDateTime.new(2147483648)))
     else

--- a/test/tc_zoneinfo_country_info.rb
+++ b/test/tc_zoneinfo_country_info.rb
@@ -3,23 +3,23 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_utils')
 include TZInfo
 
 class TCZoneinfoCountryInfo < Minitest::Test
-  
+
   def test_code
     ci = ZoneinfoCountryInfo.new('ZZ', 'Zzz', []) {|c| }
     assert_equal('ZZ', ci.code)
   end
-  
+
   def test_name
     ci = ZoneinfoCountryInfo.new('ZZ', 'Zzz', []) {|c| }
     assert_equal('Zzz', ci.name)
   end
-  
+
   def test_zone_identifiers_empty
     ci = ZoneinfoCountryInfo.new('ZZ', 'Zzz', []) {|c| }
     assert(ci.zone_identifiers.empty?)
     assert(ci.zone_identifiers.frozen?)
   end
-  
+
   def test_zone_identifiers
     zones = [
       CountryTimezone.new('ZZ/TimezoneB', Rational(1, 2), Rational(1, 2), 'Timezone B'),
@@ -27,21 +27,21 @@ class TCZoneinfoCountryInfo < Minitest::Test
       CountryTimezone.new('ZZ/TimezoneC', Rational(-10, 3), Rational(-20, 7), 'C'),
       CountryTimezone.new('ZZ/TimezoneD', Rational(-10, 3), Rational(-20, 7))
     ]
-  
+
     ci = ZoneinfoCountryInfo.new('ZZ', 'Zzz', zones)
-    
+
     assert_equal(['ZZ/TimezoneB', 'ZZ/TimezoneA', 'ZZ/TimezoneC', 'ZZ/TimezoneD'], ci.zone_identifiers)
     assert(ci.zone_identifiers.frozen?)
     assert(!ci.zones.equal?(zones))
     assert(!zones.frozen?)
   end
-  
+
   def test_zones_empty
     ci = ZoneinfoCountryInfo.new('ZZ', 'Zzz', [])
     assert(ci.zones.empty?)
     assert(ci.zones.frozen?)
   end
-  
+
   def test_zones
     zones = [
       CountryTimezone.new('ZZ/TimezoneB', Rational(1, 2), Rational(1, 2), 'Timezone B'),
@@ -49,9 +49,9 @@ class TCZoneinfoCountryInfo < Minitest::Test
       CountryTimezone.new('ZZ/TimezoneC', Rational(-10, 3), Rational(-20, 7), 'C'),
       CountryTimezone.new('ZZ/TimezoneD', Rational(-10, 3), Rational(-20, 7))
     ]
-  
+
     ci = ZoneinfoCountryInfo.new('ZZ', 'Zzz', zones)
-    
+
     assert_equal([CountryTimezone.new('ZZ/TimezoneB', Rational(1, 2), Rational(1, 2), 'Timezone B'),
       CountryTimezone.new('ZZ/TimezoneA', Rational(1, 4), Rational(1, 4), 'Timezone A'),
       CountryTimezone.new('ZZ/TimezoneC', Rational(-10, 3), Rational(-20, 7), 'C'),

--- a/test/tc_zoneinfo_data_source.rb
+++ b/test/tc_zoneinfo_data_source.rb
@@ -9,85 +9,85 @@ include TZInfo
 
 class TCZoneinfoDataSource < Minitest::Test
   ZONEINFO_DIR = File.join(File.expand_path(File.dirname(__FILE__)), 'zoneinfo').untaint
-  
+
   def setup
     @orig_search_path = ZoneinfoDataSource.search_path.clone
     @orig_alternate_iso3166_tab_search_path = ZoneinfoDataSource.alternate_iso3166_tab_search_path.clone
     @orig_pwd = FileUtils.pwd
-    
+
     # A zoneinfo directory containing files needed by the tests.
     # The symlinks in this directory are set up in test_utils.rb.
     @data_source = ZoneinfoDataSource.new(ZONEINFO_DIR)
   end
-  
+
   def teardown
     ZoneinfoDataSource.search_path = @orig_search_path
     ZoneinfoDataSource.alternate_iso3166_tab_search_path = @orig_alternate_iso3166_tab_search_path
     FileUtils.chdir(@orig_pwd)
   end
-  
+
   def test_default_search_path
     assert_equal(['/usr/share/zoneinfo', '/usr/share/lib/zoneinfo', '/etc/zoneinfo'], ZoneinfoDataSource.search_path)
     assert_equal(false, ZoneinfoDataSource.search_path.frozen?)
   end
-  
+
   def test_set_search_path_default
     ZoneinfoDataSource.search_path = ['/tmp/zoneinfo1', '/tmp/zoneinfo2']
     assert_equal(['/tmp/zoneinfo1', '/tmp/zoneinfo2'], ZoneinfoDataSource.search_path)
-    
+
     ZoneinfoDataSource.search_path = nil
     assert_equal(['/usr/share/zoneinfo', '/usr/share/lib/zoneinfo', '/etc/zoneinfo'], ZoneinfoDataSource.search_path)
     assert_equal(false, ZoneinfoDataSource.search_path.frozen?)
   end
-  
+
   def test_set_search_path_array
     path = ['/tmp/zoneinfo1', '/tmp/zoneinfo2']
     ZoneinfoDataSource.search_path = path
     assert_equal(['/tmp/zoneinfo1', '/tmp/zoneinfo2'], ZoneinfoDataSource.search_path)
     refute_same(path, ZoneinfoDataSource.search_path)
   end
-  
-  def test_set_search_path_array_to_s  
+
+  def test_set_search_path_array_to_s
     ZoneinfoDataSource.search_path = [Pathname.new('/tmp/zoneinfo3')]
     assert_equal(['/tmp/zoneinfo3'], ZoneinfoDataSource.search_path)
   end
-  
+
   def test_set_search_path_string
     ZoneinfoDataSource.search_path = ['/tmp/zoneinfo4', '/tmp/zoneinfo5'].join(File::PATH_SEPARATOR)
     assert_equal(['/tmp/zoneinfo4', '/tmp/zoneinfo5'], ZoneinfoDataSource.search_path)
   end
-  
+
   def test_default_alternate_iso3166_tab_search_path
     assert_equal(['/usr/share/misc/iso3166.tab', '/usr/share/misc/iso3166'], ZoneinfoDataSource.alternate_iso3166_tab_search_path)
     assert_equal(false, ZoneinfoDataSource.alternate_iso3166_tab_search_path.frozen?)
   end
-  
+
   def test_set_alternate_iso3166_tab_search_path_default
     ZoneinfoDataSource.alternate_iso3166_tab_search_path = ['/tmp/iso3166.tab', '/tmp/iso3166']
     assert_equal(['/tmp/iso3166.tab', '/tmp/iso3166'], ZoneinfoDataSource.alternate_iso3166_tab_search_path)
-    
+
     ZoneinfoDataSource.alternate_iso3166_tab_search_path = nil
     assert_equal(['/usr/share/misc/iso3166.tab', '/usr/share/misc/iso3166'], ZoneinfoDataSource.alternate_iso3166_tab_search_path)
     assert_equal(false, ZoneinfoDataSource.alternate_iso3166_tab_search_path.frozen?)
   end
-  
+
   def test_set_alternate_iso3166_tab_search_path_array
     path = ['/tmp/iso3166.tab', '/tmp/iso3166']
     ZoneinfoDataSource.alternate_iso3166_tab_search_path = path
     assert_equal(['/tmp/iso3166.tab', '/tmp/iso3166'], ZoneinfoDataSource.alternate_iso3166_tab_search_path)
     refute_same(path, ZoneinfoDataSource.alternate_iso3166_tab_search_path)
   end
-  
-  def test_set_alternate_iso3166_tab_search_path_array_to_s  
+
+  def test_set_alternate_iso3166_tab_search_path_array_to_s
     ZoneinfoDataSource.alternate_iso3166_tab_search_path = [Pathname.new('/tmp/iso3166.tab')]
     assert_equal(['/tmp/iso3166.tab'], ZoneinfoDataSource.alternate_iso3166_tab_search_path)
   end
-  
+
   def test_set_alternate_iso3166_tab_search_path_string
     ZoneinfoDataSource.alternate_iso3166_tab_search_path = ['/tmp/iso3166.tab', '/tmp/iso3166'].join(File::PATH_SEPARATOR)
     assert_equal(['/tmp/iso3166.tab', '/tmp/iso3166'], ZoneinfoDataSource.alternate_iso3166_tab_search_path)
   end
-  
+
   def test_new_search
     Dir.mktmpdir('tzinfo_test_dir1') do |dir1|
       Dir.mktmpdir('tzinfo_test_dir2') do |dir2|
@@ -98,10 +98,10 @@ class TCZoneinfoDataSource < Minitest::Test
             FileUtils.touch(File.join(dir3, 'iso3166.tab'))
             FileUtils.touch(File.join(dir4, 'zone.tab'))
             FileUtils.touch(File.join(dir4, 'iso3166.tab'))
-            
+
             ZoneinfoDataSource.search_path = [file, dir2, dir3, dir4]
             ZoneinfoDataSource.alternate_iso3166_tab_search_path = []
-            
+
             data_source = ZoneinfoDataSource.new
             assert_equal(dir4, data_source.zoneinfo_dir)
           end
@@ -131,11 +131,11 @@ class TCZoneinfoDataSource < Minitest::Test
       end
     end
   end
-  
+
   def test_new_search_solaris_tab_files
-    # Solaris names the tab files 'tab/country.tab' (iso3166.tab) and 
+    # Solaris names the tab files 'tab/country.tab' (iso3166.tab) and
     # 'tab/zone_sun.tab' (zone.tab).
-    
+
     Dir.mktmpdir('tzinfo_test_dir') do |dir|
       tab = File.join(dir, 'tab')
       FileUtils.mkdir(tab)
@@ -149,29 +149,29 @@ class TCZoneinfoDataSource < Minitest::Test
       assert_equal(dir, data_source.zoneinfo_dir)
     end
   end
-  
+
   def test_new_search_alternate_iso3166_path
     Dir.mktmpdir('tzinfo_test_dir_zoneinfo') do |zoneinfo_dir|
       Dir.mktmpdir('tzinfo_test_dir_tab') do |tab_dir|
         FileUtils.touch(File.join(zoneinfo_dir, 'zone.tab'))
-        
+
         tab_file = File.join(tab_dir, 'iso3166')
-        
+
         ZoneinfoDataSource.search_path = [zoneinfo_dir]
         ZoneinfoDataSource.alternate_iso3166_tab_search_path = [tab_file]
-        
+
         assert_raises(ZoneinfoDirectoryNotFound) do
           ZoneinfoDataSource.new
         end
-        
+
         FileUtils.touch(tab_file)
-      
+
         data_source = ZoneinfoDataSource.new
         assert_equal(zoneinfo_dir, data_source.zoneinfo_dir)
       end
     end
   end
-  
+
   def test_new_search_not_found
     Dir.mktmpdir('tzinfo_test_dir1') do |dir1|
       Dir.mktmpdir('tzinfo_test_dir2') do |dir2|
@@ -196,29 +196,29 @@ class TCZoneinfoDataSource < Minitest::Test
       end
     end
   end
-  
+
   def test_new_search_relative
     Dir.mktmpdir('tzinfo_test') do |dir|
       FileUtils.touch(File.join(dir, 'zone.tab'))
       FileUtils.touch(File.join(dir, 'iso3166.tab'))
-      
+
       FileUtils.chdir(dir)
-      
+
       ZoneinfoDataSource.search_path = ['.']
       ZoneinfoDataSource.alternate_iso3166_tab_search_path = []
       data_source = ZoneinfoDataSource.new
       assert_equal(Pathname.new(dir).realpath.to_s, data_source.zoneinfo_dir)
-      
+
       # Change out of the directory to allow it to be deleted on Windows.
       FileUtils.chdir(@orig_pwd)
     end
   end
-  
+
   def test_new_dir
     Dir.mktmpdir('tzinfo_test') do |dir|
       FileUtils.touch(File.join(dir, 'zone.tab'))
       FileUtils.touch(File.join(dir, 'iso3166.tab'))
-      
+
       data_source = ZoneinfoDataSource.new(dir)
       assert_equal(dir, data_source.zoneinfo_dir)
     end
@@ -233,44 +233,44 @@ class TCZoneinfoDataSource < Minitest::Test
       assert_equal(dir, data_source.zoneinfo_dir)
     end
   end
-  
+
   def test_new_dir_solaris_tab_files
-    # Solaris names the tab files 'tab/country.tab' (iso3166.tab) and 
+    # Solaris names the tab files 'tab/country.tab' (iso3166.tab) and
     # 'tab/zone_sun.tab' (zone.tab).
-    
+
     Dir.mktmpdir('tzinfo_test') do |dir|
       tab = File.join(dir, 'tab')
       FileUtils.mkdir(tab)
       FileUtils.touch(File.join(tab, 'country.tab'))
       FileUtils.touch(File.join(tab, 'zone_sun.tab'))
-            
+
       data_source = ZoneinfoDataSource.new(dir)
       assert_equal(dir, data_source.zoneinfo_dir)
     end
   end
-  
+
   def test_new_dir_alternate_iso3166_path
     Dir.mktmpdir('tzinfo_test_dir_zoneinfo') do |zoneinfo_dir|
       Dir.mktmpdir('tzinfo_test_dir_tab') do |tab_dir|
         FileUtils.touch(File.join(zoneinfo_dir, 'zone.tab'))
-        
+
         tab_file = File.join(tab_dir, 'iso3166')
         FileUtils.touch(tab_file)
-        
+
         ZoneinfoDataSource.alternate_iso3166_tab_search_path = [tab_file]
-        
+
         assert_raises(InvalidZoneinfoDirectory) do
-          # The alternate_iso3166_tab_search_path should not be used. This should raise 
+          # The alternate_iso3166_tab_search_path should not be used. This should raise
           # an exception.
           ZoneinfoDataSource.new(zoneinfo_dir)
         end
-        
+
         data_source = ZoneinfoDataSource.new(zoneinfo_dir, tab_file)
         assert_equal(zoneinfo_dir, data_source.zoneinfo_dir)
       end
     end
   end
-  
+
   def test_new_dir_invalid
     Dir.mktmpdir('tzinfo_test') do |dir|
       assert_raises(InvalidZoneinfoDirectory) do
@@ -278,37 +278,37 @@ class TCZoneinfoDataSource < Minitest::Test
       end
     end
   end
-  
+
   def test_new_dir_invalid_alternate_iso3166_path
     Dir.mktmpdir('tzinfo_test_dir_zoneinfo') do |zoneinfo_dir|
       Dir.mktmpdir('tzinfo_test_dir_tab') do |tab_dir|
         FileUtils.touch(File.join(zoneinfo_dir, 'zone.tab'))
-        
+
         assert_raises(InvalidZoneinfoDirectory) do
           ZoneinfoDataSource.new(zoneinfo_dir, File.join(tab_dir, 'iso3166'))
         end
       end
     end
   end
-  
+
   def test_new_dir_invalid_alternate_iso3166_path_overrides_valid
     Dir.mktmpdir('tzinfo_test_dir_zoneinfo') do |zoneinfo_dir|
       Dir.mktmpdir('tzinfo_test_dir_tab') do |tab_dir|
         FileUtils.touch(File.join(zoneinfo_dir, 'iso3166.tab'))
         FileUtils.touch(File.join(zoneinfo_dir, 'zone.tab'))
-        
+
         assert_raises(InvalidZoneinfoDirectory) do
           ZoneinfoDataSource.new(zoneinfo_dir, File.join(tab_dir, 'iso3166'))
         end
       end
     end
   end
-  
+
   def test_new_file
     Dir.mktmpdir('tzinfo_test') do |dir|
       file = File.join(dir, 'file')
       FileUtils.touch(file)
-      
+
       assert_raises(InvalidZoneinfoDirectory) do
         ZoneinfoDataSource.new(file)
       end
@@ -319,88 +319,88 @@ class TCZoneinfoDataSource < Minitest::Test
     Dir.mktmpdir('tzinfo_test') do |dir|
       FileUtils.touch(File.join(dir, 'zone.tab'))
       FileUtils.touch(File.join(dir, 'iso3166.tab'))
-      
+
       FileUtils.chdir(dir)
-      
+
       data_source = ZoneinfoDataSource.new('.')
       assert_equal(Pathname.new(dir).realpath.to_s, data_source.zoneinfo_dir)
-      
+
       # Change out of the directory to allow it to be deleted on Windows.
       FileUtils.chdir(@orig_pwd)
     end
   end
-  
+
   def test_zoneinfo_dir
     Dir.mktmpdir('tzinfo_test') do |dir|
       FileUtils.touch(File.join(dir, 'zone.tab'))
       FileUtils.touch(File.join(dir, 'iso3166.tab'))
-      
+
       data_source = ZoneinfoDataSource.new(dir)
       assert_equal(dir, data_source.zoneinfo_dir)
       assert_equal(true, data_source.zoneinfo_dir.frozen?)
     end
   end
-  
+
   def test_load_timezone_info_data
     info = @data_source.load_timezone_info('Europe/London')
     assert_kind_of(ZoneinfoTimezoneInfo, info)
     assert_equal('Europe/London', info.identifier)
   end
-  
+
   def test_load_timezone_info_linked
     info = @data_source.load_timezone_info('UTC')
-    
+
     # On platforms that don't support symlinks, 'UTC' will be created as a copy.
     # Either way, a ZoneinfoTimezoneInfo should be returned.
-    
+
     assert_kind_of(ZoneinfoTimezoneInfo, info)
     assert_equal('UTC', info.identifier)
   end
-  
+
   def test_load_timezone_info_does_not_exist
     assert_raises(InvalidTimezoneIdentifier) do
       @data_source.load_timezone_info('Nowhere/Special')
     end
   end
-  
+
   def test_load_timezone_info_invalid
     assert_raises(InvalidTimezoneIdentifier) do
       @data_source.load_timezone_info('../Definitions/Europe/London')
     end
   end
-  
+
   def test_load_timezone_info_ignored_file
     assert_raises(InvalidTimezoneIdentifier) do
       @data_source.load_timezone_info('localtime')
     end
   end
-  
+
   def test_load_timezone_info_ignored_plus_version_file
     # Mac OS X includes a file named +VERSION containing the tzdata version.
-    
+
     Dir.mktmpdir('tzinfo_test') do |dir|
       FileUtils.touch(File.join(dir, 'zone.tab'))
       FileUtils.touch(File.join(dir, 'iso3166.tab'))
-      
+
       File.open(File.join(dir, '+VERSION'), 'w') do |f|
         f.binmode
         f.write("2013a\n")
       end
-      
+
       data_source = ZoneinfoDataSource.new(dir)
-      
+
       assert_raises(InvalidTimezoneIdentifier) do
         data_source.load_timezone_info('+VERSION')
       end
     end
   end
-  
+
   def test_load_timezone_info_nil
     assert_raises(InvalidTimezoneIdentifier) do
       @data_source.load_timezone_info(nil)
     end
   end
-  
+
   def test_load_timezone_info_case
     assert_raises(InvalidTimezoneIdentifier) do
       @data_source.load_timezone_info('europe/london')
@@ -411,80 +411,80 @@ class TCZoneinfoDataSource < Minitest::Test
     Dir.mktmpdir('tzinfo_test') do |dir|
       FileUtils.touch(File.join(dir, 'zone.tab'))
       FileUtils.touch(File.join(dir, 'iso3166.tab'))
-      
+
       file = File.join(dir, 'UTC')
       FileUtils.touch(file)
-      FileUtils.chmod(0200, file)      
-      
+      FileUtils.chmod(0200, file)
+
       data_source = ZoneinfoDataSource.new(dir)
-      
+
       assert_raises(InvalidTimezoneIdentifier) do
         data_source.load_timezone_info('UTC')
       end
     end
   end
-  
+
   def test_load_timezone_info_directory
     Dir.mktmpdir('tzinfo_test') do |dir|
       FileUtils.touch(File.join(dir, 'zone.tab'))
       FileUtils.touch(File.join(dir, 'iso3166.tab'))
-      
+
       subdir = File.join(dir, 'Subdir')
-      FileUtils.mkdir(subdir)     
-      
+      FileUtils.mkdir(subdir)
+
       data_source = ZoneinfoDataSource.new(dir)
-      
+
       assert_raises(InvalidTimezoneIdentifier) do
         data_source.load_timezone_info('Subdir')
       end
     end
   end
-  
+
   def test_load_timezone_info_linked_absolute_outside
     Dir.mktmpdir('tzinfo_test') do |dir|
       Dir.mktmpdir('tzinfo_test') do |outside|
         outside_file = File.join(outside, 'EST')
         FileUtils.cp(File.join(@data_source.zoneinfo_dir, 'EST'), outside_file)
-        
+
         FileUtils.touch(File.join(dir, 'zone.tab'))
         FileUtils.touch(File.join(dir, 'iso3166.tab'))
-        
+
         file = File.join(dir, 'EST')
-        
+
         begin
           FileUtils.ln_s(outside_file, file)
         rescue NotImplementedError
           # Symlinks not supported on this platform - skip test
           return
         end
-        
+
         data_source = ZoneinfoDataSource.new(dir)
-        
+
         info = data_source.load_timezone_info('EST')
         assert_kind_of(ZoneinfoTimezoneInfo, info)
         assert_equal('EST', info.identifier)
       end
     end
   end
-  
+
   def test_load_timezone_info_linked_absolute_inside
     Dir.mktmpdir('tzinfo_test') do |dir|
       FileUtils.touch(File.join(dir, 'zone.tab'))
       FileUtils.touch(File.join(dir, 'iso3166.tab'))
-      
+
       FileUtils.cp(File.join(@data_source.zoneinfo_dir, 'EST'), File.join(dir, 'EST'))
-      
+
       link = File.join(dir, 'Link')
-      
-      begin  
-        FileUtils.ln_s(File.join(File.expand_path(dir), 'EST'), link)      
+
+      begin
+        FileUtils.ln_s(File.join(File.expand_path(dir), 'EST'), link)
       rescue NotImplementedError
         # Symlinks not supported on this platform - skip test
         return
       end
-      
+
       data_source = ZoneinfoDataSource.new(dir)
-      
+
       info = data_source.load_timezone_info('Link')
       assert_kind_of(ZoneinfoTimezoneInfo, info)
       assert_equal('Link', info.identifier)
@@ -494,50 +494,50 @@ class TCZoneinfoDataSource < Minitest::Test
   def test_load_timezone_info_linked_relative_outside
     Dir.mktmpdir('tzinfo_test') do |root|
       FileUtils.cp(File.join(@data_source.zoneinfo_dir, 'EST'), File.join(root, 'outside'))
-      
+
       dir = File.join(root, 'zoneinfo')
       FileUtils.mkdir(dir)
-      
+
       FileUtils.touch(File.join(dir, 'zone.tab'))
       FileUtils.touch(File.join(dir, 'iso3166.tab'))
-      
-      link = File.join(dir, 'Link')      
-      
+
+      link = File.join(dir, 'Link')
+
       begin
         FileUtils.ln_s('../outside', link)
       rescue NotImplementedError
         # Symlinks not supported on this platform - skip test
         return
       end
-      
+
       subdir = File.join(dir, 'Subdir')
       subdir_link = File.join(subdir, 'Link')
       FileUtils.mkdir(subdir)
       FileUtils.ln_s('../../outside', subdir_link)
-      
+
       data_source = ZoneinfoDataSource.new(dir)
-      
+
       info = data_source.load_timezone_info('Link')
       assert_kind_of(ZoneinfoTimezoneInfo, info)
       assert_equal('Link', info.identifier)
-      
+
       info = data_source.load_timezone_info('Subdir/Link')
       assert_kind_of(ZoneinfoTimezoneInfo, info)
       assert_equal('Subdir/Link', info.identifier)
     end
   end
-  
+
   def test_load_timezone_info_linked_relative_parent_inside
     Dir.mktmpdir('tzinfo_test') do |dir|
       FileUtils.touch(File.join(dir, 'zone.tab'))
       FileUtils.touch(File.join(dir, 'iso3166.tab'))
-      
+
       FileUtils.cp(File.join(@data_source.zoneinfo_dir, 'EST'), File.join(dir, 'EST'))
-       
+
       subdir = File.join(dir, 'Subdir')
       FileUtils.mkdir(subdir)
       FileUtils.cp(File.join(@data_source.zoneinfo_dir, 'EST'), File.join(subdir, 'EST'))
-      
+
       subdir_link = File.join(subdir, 'Link')
       begin
         FileUtils.ln_s('../Subdir/EST', subdir_link)
@@ -545,55 +545,55 @@ class TCZoneinfoDataSource < Minitest::Test
         # Symlinks not supported on this platform - skip test
         return
       end
-      
+
       subdir_link2 = File.join(subdir, 'Link2')
       FileUtils.ln_s('../EST', subdir_link2)
-      
+
       subdir2 = File.join(dir, 'Subdir2')
       FileUtils.mkdir(subdir2)
       subdir2_link = File.join(subdir2, 'Link')
       FileUtils.ln_s('../Subdir/EST', subdir2_link)
-      
+
       data_source = ZoneinfoDataSource.new(dir)
-      
+
       info = data_source.load_timezone_info('Subdir/Link')
       assert_kind_of(ZoneinfoTimezoneInfo, info)
       assert_equal('Subdir/Link', info.identifier)
-      
+
       info = data_source.load_timezone_info('Subdir/Link2')
       assert_kind_of(ZoneinfoTimezoneInfo, info)
       assert_equal('Subdir/Link2', info.identifier)
-      
+
       info = data_source.load_timezone_info('Subdir2/Link')
       assert_kind_of(ZoneinfoTimezoneInfo, info)
       assert_equal('Subdir2/Link', info.identifier)
     end
   end
-  
+
   def test_load_timezone_info_invalid_file
     Dir.mktmpdir('tzinfo_test') do |dir|
       FileUtils.touch(File.join(dir, 'zone.tab'))
       FileUtils.touch(File.join(dir, 'iso3166.tab'))
-  
+
       File.open(File.join(dir, 'Zone'), 'wb') do |file|
-        file.write('NotAValidTZifFile')        
+        file.write('NotAValidTZifFile')
       end
-      
+
       data_source = ZoneinfoDataSource.new(dir)
-      
+
       assert_raises(InvalidTimezoneIdentifier) do
         data_source.load_timezone_info('Zone')
-      end      
+      end
     end
   end
-    
+
   def test_load_timezone_info_invalid_file_2
     Dir.mktmpdir('tzinfo_test') do |dir|
       FileUtils.touch(File.join(dir, 'zone.tab'))
       FileUtils.touch(File.join(dir, 'iso3166.tab'))
 
-      zone = File.join(dir, 'Zone')      
-      
+      zone = File.join(dir, 'Zone')
+
       File.open(File.join(@data_source.zoneinfo_dir, 'EST')) do |src|
         # Change header to TZif1 (which is not a valid header).
         File.open(zone, 'wb') do |dest|
@@ -602,12 +602,12 @@ class TCZoneinfoDataSource < Minitest::Test
           FileUtils.copy_stream(src, dest)
         end
       end
-      
+
       data_source = ZoneinfoDataSource.new(dir)
-      
+
       assert_raises(InvalidTimezoneIdentifier) do
         data_source.load_timezone_info('Zone')
-      end      
+      end
     end
   end
 
@@ -620,14 +620,14 @@ class TCZoneinfoDataSource < Minitest::Test
       assert(identifier.tainted?)
     end
   end
-  
+
   def test_load_timezone_info_tainted_and_frozen
     safe_test do
       info = @data_source.load_timezone_info('Europe/Amsterdam'.dup.taint.freeze)
       assert_equal('Europe/Amsterdam', info.identifier)
     end
   end
-  
+
   def test_load_timezone_info_tainted_zoneinfo_dir_safe_mode
     safe_test(:unavailable => :skip) do
       assert_raises(SecurityError) do
@@ -635,31 +635,31 @@ class TCZoneinfoDataSource < Minitest::Test
       end
     end
   end
-  
+
   def test_load_timezone_info_tainted_zoneinfo_dir
     data_source = ZoneinfoDataSource.new(@data_source.zoneinfo_dir.dup.taint)
     info = data_source.load_timezone_info('Europe/London')
     assert_kind_of(ZoneinfoTimezoneInfo, info)
     assert_equal('Europe/London', info.identifier)
   end
-  
+
   def get_timezone_filenames(directory)
     entries = Dir.glob(File.join(directory, '**', '*'))
-    
+
     entries = entries.select do |file|
       file.untaint
       File.file?(file)
     end
-       
+
     entries = entries.collect {|file| file[directory.length + File::SEPARATOR.length, file.length - directory.length - File::SEPARATOR.length]}
 
     # Exclude right (with leapseconds) and posix (copy) directories; .tab files; localtime, posixrules and Factory zones
-    entries = entries.select do |file| 
+    entries = entries.select do |file|
       file !~ /\A(posix|right)\// &&
         file !~ /\.tab\z/ &&
         !%w(localtime posixrules Factory).include?(file)
     end
-    
+
     entries.sort
   end
 
@@ -670,7 +670,7 @@ class TCZoneinfoDataSource < Minitest::Test
     assert_array_same_items(expected, all)
     assert_equal(true, all.frozen?)
   end
-  
+
   def test_data_timezone_identifiers
     expected = get_timezone_filenames(@data_source.zoneinfo_dir)
     all_data = @data_source.data_timezone_identifiers
@@ -678,14 +678,14 @@ class TCZoneinfoDataSource < Minitest::Test
     assert_array_same_items(expected, all_data)
     assert_equal(true, all_data.frozen?)
   end
-  
+
   def test_linked_timezone_identifiers
     all_linked = @data_source.linked_timezone_identifiers
     assert_kind_of(Array, all_linked)
     assert_equal(true, all_linked.empty?)
     assert_equal(true, all_linked.frozen?)
   end
-  
+
   def test_timezone_identifiers_safe_mode
     safe_test do
       expected = get_timezone_filenames(@data_source.zoneinfo_dir)
@@ -695,77 +695,77 @@ class TCZoneinfoDataSource < Minitest::Test
       assert_equal(true, all.frozen?)
     end
   end
-  
+
   def test_timezone_identifiers_ignored_plus_version_file
     # Mac OS X includes a file named +VERSION containing the tzdata version.
-    
+
     Dir.mktmpdir('tzinfo_test') do |dir|
       FileUtils.touch(File.join(dir, 'zone.tab'))
       FileUtils.touch(File.join(dir, 'iso3166.tab'))
       FileUtils.cp(File.join(@data_source.zoneinfo_dir, 'EST'), File.join(dir, 'EST'))
-      
+
       File.open(File.join(dir, '+VERSION'), 'w') do |f|
         f.binmode
         f.write("2013a\n")
       end
-      
+
       data_source = ZoneinfoDataSource.new(dir)
       assert_array_same_items(['EST'], data_source.timezone_identifiers)
     end
   end
-  
+
   def test_timezone_identifiers_ignored_src_directory
     # Solaris includes a src directory containing the source timezone data files
     # from the tzdata distribution. These should be ignored.
-    
+
     Dir.mktmpdir('tzinfo_test') do |dir|
       FileUtils.touch(File.join(dir, 'zone.tab'))
       FileUtils.touch(File.join(dir, 'iso3166.tab'))
       FileUtils.cp(File.join(@data_source.zoneinfo_dir, 'EST'), File.join(dir, 'EST'))
-      
+
       src_dir = File.join(dir, 'src')
       FileUtils.mkdir(src_dir)
-      
+
       File.open(File.join(src_dir, 'europe'), 'w') do |f|
         f.binmode
         f.write("Zone\tEurope/London\t0:00\tEU\tGMT/BST\n")
-      end      
-      
+      end
+
       data_source = ZoneinfoDataSource.new(dir)
       assert_array_same_items(['EST'], data_source.timezone_identifiers)
     end
   end
-  
+
   def test_load_country_info
     info = @data_source.load_country_info('GB')
     assert_equal('GB', info.code)
     assert_equal('Britain (UK)', info.name)
   end
-    
+
   def test_load_country_info_not_exist
     assert_raises(InvalidCountryCode) do
       @data_source.load_country_info('ZZ')
     end
   end
-  
+
   def test_load_country_info_invalid
     assert_raises(InvalidCountryCode) do
       @data_source.load_country_info('../Countries/GB')
     end
   end
-  
+
   def test_load_country_info_nil
     assert_raises(InvalidCountryCode) do
       @data_source.load_country_info(nil)
     end
   end
-  
+
   def test_load_country_info_case
     assert_raises(InvalidCountryCode) do
       @data_source.load_country_info('gb')
     end
   end
-  
+
   def test_load_country_info_tainted
     safe_test do
       code = 'NL'.dup.taint
@@ -775,23 +775,23 @@ class TCZoneinfoDataSource < Minitest::Test
       assert(code.tainted?)
     end
   end
-  
+
   def test_load_country_info_tainted_and_frozen
     safe_test do
       info = @data_source.load_country_info('NL'.dup.taint.freeze)
       assert_equal('NL', info.code)
     end
   end
-  
+
   def test_load_country_info_check_zones
     Dir.mktmpdir('tzinfo_test') do |dir|
-      RubyCoreSupport.open_file(File.join(dir, 'iso3166.tab'), 'w', :external_encoding => 'UTF-8') do |iso3166|      
+      RubyCoreSupport.open_file(File.join(dir, 'iso3166.tab'), 'w', :external_encoding => 'UTF-8') do |iso3166|
         iso3166.puts('# iso3166.tab')
         iso3166.puts('')
         iso3166.puts("FC\tFake Country")
         iso3166.puts("OC\tOther Country")
       end
-      
+
       RubyCoreSupport.open_file(File.join(dir, 'zone.tab'), 'w', :external_encoding => 'UTF-8') do |zone|
         zone.puts('# zone.tab')
         zone.puts('')
@@ -800,9 +800,9 @@ class TCZoneinfoDataSource < Minitest::Test
         zone.puts("FC\t-2332-04637\tFake/Three\tThis is Three")
         zone.puts("OC\t+5005+01426\tOther/One")
       end
-      
+
       data_source = ZoneinfoDataSource.new(dir)
-      
+
       info = data_source.load_country_info('FC')
       assert_equal('FC', info.code)
       assert_equal('Fake Country', info.name)
@@ -813,7 +813,7 @@ class TCZoneinfoDataSource < Minitest::Test
         CountryTimezone.new('Fake/Two', Rational(32089, 900), Rational(503081, 3600), 'Another description'),
         CountryTimezone.new('Fake/Three', Rational(-353, 15), Rational(-2797, 60), 'This is Three')], info.zones)
       assert_equal(true, info.zones.frozen?)
-      
+
       info = data_source.load_country_info('OC')
       assert_equal('OC', info.code)
       assert_equal('Other Country', info.name)
@@ -897,7 +897,7 @@ class TCZoneinfoDataSource < Minitest::Test
       assert_equal(true, info.zones.frozen?)
     end
   end
-  
+
   def test_load_country_info_check_zones_solaris_tab_files
     # Solaris uses 5 columns instead of the usual 4 in zone_sun.tab.
     # An extra column before the comment gives an optional linked/alternate
@@ -907,18 +907,18 @@ class TCZoneinfoDataSource < Minitest::Test
     # covering regions. These are given lower-case "country" codes. The timezone
     # identifier column refers to a continent instead of an identifier. These
     # lines will be ignored by TZInfo.
-    
+
     Dir.mktmpdir('tzinfo_test') do |dir|
       tab_dir = File.join(dir, 'tab')
       FileUtils.mkdir(tab_dir)
-    
+
       RubyCoreSupport.open_file(File.join(tab_dir, 'country.tab'), 'w', :external_encoding => 'UTF-8') do |country|
         country.puts('# country.tab')
         country.puts('# Solaris')
         country.puts("FC\tFake Country")
         country.puts("OC\tOther Country")
       end
-      
+
       RubyCoreSupport.open_file(File.join(tab_dir, 'zone_sun.tab'), 'w', :external_encoding => 'UTF-8') do |zone_sun|
         zone_sun.puts('# zone_sun.tab')
         zone_sun.puts('# Solaris')
@@ -933,9 +933,9 @@ class TCZoneinfoDataSource < Minitest::Test
         zone_sun.puts("me\t+0000+00000\tEurope/\tMET")
         zone_sun.puts("we\t+0000+00000\tEurope/\tWET")
       end
-      
+
       data_source = ZoneinfoDataSource.new(dir)
-      
+
       info = data_source.load_country_info('FC')
       assert_equal('FC', info.code)
       assert_equal('Fake Country', info.name)
@@ -946,7 +946,7 @@ class TCZoneinfoDataSource < Minitest::Test
         CountryTimezone.new('Fake/Two', Rational(32089, 900), Rational(503081, 3600), 'Another description'),
         CountryTimezone.new('Fake/Three', Rational(-353, 15), Rational(-2797, 60), 'This is Three')], info.zones)
       assert_equal(true, info.zones.frozen?)
-      
+
       info = data_source.load_country_info('OC')
       assert_equal('OC', info.code)
       assert_equal('Other Country', info.name)
@@ -958,30 +958,30 @@ class TCZoneinfoDataSource < Minitest::Test
       assert_equal(true, info.zones.frozen?)
     end
   end
-  
+
   def test_load_country_info_check_zones_alternate_iso3166_file
     Dir.mktmpdir('tzinfo_test') do |dir|
       zoneinfo_dir = File.join(dir, 'zoneinfo')
       tab_dir = File.join(dir, 'tab')
       FileUtils.mkdir(zoneinfo_dir)
       FileUtils.mkdir(tab_dir)
-      
+
       tab_file = File.join(tab_dir, 'iso3166')
       RubyCoreSupport.open_file(tab_file, 'w', :external_encoding => 'UTF-8') do |iso3166|
         # Use the BSD 4 column format (alternate iso3166 is used on BSD).
         iso3166.puts("FC\tFCC\t001\tFake Country")
         iso3166.puts("OC\tOCC\t002\tOther Country")
       end
-      
+
       RubyCoreSupport.open_file(File.join(zoneinfo_dir, 'zone.tab'), 'w', :external_encoding => 'UTF-8') do |zone|
         zone.puts("FC\t+513030-0000731\tFake/One\tDescription of one")
         zone.puts("FC\t+353916+1394441\tFake/Two\tAnother description")
         zone.puts("FC\t-2332-04637\tFake/Three\tThis is Three")
         zone.puts("OC\t+5005+01426\tOther/One")
       end
-      
+
       data_source = ZoneinfoDataSource.new(zoneinfo_dir, tab_file)
-      
+
       info = data_source.load_country_info('FC')
       assert_equal('FC', info.code)
       assert_equal('Fake Country', info.name)
@@ -992,7 +992,7 @@ class TCZoneinfoDataSource < Minitest::Test
         CountryTimezone.new('Fake/Two', Rational(32089, 900), Rational(503081, 3600), 'Another description'),
         CountryTimezone.new('Fake/Three', Rational(-353, 15), Rational(-2797, 60), 'This is Three')], info.zones)
       assert_equal(true, info.zones.frozen?)
-      
+
       info = data_source.load_country_info('OC')
       assert_equal('OC', info.code)
       assert_equal('Other Country', info.name)
@@ -1002,29 +1002,29 @@ class TCZoneinfoDataSource < Minitest::Test
       assert_equal(true, info.zones.frozen?)
     end
   end
-  
+
   def test_load_country_info_four_column_iso31611
     # OpenBSD and FreeBSD use a 4 column iso3166.tab file that includes
     # alpha-3 and numeric-3 codes in addition to the alpha-2 and name in the
     # tz database version.
-    
+
     Dir.mktmpdir('tzinfo_test') do |dir|
       RubyCoreSupport.open_file(File.join(dir, 'iso3166.tab'), 'w', :external_encoding => 'UTF-8') do |iso3166|
         iso3166.puts("FC\tFCC\t001\tFake Country")
         iso3166.puts("OC\tOCC\t002\tOther Country")
       end
-      
+
       RubyCoreSupport.open_file(File.join(dir, 'zone.tab'), 'w', :external_encoding => 'UTF-8') do |zone|
         zone.puts("FC\t+513030-0000731\tFake/One\tDescription of one")
         zone.puts("OC\t+5005+01426\tOther/One")
       end
-      
+
       data_source = ZoneinfoDataSource.new(dir)
-      
+
       info = data_source.load_country_info('FC')
       assert_equal('FC', info.code)
       assert_equal('Fake Country', info.name)
-      
+
       info = data_source.load_country_info('OC')
       assert_equal('OC', info.code)
       assert_equal('Other Country', info.name)
@@ -1037,18 +1037,18 @@ class TCZoneinfoDataSource < Minitest::Test
 
     # zone.tab is in ASCII, with no plans to change. Since ASCII is a subset of
     # UTF-8, test that this is loaded in UTF-8 anyway.
-    
+
     Dir.mktmpdir('tzinfo_test') do |dir|
       RubyCoreSupport.open_file(File.join(dir, 'iso3166.tab'), 'w', :external_encoding => 'UTF-8') do |iso3166|
         iso3166.puts("UT\tUnicode Test ✓")
       end
-      
+
       RubyCoreSupport.open_file(File.join(dir, 'zone.tab'), 'w', :external_encoding => 'UTF-8') do |zone|
         zone.puts("UT\t+513030-0000731\tUnicode✓/One\tUnicode Description ✓")
       end
-      
+
       data_source = ZoneinfoDataSource.new(dir)
-      
+
       info = data_source.load_country_info('UT')
       assert_equal('UT', info.code)
       assert_equal('Unicode Test ✓', info.name)
@@ -1081,40 +1081,40 @@ class TCZoneinfoDataSource < Minitest::Test
       assert_equal([CountryTimezone.new('Unicode✓/One', Rational(6181, 120), Rational(-451, 3600), 'Unicode Description ✓')], info.zones)
     end
   end
-  
+
   def test_country_codes
     file_codes = []
-        
+
     RubyCoreSupport.open_file(File.join(@data_source.zoneinfo_dir, 'iso3166.tab'), 'r', :external_encoding => 'UTF-8', :internal_encoding => 'UTF-8') do |file|
       file.each_line do |line|
         line.chomp!
         file_codes << $1 if line =~ /\A([A-Z]{2})\t/
       end
     end
-    
+
     codes = @data_source.country_codes
     assert_array_same_items(file_codes, codes)
     assert_equal(true, codes.frozen?)
   end
-  
+
   def test_country_codes_four_column_iso3166
     # OpenBSD and FreeBSD use a 4 column iso3166.tab file that includes
     # alpha-3 and numeric-3 codes in addition to the alpha-2 and name in the
     # tz database version.
-    
+
     Dir.mktmpdir('tzinfo_test') do |dir|
       RubyCoreSupport.open_file(File.join(dir, 'iso3166.tab'), 'w', :external_encoding => 'UTF-8') do |iso3166|
         iso3166.puts("FC\tFCC\t001\tFake Country")
         iso3166.puts("OC\tOCC\t002\tOther Country")
       end
-      
+
       RubyCoreSupport.open_file(File.join(dir, 'zone.tab'), 'w', :external_encoding => 'UTF-8') do |zone|
         zone.puts("FC\t+513030-0000731\tFake/One\tDescription of one")
         zone.puts("OC\t+5005+01426\tOther/One")
       end
-      
+
       data_source = ZoneinfoDataSource.new(dir)
-      
+
       codes = data_source.country_codes
       assert_array_same_items(%w(FC OC), codes)
     end

--- a/test/tc_zoneinfo_timezone_info.rb
+++ b/test/tc_zoneinfo_timezone_info.rb
@@ -23,7 +23,7 @@ class TCZoneinfoTimezoneInfo < Minitest::Test
     SUPPORTS_NEGATIVE = false
   end
 
-  def assert_period(abbreviation, utc_offset, std_offset, dst, start_at, end_at, info)    
+  def assert_period(abbreviation, utc_offset, std_offset, dst, start_at, end_at, info)
     if start_at
       period = info.period_for_utc(start_at)
     elsif end_at
@@ -32,19 +32,19 @@ class TCZoneinfoTimezoneInfo < Minitest::Test
       # no transitions, pick the epoch
       period = info.period_for_utc(Time.utc(1970, 1, 1))
     end
-    
+
     assert_equal(abbreviation, period.abbreviation)
     assert_equal(utc_offset, period.utc_offset)
     assert_equal(std_offset, period.std_offset)
     assert_equal(dst, period.dst?)
-    
+
     if start_at
       refute_nil(period.utc_start_time)
       assert_equal(start_at, period.utc_start_time)
     else
       assert_nil(period.utc_start_time)
     end
-    
+
     if end_at
       refute_nil(period.utc_end_time)
       assert_equal(end_at, period.utc_end_time)
@@ -52,7 +52,7 @@ class TCZoneinfoTimezoneInfo < Minitest::Test
       assert_nil(period.utc_end_time)
     end
   end
-  
+
   def convert_times_to_i(items, key = :at)
     items.each do |item|
       if item[key].kind_of?(Time)
@@ -60,31 +60,31 @@ class TCZoneinfoTimezoneInfo < Minitest::Test
       end
     end
   end
-  
+
   def select_with_32bit_values(items, key = :at)
     items.select do |item|
       i = item[key]
       i >= -2147483648 && i <= 2147483647
     end
   end
-  
+
   def pack_int64_network_order(values)
     values.collect {|value| [value >> 32, value & 0xFFFFFFFF]}.flatten.pack('NN' * values.length)
   end
-  
+
   def pack_int64_signed_network_order(values)
     # Convert to the equivalent 64-bit unsigned integer with the same bit representation
     pack_int64_network_order(values.collect {|value| value < 0 ? value + 0x10000000000000000 : value})
   end
-  
+
   def write_tzif(format, offsets, transitions, leaps = [], options = {})
-    
+
     # Options for testing malformed zoneinfo files.
     magic = options[:magic]
     section2_magic = options[:section2_magic]
     abbrev_separator = options[:abbrev_separator] || "\0"
     abbrev_offset_base = options[:abbrev_offset_base] || 0
-      
+
     unless magic
       if format == 1
         magic = "TZif\0"
@@ -94,21 +94,21 @@ class TCZoneinfoTimezoneInfo < Minitest::Test
         raise ArgumentError, 'Invalid format specified'
       end
     end
-    
+
     if section2_magic.kind_of?(Proc)
       section2_magic = section2_magic.call(format)
     else
       section2_magic = magic unless section2_magic
     end
-    
+
     convert_times_to_i(transitions)
-    convert_times_to_i(leaps)    
-    
+    convert_times_to_i(leaps)
+
     abbrevs = offsets.collect {|o| o[:abbrev]}.uniq
-    
+
     if abbrevs.length > 0
-      abbrevs = abbrevs.collect {|a| a.encode('UTF-8')} if abbrevs.first.respond_to?(:encode)    
-    
+      abbrevs = abbrevs.collect {|a| a.encode('UTF-8')} if abbrevs.first.respond_to?(:encode)
+
       if abbrevs.first.respond_to?(:bytesize)
         abbrevs_length = abbrevs.inject(0) {|sum, a| sum + a.bytesize + abbrev_separator.bytesize}
       else
@@ -117,110 +117,110 @@ class TCZoneinfoTimezoneInfo < Minitest::Test
     else
       abbrevs_length = 0
     end
-  
-    b32_transitions = select_with_32bit_values(transitions)    
+
+    b32_transitions = select_with_32bit_values(transitions)
     b32_leaps = select_with_32bit_values(leaps)
-  
+
     Tempfile.open('tzinfo-test-zone') do |file|
       file.binmode
-      
+
       file.write(
-        [magic, offsets.length, offsets.length, leaps.length, 
+        [magic, offsets.length, offsets.length, leaps.length,
          b32_transitions.length, offsets.length, abbrevs_length].pack('a5 x15 NNNNNN'))
-	
+
       unless b32_transitions.empty?
         file.write(b32_transitions.collect {|t| t[:at]}.pack('N' * b32_transitions.length))
         file.write(b32_transitions.collect {|t| t[:offset_index]}.pack('C' * b32_transitions.length))
       end
-      
+
       offsets.each do |offset|
         index = abbrevs.index(offset[:abbrev])
         abbrev_offset = abbrev_offset_base
         0.upto(index - 1) {|i| abbrev_offset += abbrevs[i].length + 1}
-      
+
         file.write([offset[:gmtoff], offset[:isdst] ? 1 : 0, abbrev_offset].pack('NCC'))
       end
-          
+
       abbrevs.each do |a|
         file.write(a)
         file.write(abbrev_separator)
       end
-      
+
       b32_leaps.each do |leap|
         file.write([leap[:at], leap[:seconds]].pack('NN'))
       end
-      
+
       unless offsets.empty?
         file.write("\0" * offsets.length * 2)
       end
-      
+
       if format >= 2
         file.write(
-          [section2_magic, offsets.length, offsets.length, leaps.length, 
+          [section2_magic, offsets.length, offsets.length, leaps.length,
            transitions.length, offsets.length, abbrevs_length].pack('a5 x15 NNNNNN'))
-    
+
         unless transitions.empty?
           file.write(pack_int64_signed_network_order(transitions.collect {|t| t[:at]}))
           file.write(transitions.collect {|t| t[:offset_index]}.pack('C' * transitions.length))
         end
-        
+
         offsets.each do |offset|
           index = abbrevs.index(offset[:abbrev])
           abbrev_offset = abbrev_offset_base
           0.upto(index - 1) {|i| abbrev_offset += abbrevs[i].length + 1}
-        
+
           file.write([offset[:gmtoff], offset[:isdst] ? 1 : 0, abbrev_offset].pack('NCC'))
         end
-        
+
         abbrevs.each do |a|
           file.write(a)
           file.write(abbrev_separator)
         end
-        
-        leaps.each do |leap|          
+
+        leaps.each do |leap|
           file.write(pack_int64_signed_network_order([leap[:at]]))
           file.write([leap[:seconds]].pack('N'))
         end
-        
+
         unless offsets.empty?
           file.write("\0" * offsets.length * 2)
         end
-        
+
         # Empty POSIX timezone string
         file.write("\n\n")
       end
-      
+
       file.flush
-      
+
       yield file.path, format
     end
   end
-  
+
   def tzif_test(offsets, transitions, leaps = [], options = {}, &block)
     min_format = options[:min_format] || 1
-    
+
     min_format.upto(3) do |format|
       write_tzif(format, offsets, transitions, leaps, options, &block)
     end
   end
-  
+
   def test_load
     offsets = [
       {:gmtoff => 3542, :isdst => false, :abbrev => 'LMT'},
       {:gmtoff => 3600, :isdst => false, :abbrev => 'XST'},
       {:gmtoff => 7200, :isdst => true,  :abbrev => 'XDT'},
       {:gmtoff =>    0, :isdst => false, :abbrev => 'XNST'}]
-      
+
     transitions = [
       {:at => Time.utc(1971,  1,  2), :offset_index => 1},
       {:at => Time.utc(1980,  4, 22), :offset_index => 2},
       {:at => Time.utc(1980, 10, 21), :offset_index => 1},
       {:at => Time.utc(2000, 12, 31), :offset_index => 3}]
-  
-    tzif_test(offsets, transitions) do |path, format|     
+
+    tzif_test(offsets, transitions) do |path, format|
       info = ZoneinfoTimezoneInfo.new('Zone/One', path)
       assert_equal('Zone/One', info.identifier)
-      
+
       assert_period(:LMT,  3542,    0, false,                    nil, Time.utc(1971,  1,  2), info)
       assert_period(:XST,  3600,    0, false, Time.utc(1971,  1,  2), Time.utc(1980,  4, 22), info)
       assert_period(:XDT,  3600, 3600,  true, Time.utc(1980,  4, 22), Time.utc(1980, 10, 21), info)
@@ -228,24 +228,24 @@ class TCZoneinfoTimezoneInfo < Minitest::Test
       assert_period(:XNST,    0,    0, false, Time.utc(2000, 12, 31),                    nil, info)
     end
   end
-  
+
   def test_load_negative_utc_offset
     offsets = [
       {:gmtoff => -12492, :isdst => false, :abbrev => 'LMT'},
       {:gmtoff => -12000, :isdst => false, :abbrev => 'XST'},
       {:gmtoff => -8400,  :isdst => true,  :abbrev => 'XDT'},
       {:gmtoff => -8400,  :isdst => false, :abbrev => 'XNST'}]
-      
+
     transitions = [
       {:at => Time.utc(1971,  7,  9, 3,  0, 0), :offset_index => 1},
       {:at => Time.utc(1972, 10, 12, 3,  0, 0), :offset_index => 2},
       {:at => Time.utc(1973,  4, 29, 3,  0, 0), :offset_index => 1},
       {:at => Time.utc(1992,  4,  1, 4, 30, 0), :offset_index => 3}]
-  
-    tzif_test(offsets, transitions) do |path, format|     
+
+    tzif_test(offsets, transitions) do |path, format|
       info = ZoneinfoTimezoneInfo.new('Zone/One', path)
       assert_equal('Zone/One', info.identifier)
-      
+
       assert_period(:LMT, -12492,    0, false,                              nil, Time.utc(1971,  7,  9, 3,  0, 0), info)
       assert_period(:XST, -12000,    0, false, Time.utc(1971,  7,  9, 3,  0, 0), Time.utc(1972, 10, 12, 3,  0, 0), info)
       assert_period(:XDT, -12000, 3600,  true, Time.utc(1972, 10, 12, 3,  0, 0), Time.utc(1973,  4, 29, 3,  0, 0), info)
@@ -253,97 +253,97 @@ class TCZoneinfoTimezoneInfo < Minitest::Test
       assert_period(:XNST, -8400,    0, false, Time.utc(1992,  4,  1, 4, 30, 0),                              nil, info)
     end
   end
-  
+
   def test_load_dst_first
     offsets = [
       {:gmtoff => 7200, :isdst => true,  :abbrev => 'XDT'},
       {:gmtoff => 3542, :isdst => false, :abbrev => 'LMT'},
       {:gmtoff => 3600, :isdst => false, :abbrev => 'XST'},
       {:gmtoff =>    0, :isdst => false, :abbrev => 'XNST'}]
-      
+
     transitions = [
       {:at => Time.utc(1979,  1,  2), :offset_index => 2},
       {:at => Time.utc(1980,  4, 22), :offset_index => 0},
       {:at => Time.utc(1980, 10, 21), :offset_index => 2},
       {:at => Time.utc(2000, 12, 31), :offset_index => 3}]
-  
+
     tzif_test(offsets, transitions) do |path, format|
       info = ZoneinfoTimezoneInfo.new('Zone/Two', path)
       assert_equal('Zone/Two', info.identifier)
-      
-      assert_period(:LMT, 3542, 0, false, nil, Time.utc(1979, 1, 2), info)      
+
+      assert_period(:LMT, 3542, 0, false, nil, Time.utc(1979, 1, 2), info)
     end
   end
-    
+
   def test_load_no_transitions
     offsets = [{:gmtoff => -12094, :isdst => false, :abbrev => 'LT'}]
-        
+
     tzif_test(offsets, []) do |path, format|
       info = ZoneinfoTimezoneInfo.new('Zone/three', path)
       assert_equal('Zone/three', info.identifier)
-      
+
       assert_period(:LT, -12094, 0, false, nil, nil, info)
     end
   end
-  
+
   def test_load_invalid_offset_index
     offsets = [{:gmtoff => -0, :isdst => false, :abbrev => 'LMT'}]
     transitions = [{:at => Time.utc(2000, 12, 31), :offset_index => 2}]
-        
+
     tzif_test(offsets, transitions) do |path, format|
       assert_raises(InvalidZoneinfoFile) do
         ZoneinfoTimezoneInfo.new('Zone', path)
       end
     end
   end
-  
+
   def test_load_with_leap_seconds
     offsets = [{:gmtoff => -0, :isdst => false, :abbrev => 'LMT'}]
     leaps = [{:at => Time.utc(1972,6,30,23,59,60), :seconds => 1}]
-        
+
     tzif_test(offsets, [], leaps) do |path, format|
       assert_raises(InvalidZoneinfoFile) do
         ZoneinfoTimezoneInfo.new('Zone', path)
       end
     end
   end
-  
+
   def test_load_invalid_magic
-    ['TZif4', 'tzif2', '12345'].each do |magic|    
+    ['TZif4', 'tzif2', '12345'].each do |magic|
       offsets = [{:gmtoff => -12094, :isdst => false, :abbrev => 'LT'}]
-          
-      tzif_test(offsets, [], [], :magic => magic) do |path, format|        
+
+      tzif_test(offsets, [], [], :magic => magic) do |path, format|
         assert_raises(InvalidZoneinfoFile) do
           ZoneinfoTimezoneInfo.new('Zone2', path)
         end
       end
     end
   end
-  
+
   # These tests can only be run if the platform supports 64-bit Times. When
-  # 64-bit support is unavailable, the second section will not be read, so no 
+  # 64-bit support is unavailable, the second section will not be read, so no
   # error will be raised.
   if SUPPORTS_64BIT
     def test_load_invalid_section2_magic
-      ['TZif4', 'tzif2', '12345'].each do |section2_magic|    
+      ['TZif4', 'tzif2', '12345'].each do |section2_magic|
         offsets = [{:gmtoff => -12094, :isdst => false, :abbrev => 'LT'}]
-            
-        tzif_test(offsets, [], [], :min_format => 2, :section2_magic => section2_magic) do |path, format|        
+
+        tzif_test(offsets, [], [], :min_format => 2, :section2_magic => section2_magic) do |path, format|
           assert_raises(InvalidZoneinfoFile) do
             ZoneinfoTimezoneInfo.new('Zone4', path)
           end
         end
       end
     end
-    
+
     def test_load_mismatched_section2_magic
       minus_one = Proc.new {|f| f == 2 ? "TZif\0" : "TZif#{f - 1}" }
       plus_one = Proc.new {|f| "TZif#{f + 1}" }
-      
-      [minus_one, plus_one].each do |section2_magic|    
+
+      [minus_one, plus_one].each do |section2_magic|
         offsets = [{:gmtoff => -12094, :isdst => false, :abbrev => 'LT'}]
-            
-        tzif_test(offsets, [], [], :min_format => 2, :section2_magic => section2_magic) do |path, format|        
+
+        tzif_test(offsets, [], [], :min_format => 2, :section2_magic => section2_magic) do |path, format|
           assert_raises(InvalidZoneinfoFile) do
             ZoneinfoTimezoneInfo.new('Zone5', path)
           end
@@ -351,71 +351,71 @@ class TCZoneinfoTimezoneInfo < Minitest::Test
       end
     end
   end
-  
+
   def test_load_invalid_format
     Tempfile.open('tzinfo-test-zone') do |file|
       file.write('Invalid')
       file.flush
-      
+
       assert_raises(InvalidZoneinfoFile) do
         ZoneinfoTimezoneInfo.new('Zone3', file.path)
       end
     end
   end
-  
+
   def test_load_missing_abbrev_null_termination
     offsets = [
       {:gmtoff => 3542, :isdst => false, :abbrev => 'LMT'},
       {:gmtoff => 3600, :isdst => false,  :abbrev => 'XST'}]
-      
+
     transitions = [
       {:at => Time.utc(2000, 1, 1), :offset_index => 1}]
-            
+
     tzif_test(offsets, transitions, [], :abbrev_separator => '^') do |path, format|
       assert_raises(InvalidZoneinfoFile) do
         ZoneinfoTimezoneInfo.new('Zone', path)
       end
     end
   end
-  
+
   def test_load_out_of_range_abbrev_offsets
     offsets = [
       {:gmtoff => 3542, :isdst => false, :abbrev => 'LMT'},
       {:gmtoff => 3600, :isdst => false,  :abbrev => 'XST'}]
-      
+
     transitions = [
       {:at => Time.utc(2000, 1, 1), :offset_index => 1}]
-            
+
     tzif_test(offsets, transitions, [], :abbrev_offset_base => 8) do |path, format|
       assert_raises(InvalidZoneinfoFile) do
         ZoneinfoTimezoneInfo.new('Zone', path)
       end
     end
   end
-  
+
   def test_load_before_epoch
     # Some platforms don't support negative timestamps for times before the
     # epoch. Check that they are returned when supported and skipped when not.
 
     # Note the last transition before the epoch (and within the 32-bit range) is
     # moved to the epoch on platforms that do not support negative timestamps.
-  
+
     offsets = [
       {:gmtoff => 3542, :isdst => false, :abbrev => 'LMT'},
       {:gmtoff => 3600, :isdst => false, :abbrev => 'XST'},
       {:gmtoff => 7200, :isdst => true,  :abbrev => 'XDT'},
       {:gmtoff =>    0, :isdst => false, :abbrev => 'XNST'}]
-      
+
     transitions = [
       {:at =>             -694224000, :offset_index => 1}, # Time.utc(1948,  1,  2)
       {:at =>              -21945600, :offset_index => 2}, # Time.utc(1969,  4, 22)
       {:at => Time.utc(1970, 10, 21), :offset_index => 1},
       {:at => Time.utc(2000, 12, 31), :offset_index => 3}]
-  
-    tzif_test(offsets, transitions) do |path, format|     
+
+    tzif_test(offsets, transitions) do |path, format|
       info = ZoneinfoTimezoneInfo.new('Zone/Negative', path)
       assert_equal('Zone/Negative', info.identifier)
-      
+
       if SUPPORTS_NEGATIVE
         assert_period(:LMT,  3542,    0, false,                    nil, Time.utc(1948,  1,  2), info)
         assert_period(:XST,  3600,    0, false, Time.utc(1948,  1,  2), Time.utc(1969,  4, 22), info)
@@ -424,7 +424,7 @@ class TCZoneinfoTimezoneInfo < Minitest::Test
         assert_period(:LMT,  3542,    0, false,                    nil, Time.utc(1970,  1,  1), info)
         assert_period(:XDT,  3600, 3600,  true, Time.utc(1970,  1,  1), Time.utc(1970, 10, 21), info)
       end
-      
+
       assert_period(:XST,  3600,    0, false, Time.utc(1970, 10, 21), Time.utc(2000, 12, 31), info)
       assert_period(:XNST,    0,    0, false, Time.utc(2000, 12, 31),                    nil, info)
     end
@@ -463,27 +463,27 @@ class TCZoneinfoTimezoneInfo < Minitest::Test
   def test_load_64bit
     # Some platforms support 64-bit Times, others only 32-bit. The TZif version
     # 2 and later format contains both 32-bit and 64-bit times.
-    
-    # Where 64-bit is supported and a TZif 2 or later file is provided, the 
-    # 64-bit times should be used, otherwise the 32-bit information should be 
+
+    # Where 64-bit is supported and a TZif 2 or later file is provided, the
+    # 64-bit times should be used, otherwise the 32-bit information should be
     # used.
-  
+
     offsets = [
       {:gmtoff => 3542, :isdst => false, :abbrev => 'LMT'},
       {:gmtoff => 3600, :isdst => false, :abbrev => 'XST'},
       {:gmtoff => 7200, :isdst => true,  :abbrev => 'XDT'},
       {:gmtoff =>    0, :isdst => false, :abbrev => 'XNST'}]
-      
+
     transitions = [
       {:at =>            -3786739200, :offset_index => 1}, # Time.utc(1850,  1,  2)
       {:at => Time.utc(2003,  4, 22), :offset_index => 2},
       {:at => Time.utc(2003, 10, 21), :offset_index => 1},
       {:at =>             2240524800, :offset_index => 3}] # Time.utc(2040, 12, 31)
-  
-    tzif_test(offsets, transitions) do |path, format|     
+
+    tzif_test(offsets, transitions) do |path, format|
       info = ZoneinfoTimezoneInfo.new('Zone/SixtyFour', path)
       assert_equal('Zone/SixtyFour', info.identifier)
-  
+
       if SUPPORTS_64BIT && format >= 2
         assert_period(:LMT,  3542,    0, false,                    nil, Time.utc(1850,  1,  2), info)
         assert_period(:XST,  3600,    0, false, Time.utc(1850,  1,  2), Time.utc(2003,  4, 22), info)
@@ -497,7 +497,7 @@ class TCZoneinfoTimezoneInfo < Minitest::Test
       end
     end
   end
-  
+
   def test_load_64bit_range
     # The full range of 64 bit timestamps is not currently supported because of
     # the way transitions are indexed. Transitions outside the supported range
@@ -599,23 +599,23 @@ class TCZoneinfoTimezoneInfo < Minitest::Test
   def test_load_std_offset_changes
     # The zoneinfo files don't include the offset from standard time, so this
     # has to be derived by looking at changes in the total UTC offset.
-  
+
     offsets = [
       {:gmtoff =>  3542, :isdst => false, :abbrev => 'LMT'},
       {:gmtoff =>  3600, :isdst => false, :abbrev => 'XST'},
       {:gmtoff =>  7200, :isdst => true,  :abbrev => 'XDT'},
       {:gmtoff => 10800, :isdst => true,  :abbrev => 'XDDT'}]
-      
+
     transitions = [
       {:at => Time.utc(2000, 1, 1), :offset_index => 1},
       {:at => Time.utc(2000, 2, 1), :offset_index => 2},
       {:at => Time.utc(2000, 3, 1), :offset_index => 3},
       {:at => Time.utc(2000, 4, 1), :offset_index => 1}]
-  
-    tzif_test(offsets, transitions) do |path, format|     
+
+    tzif_test(offsets, transitions) do |path, format|
       info = ZoneinfoTimezoneInfo.new('Zone/DoubleDaylight', path)
       assert_equal('Zone/DoubleDaylight', info.identifier)
-  
+
       assert_period(:LMT,  3542,    0, false,                  nil, Time.utc(2000, 1, 1), info)
       assert_period(:XST,  3600,    0, false, Time.utc(2000, 1, 1), Time.utc(2000, 2, 1), info)
       assert_period(:XDT,  3600, 3600,  true, Time.utc(2000, 2, 1), Time.utc(2000, 3, 1), info)
@@ -623,42 +623,42 @@ class TCZoneinfoTimezoneInfo < Minitest::Test
       assert_period(:XST,  3600,    0, false, Time.utc(2000, 4, 1), nil, info)
     end
   end
-  
+
   def test_load_std_offset_changes_jump_to_double_dst
     # The zoneinfo files don't include the offset from standard time, so this
     # has to be derived by looking at changes in the total UTC offset.
-  
+
     offsets = [
       {:gmtoff =>  3542, :isdst => false, :abbrev => 'LMT'},
-      {:gmtoff =>  3600, :isdst => false, :abbrev => 'XST'},      
+      {:gmtoff =>  3600, :isdst => false, :abbrev => 'XST'},
       {:gmtoff => 10800, :isdst => true,  :abbrev => 'XDDT'}]
-      
+
     transitions = [
       {:at => Time.utc(2000, 4, 1), :offset_index => 1},
       {:at => Time.utc(2000, 5, 1), :offset_index => 2},
       {:at => Time.utc(2000, 6, 1), :offset_index => 1}]
-  
-    tzif_test(offsets, transitions) do |path, format|     
+
+    tzif_test(offsets, transitions) do |path, format|
       info = ZoneinfoTimezoneInfo.new('Zone/DoubleDaylight', path)
       assert_equal('Zone/DoubleDaylight', info.identifier)
-  
+
       assert_period(:LMT,  3542,    0, false,                  nil, Time.utc(2000, 4, 1), info)
       assert_period(:XST,  3600,    0, false, Time.utc(2000, 4, 1), Time.utc(2000, 5, 1), info)
       assert_period(:XDDT, 3600, 7200,  true, Time.utc(2000, 5, 1), Time.utc(2000, 6, 1), info)
       assert_period(:XST,  3600,    0, false, Time.utc(2000, 6, 1),                  nil, info)
     end
   end
-  
+
   def test_load_std_offset_changes_negative
     # The zoneinfo files don't include the offset from standard time, so this
     # has to be derived by looking at changes in the total UTC offset.
-  
+
     offsets = [
       {:gmtoff => -10821, :isdst => false, :abbrev => 'LMT'},
       {:gmtoff => -10800, :isdst => false, :abbrev => 'XST'},
       {:gmtoff =>  -7200, :isdst => true,  :abbrev => 'XDT'},
       {:gmtoff =>  -3600, :isdst => true,  :abbrev => 'XDDT'}]
-      
+
     transitions = [
       {:at => Time.utc(2000, 1, 1), :offset_index => 1},
       {:at => Time.utc(2000, 2, 1), :offset_index => 2},
@@ -666,11 +666,11 @@ class TCZoneinfoTimezoneInfo < Minitest::Test
       {:at => Time.utc(2000, 4, 1), :offset_index => 1},
       {:at => Time.utc(2000, 5, 1), :offset_index => 3},
       {:at => Time.utc(2000, 6, 1), :offset_index => 1}]
-  
-    tzif_test(offsets, transitions) do |path, format|     
+
+    tzif_test(offsets, transitions) do |path, format|
       info = ZoneinfoTimezoneInfo.new('Zone/DoubleDaylight', path)
       assert_equal('Zone/DoubleDaylight', info.identifier)
-  
+
       assert_period(:LMT,  -10821,    0, false,                  nil, Time.utc(2000, 1, 1), info)
       assert_period(:XST,  -10800,    0, false, Time.utc(2000, 1, 1), Time.utc(2000, 2, 1), info)
       assert_period(:XDT,  -10800, 3600,  true, Time.utc(2000, 2, 1), Time.utc(2000, 3, 1), info)
@@ -680,133 +680,133 @@ class TCZoneinfoTimezoneInfo < Minitest::Test
       assert_period(:XST,  -10800,    0, false, Time.utc(2000, 6, 1),                  nil, info)
     end
   end
-  
+
   def test_load_starts_two_hour_std_offset
     # The zoneinfo files don't include the offset from standard time, so this
     # has to be derived by looking at changes in the total UTC offset.
-  
+
     offsets = [
       {:gmtoff =>  3542, :isdst => false, :abbrev => 'LMT'},
       {:gmtoff =>  3600, :isdst => false, :abbrev => 'XST'},
       {:gmtoff =>  7200, :isdst => true,  :abbrev => 'XDT'},
       {:gmtoff => 10800, :isdst => true,  :abbrev => 'XDDT'}]
-      
+
     transitions = [
       {:at => Time.utc(2000, 1, 1), :offset_index => 3},
       {:at => Time.utc(2000, 2, 1), :offset_index => 2},
       {:at => Time.utc(2000, 3, 1), :offset_index => 1}]
-  
-    tzif_test(offsets, transitions) do |path, format|     
+
+    tzif_test(offsets, transitions) do |path, format|
       info = ZoneinfoTimezoneInfo.new('Zone/DoubleDaylight', path)
       assert_equal('Zone/DoubleDaylight', info.identifier)
-  
+
       assert_period(:LMT,  3542,    0, false,                  nil, Time.utc(2000, 1, 1), info)
       assert_period(:XDDT, 3600, 7200,  true, Time.utc(2000, 1, 1), Time.utc(2000, 2, 1), info)
       assert_period(:XDT,  3600, 3600,  true, Time.utc(2000, 2, 1), Time.utc(2000, 3, 1), info)
       assert_period(:XST,  3600,    0, false, Time.utc(2000, 3, 1),                  nil, info)
     end
   end
-    
+
   def test_load_starts_all_same_dst_offset
     # The zoneinfo files don't include the offset from standard time, so this
     # has to be derived by looking at changes in the total UTC offset.
     #
-    # If there are no changes in the UTC offset (ignoring the first offset, 
+    # If there are no changes in the UTC offset (ignoring the first offset,
     # which is usually local mean time), then a value of 1 hour is used as the
     # standard time offset.
-  
+
     offsets = [
       {:gmtoff => 3542, :isdst => false, :abbrev => 'LMT'},
       {:gmtoff => 7200, :isdst => true,  :abbrev => 'XDDT'}]
-      
+
     transitions = [
       {:at => Time.utc(2000, 1, 1), :offset_index => 1}]
-  
-    tzif_test(offsets, transitions) do |path, format|     
+
+    tzif_test(offsets, transitions) do |path, format|
       info = ZoneinfoTimezoneInfo.new('Zone/DoubleDaylight', path)
       assert_equal('Zone/DoubleDaylight', info.identifier)
-  
+
       assert_period(:LMT,  3542,    0, false,                  nil, Time.utc(2000, 1, 1), info)
       assert_period(:XDDT, 3600, 3600,  true, Time.utc(2000, 1, 1),                  nil, info)
     end
   end
-  
+
   def test_load_switch_to_dst_and_change_utc_offset
     # The zoneinfo files don't include the offset from standard time, so this
     # has to be derived by looking at changes in the total UTC offset.
-  
+
     # Switch from non-DST to DST at the same time as moving the UTC offset
     # back an hour (i.e. wall clock time doesn't change).
-  
+
     offsets = [
       {:gmtoff => 3542, :isdst => false, :abbrev => 'LMT'},
       {:gmtoff => 3600, :isdst => false, :abbrev => 'YST'},
       {:gmtoff => 3600, :isdst => true,  :abbrev => 'XDT'}]
-      
+
     transitions = [
       {:at => Time.utc(2000, 1, 1), :offset_index => 1},
       {:at => Time.utc(2000, 2, 1), :offset_index => 2}]
-  
-    tzif_test(offsets, transitions) do |path, format|     
+
+    tzif_test(offsets, transitions) do |path, format|
       info = ZoneinfoTimezoneInfo.new('Zone/DoubleDaylight', path)
       assert_equal('Zone/DoubleDaylight', info.identifier)
-  
+
       assert_period(:LMT,  3542,    0, false,                  nil, Time.utc(2000, 1, 1), info)
       assert_period(:YST,  3600,    0, false, Time.utc(2000, 1, 1), Time.utc(2000, 2, 1), info)
       assert_period(:XDT,     0, 3600,  true, Time.utc(2000, 2, 1), nil, info)
     end
   end
-  
+
   def test_load_in_safe_mode
     offsets = [{:gmtoff => -12094, :isdst => false, :abbrev => 'LT'}]
-        
+
     tzif_test(offsets, []) do |path, format|
       # untaint only required for Ruby 1.9.2
       path.untaint
-      
-      safe_test do        
+
+      safe_test do
         info = ZoneinfoTimezoneInfo.new('Zone/three', path)
         assert_equal('Zone/three', info.identifier)
-        
+
         assert_period(:LT, -12094, 0, false, nil, nil, info)
       end
     end
   end
-  
+
   def test_load_encoding
     # tzfile.5 doesn't specify an encoding, but the source data is in ASCII.
     # ZoneinfoTimezoneInfo will load as UTF-8 (a superset of ASCII).
-  
+
     offsets = [
       {:gmtoff => 3542, :isdst => false, :abbrev => 'LMT'},
       {:gmtoff => 3600, :isdst => false, :abbrev => 'XST©'}]
-      
+
     transitions = [
       {:at => Time.utc(1971,  1,  2), :offset_index => 1}]
-  
-    tzif_test(offsets, transitions) do |path, format|     
+
+    tzif_test(offsets, transitions) do |path, format|
       info = ZoneinfoTimezoneInfo.new('Zone/One', path)
       assert_equal('Zone/One', info.identifier)
-      
+
       assert_period(:LMT,     3542,    0, false,                    nil, Time.utc(1971,  1,  2), info)
       assert_period(:"XST©",  3600,    0, false, Time.utc(1971,  1,  2),                    nil, info)
     end
   end
-  
+
   def test_load_binmode
     offsets = [
       {:gmtoff => 3542, :isdst => false, :abbrev => 'LMT'},
       {:gmtoff => 3600, :isdst => false, :abbrev => 'XST'}]
-      
+
     # Transition time that includes CRLF (4EFF0D0A).
     # Test that this doesn't get corrupted by translating CRLF to LF.
     transitions = [
       {:at => Time.utc(2011, 12, 31, 13, 24, 26), :offset_index => 1}]
-  
-    tzif_test(offsets, transitions) do |path, format|     
+
+    tzif_test(offsets, transitions) do |path, format|
       info = ZoneinfoTimezoneInfo.new('Zone/One', path)
       assert_equal('Zone/One', info.identifier)
-      
+
       assert_period(:LMT, 3542, 0, false,                                nil, Time.utc(2011, 12, 31, 13, 24, 26), info)
       assert_period(:XST, 3600, 0, false, Time.utc(2011, 12, 31, 13, 24, 26),                                nil, info)
     end

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -18,14 +18,14 @@ module TestUtils
   ZONEINFO_SYMLINKS = [
     ['localtime', 'America/New_York'],
     ['UTC', 'Etc/UTC']]
-  
+
 
   def self.prepare_test_zoneinfo_dir
     ZONEINFO_SYMLINKS.each do |file, target|
       path = File.join(TZINFO_TEST_ZONEINFO_DIR, file)
-      
+
       File.delete(path) if File.exist?(path)
-    
+
       begin
         FileUtils.ln_s(target, path)
       rescue NotImplementedError
@@ -51,39 +51,39 @@ module Kernel
       $-v = old_verbose
     end
   end
-  
+
   def safe_test(options = {})
     # JRuby and Rubinus don't support SAFE levels.
     available = !(defined?(RUBY_ENGINE) && %w(jruby rbx).include?(RUBY_ENGINE))
-   
+
     if available || options[:unavailable] != :skip
       thread = Thread.new do
         $SAFE = options[:level] || 1 if available
         yield
       end
-      
+
       thread.join
     end
   end
-  
+
   def assert_array_same_items(expected, actual, msg = nil)
     full_message = message(msg, '') { diff(expected, actual) }
     condition = (expected.size == actual.size) && (expected - actual == [])
     assert(condition, full_message)
   end
-  
+
   def assert_sub_process_returns(expected_lines, code, extra_load_path = [], required = ['tzinfo'])
-    ruby = File.join(RbConfig::CONFIG['bindir'], 
+    ruby = File.join(RbConfig::CONFIG['bindir'],
       RbConfig::CONFIG['ruby_install_name'] + RbConfig::CONFIG['EXEEXT'])
-      
+
     load_path = [TZINFO_LIB_DIR] + extra_load_path
-    
+
     # If RubyGems is loaded in the current process, then require it in the
     # sub-process, as it may be needed in order to require dependencies.
     if defined?(Gem) && Gem.instance_of?(Module)
       required = ['rubygems'] + required
     end
-    
+
     if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'
       # Stop Rubinus from operating as irb.
       args = ' -'
@@ -93,17 +93,17 @@ module Kernel
 
     IO.popen("\"#{ruby}\"#{args}", 'r+') do |process|
       load_path.each do |p|
-        process.puts("$:.unshift('#{p.gsub("'", "\\\\'")}')")        
+        process.puts("$:.unshift('#{p.gsub("'", "\\\\'")}')")
       end
-      
+
       required.each do |r|
         process.puts("require '#{r.gsub("'", "\\\\'")}'")
       end
-      
+
       process.puts(code)
       process.flush
       process.close_write
-      
+
       actual_lines = process.readlines
       actual_lines = actual_lines.collect {|l| l.chomp}
       assert_equal(expected_lines, actual_lines)
@@ -121,7 +121,7 @@ module Kernel
 end
 
 
-# JRuby 1.7.5 to 1.7.9 consider DateTime instances that differ by less than 
+# JRuby 1.7.5 to 1.7.9 consider DateTime instances that differ by less than
 # 1 millisecond to be equivalent (https://github.com/jruby/jruby/issues/1311).
 #
 # A few test cases compare at a resolution of 1 microsecond, so this causes

--- a/tzinfo.gemspec
+++ b/tzinfo.gemspec
@@ -23,5 +23,4 @@ Gem::Specification.new do |s|
                     '--main' << 'README.md'
   s.extra_rdoc_files = ['README.md', 'CHANGES.md', 'LICENSE']
   s.required_ruby_version = '>= 1.8.7'
-  s.add_dependency 'thread_safe', '~> 0.1'
 end


### PR DESCRIPTION
This PR includes the whitespace PR I just sent.  If you merge that PR, you should just see the relevant changes here.

This change removes the thread_safe gem dependency and instead uses a Mutex as a write barrier to ensure multiple threads can't write to the Hash at the same time.