### PR TITLE
Include identifier with invalid errors

### DIFF
--- a/lib/tzinfo/ruby_data_source.rb
+++ b/lib/tzinfo/ruby_data_source.rb
@@ -19,7 +19,8 @@ module TZInfo
     # Raises InvalidTimezoneIdentifier if the timezone is not found or the
     # identifier is invalid.
     def load_timezone_info(identifier)
-      raise InvalidTimezoneIdentifier, 'Invalid identifier' if identifier !~ /^[A-Za-z0-9\+\-_]+(\/[A-Za-z0-9\+\-_]+)*$/
+      original_identifier = identifier
+      raise InvalidTimezoneIdentifier, "Invalid identifier - #{original_identifier}" if identifier !~ /^[A-Za-z0-9\+\-_]+(\/[A-Za-z0-9\+\-_]+)*$/
 
       identifier = identifier.gsub(/-/, '__m__').gsub(/\+/, '__p__')
 
@@ -39,7 +40,7 @@ module TZInfo
 
         m.get
       rescue LoadError, NameError => e
-        raise InvalidTimezoneIdentifier, e.message
+        raise InvalidTimezoneIdentifier, "#{e.message} - #{original_identifier}"
       end
     end
 
@@ -69,7 +70,7 @@ module TZInfo
     def load_country_info(code)
       load_country_index
       info = Data::Indexes::Countries.countries[code]
-      raise InvalidCountryCode, 'Invalid country code' unless info
+      raise InvalidCountryCode, "Invalid country code - #{code}" unless info
       info
     end
 

--- a/lib/tzinfo/zoneinfo_data_source.rb
+++ b/lib/tzinfo/zoneinfo_data_source.rb
@@ -205,10 +205,10 @@ module TZInfo
             raise InvalidTimezoneIdentifier, e.message
           end
         else
-          raise InvalidTimezoneIdentifier, 'Invalid identifier'
+          raise InvalidTimezoneIdentifier, "Invalid identifier - #{identifier}"
         end
       rescue Errno::ENOENT, Errno::ENAMETOOLONG, Errno::ENOTDIR
-        raise InvalidTimezoneIdentifier, 'Invalid identifier'
+        raise InvalidTimezoneIdentifier, "Invalid identifier - #{identifier}"
       rescue Errno::EACCES => e
         raise InvalidTimezoneIdentifier, e.message
       end

--- a/test/tc_ruby_data_source.rb
+++ b/test/tc_ruby_data_source.rb
@@ -21,9 +21,11 @@ class TCRubyDataSource < Minitest::Test
   end
 
   def test_load_timezone_info_does_not_exist
-    assert_raises(InvalidTimezoneIdentifier) do
+    error = assert_raises(InvalidTimezoneIdentifier) do
       @data_source.load_timezone_info('Nowhere/Special')
     end
+
+    assert_match 'Nowhere/Special', error.message
   end
 
   def test_load_timezone_info_invalid
@@ -39,9 +41,11 @@ class TCRubyDataSource < Minitest::Test
   end
 
   def test_load_timezone_info_case
-    assert_raises(InvalidTimezoneIdentifier) do
+    error = assert_raises(InvalidTimezoneIdentifier) do
       @data_source.load_timezone_info('europe/london')
     end
+
+    assert_match 'europe/london', error.message
   end
 
   def test_load_timezone_info_plus
@@ -95,9 +99,11 @@ class TCRubyDataSource < Minitest::Test
   end
 
   def test_load_country_info_not_exist
-    assert_raises(InvalidCountryCode) do
+    error = assert_raises(InvalidCountryCode) do
       @data_source.load_country_info('ZZ')
     end
+
+    assert_match 'ZZ', error.message
   end
 
   def test_load_country_info_invalid

--- a/test/tc_timezone.rb
+++ b/test/tc_timezone.rb
@@ -205,7 +205,11 @@ class TCTimezone < Minitest::Test
   end
 
   def test_get_not_exist
-    assert_raises(InvalidTimezoneIdentifier) { Timezone.get('Nowhere/Special') }
+    error = assert_raises(InvalidTimezoneIdentifier) do
+      Timezone.get('Nowhere/Special')
+    end
+
+    assert_match 'Nowhere/Special', error.message
   end
 
   def test_get_invalid
@@ -218,7 +222,9 @@ class TCTimezone < Minitest::Test
 
   def test_get_case
     Timezone.get('Europe/Prague')
-    assert_raises(InvalidTimezoneIdentifier) { Timezone.get('Europe/prague') }
+    error = assert_raises(InvalidTimezoneIdentifier) { Timezone.get('Europe/prague') }
+
+    assert_match 'Europe/prague', error.message
   end
 
   def test_get_proxy_valid

--- a/test/tc_zoneinfo_data_source.rb
+++ b/test/tc_zoneinfo_data_source.rb
@@ -358,9 +358,11 @@ class TCZoneinfoDataSource < Minitest::Test
   end
 
   def test_load_timezone_info_does_not_exist
-    assert_raises(InvalidTimezoneIdentifier) do
+    error = assert_raises(InvalidTimezoneIdentifier) do
       @data_source.load_timezone_info('Nowhere/Special')
     end
+
+    assert_match 'Nowhere/Special', error.message
   end
 
   def test_load_timezone_info_invalid
@@ -370,9 +372,11 @@ class TCZoneinfoDataSource < Minitest::Test
   end
 
   def test_load_timezone_info_ignored_file
-    assert_raises(InvalidTimezoneIdentifier) do
+    error = assert_raises(InvalidTimezoneIdentifier) do
       @data_source.load_timezone_info('localtime')
     end
+
+    assert_match 'localtime', error.message
   end
 
   def test_load_timezone_info_ignored_plus_version_file
@@ -402,9 +406,11 @@ class TCZoneinfoDataSource < Minitest::Test
   end
 
   def test_load_timezone_info_case
-    assert_raises(InvalidTimezoneIdentifier) do
+    error = assert_raises(InvalidTimezoneIdentifier) do
       @data_source.load_timezone_info('europe/london')
     end
+
+    assert_match 'europe/london', error.message
   end
 
   def test_load_timezone_info_permission_denied
@@ -581,9 +587,11 @@ class TCZoneinfoDataSource < Minitest::Test
 
       data_source = ZoneinfoDataSource.new(dir)
 
-      assert_raises(InvalidTimezoneIdentifier) do
+      error = assert_raises(InvalidTimezoneIdentifier) do
         data_source.load_timezone_info('Zone')
       end
+
+      assert_match 'Zone', error.message
     end
   end
 
@@ -605,9 +613,11 @@ class TCZoneinfoDataSource < Minitest::Test
 
       data_source = ZoneinfoDataSource.new(dir)
 
-      assert_raises(InvalidTimezoneIdentifier) do
+      error = assert_raises(InvalidTimezoneIdentifier) do
         data_source.load_timezone_info('Zone')
       end
+
+      assert_match 'Zone', error.message
     end
   end
 


### PR DESCRIPTION
We had an error where a downstream provider was undocumented, erroneous values. Having the identifier that could not be located within the message would have made it a little easier to debug the problem.