### PR TITLE
Issue 39: return nil if nil is passed to utc_to_local

### DIFF
--- a/lib/tzinfo/timezone.rb
+++ b/lib/tzinfo/timezone.rb
@@ -423,9 +423,11 @@ module TZInfo
     # type as utc. Any timezone information in utc is ignored (it is treated as
     # a UTC time).
     def utc_to_local(utc)
-      TimeOrDateTime.wrap(utc) {|wrapped|
-        period_for_utc(wrapped).to_local(wrapped)
-      }
+      unless utc.nil?
+        TimeOrDateTime.wrap(utc) {|wrapped|
+          period_for_utc(wrapped).to_local(wrapped)
+        }
+      end
     end
 
     # Converts a time in the local timezone to UTC. local can either be

--- a/test/tc_timezone.rb
+++ b/test/tc_timezone.rb
@@ -724,6 +724,7 @@ class TCTimezone < Minitest::Test
       TestTimezoneTransition.new(o2, o1, 1111885200),
       TestTimezoneTransition.new(o1, o2, 1130634000))
 
+    assert_nil(TestTimezone.new('Europe/London', period, [], dt).utc_to_local(nil))
     assert_equal(DateTime.new(2005,6,18,17,24,23), TestTimezone.new('Europe/London', period, [], dt).utc_to_local(dt))
     assert_equal(DateTime.new(2005,6,18,17,24,23), TestTimezone.new('Europe/London', period, [], dt2).utc_to_local(dt2))
     assert_equal(DateTime.new(2005,6,18,17,24,23 + Rational(567,1000)), TestTimezone.new('Europe/London', period, [], dtu).utc_to_local(dtu))


### PR DESCRIPTION
@aug-riedinger would like to see `nil` returned as mentioned in #39. When `nil` is passed as an argument to `utc_to_local` method, `-18000` is returned for some reason. That doesn't seem like `nil` to me. So, this should fix it.
