### PR TITLE
Move from thread_safe gem to concurrent-ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,16 @@ before_script:
   - bundle update
 cache: bundler
 rvm:
-  - 1.8.7-p374
-  - 1.9.2-p330
   - 1.9.3-p551
   - 2.0.0-p648
   - 2.1.8
   - 2.2.4
   - 2.3.0
   - ruby-head
-  - jruby-18mode
   - jruby-19mode
   - jruby-9.0.5.0
   - jruby-head
   - rbx-2
-  - ree
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/lib/tzinfo/country.rb
+++ b/lib/tzinfo/country.rb
@@ -1,4 +1,4 @@
-require 'thread_safe'
+require 'concurrent/map'
 
 module TZInfo
   # Raised by Country#get if the code given is not valid.
@@ -184,7 +184,7 @@ module TZInfo
 
       # Initializes @@countries.
       def self.init_countries
-        @@countries = ThreadSafe::Cache.new
+        @@countries = Concurrent::Map.new
       end
       init_countries
 

--- a/lib/tzinfo/timezone.rb
+++ b/lib/tzinfo/timezone.rb
@@ -1,6 +1,6 @@
 require 'date'
 require 'set'
-require 'thread_safe'
+require 'concurrent/map'
 
 module TZInfo
   # AmbiguousTime is raised to indicates that a specified time in a local
@@ -636,7 +636,7 @@ module TZInfo
     private
       # Initializes @@loaded_zones.
       def self.init_loaded_zones
-        @@loaded_zones = ThreadSafe::Cache.new
+        @@loaded_zones = Concurrent::Map.new
       end
       init_loaded_zones
 

--- a/tzinfo.gemspec
+++ b/tzinfo.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
   s.rdoc_options << '--title' << 'TZInfo' <<
                     '--main' << 'README.md'
   s.extra_rdoc_files = ['README.md', 'CHANGES.md', 'LICENSE']
-  s.required_ruby_version = '>= 1.8.7'
-  s.add_dependency 'thread_safe', '~> 0.1'
+  s.required_ruby_version = '>= 1.9.3'
+  s.add_dependency 'concurrent-ruby', ">= 1.0.0"
 end


### PR DESCRIPTION
This also updates the gem to require Ruby 1.9.3 or greater.