### PR TITLE
Implementing correct offsets for to_local

### DIFF
--- a/lib/tzinfo/time_or_datetime.rb
+++ b/lib/tzinfo/time_or_datetime.rb
@@ -255,22 +255,16 @@ module TZInfo
       self + (-seconds)
     end
 
-    # Sets offset from UTC for the TimeOrDateTime. Returns a new TimeOrDateTime,
-    # preserving original class. Does NOT changes values of hour-min-second,
-    # so, (18:00 UTC).offset(3600) will became (18:00 +01:00).
+    # Converts TimeOrDateTime to new UTC offset.
     # Considers original value's UTC offset wisely.
     def offset(seconds)
-      return self if seconds == 0
-
       if @orig.is_a?(DateTime)
         off = OffsetRationals.rational_for_offset(seconds)
         TimeOrDateTime.new(@orig.new_offset(off), false)
       elsif @orig.is_a?(Time)
-        offset_str = '%+03i:%02i' % [seconds / 3600, seconds / 60 % 60]
-
-        time = @time + seconds
+        time = @time.getutc + seconds
         nsec_part = Rational(time.nsec, 1_000_000_000)
-        time = Time.new(time.year, time.mon, time.mday, time.hour, time.min, time.sec + nsec_part, offset_str)
+        time = Time.new(time.year, time.mon, time.mday, time.hour, time.min, time.sec + nsec_part, seconds)
         TimeOrDateTime.new(time, false)
       else
         # Integer: fallback to "just shift timestamp"

--- a/lib/tzinfo/time_or_datetime.rb
+++ b/lib/tzinfo/time_or_datetime.rb
@@ -198,6 +198,8 @@ module TZInfo
       end
     end
 
+    # Returns utc offset of original value _in seconds_ (or 0 if original
+    # value was integer timestamp).
     def offset
       if @time
         @time.utc_offset
@@ -308,6 +310,12 @@ module TZInfo
     # TimeOrDateTime. If a TimeOrDateTime is passed in, no new TimeOrDateTime
     # will be constructed and the value passed to wrap will be used when
     # calling the block.
+    #
+    # Optional ignore_offset second parameter (defaults to true) controls
+    # whether timezone/UTC offset of input value will be considered or
+    # ignored completely (in a latter case `2016-06-01 12:30:50 +03:00`
+    # and `2016-06-01 12:30:50 GMT` would be wrapped into exactly the
+    # same `TimeOrDateTime` object).
     def self.wrap(timeOrDateTime, ignore_offset = true)
       t = timeOrDateTime.is_a?(TimeOrDateTime) ? timeOrDateTime : TimeOrDateTime.new(timeOrDateTime, ignore_offset)
 

--- a/lib/tzinfo/time_or_datetime.rb
+++ b/lib/tzinfo/time_or_datetime.rb
@@ -301,8 +301,8 @@ module TZInfo
     # TimeOrDateTime. If a TimeOrDateTime is passed in, no new TimeOrDateTime
     # will be constructed and the value passed to wrap will be used when
     # calling the block.
-    def self.wrap(timeOrDateTime)
-      t = timeOrDateTime.is_a?(TimeOrDateTime) ? timeOrDateTime : TimeOrDateTime.new(timeOrDateTime)
+    def self.wrap(timeOrDateTime, ignore_offset = true)
+      t = timeOrDateTime.is_a?(TimeOrDateTime) ? timeOrDateTime : TimeOrDateTime.new(timeOrDateTime, ignore_offset)
 
       if block_given?
         t = yield t

--- a/lib/tzinfo/timezone.rb
+++ b/lib/tzinfo/timezone.rb
@@ -419,8 +419,8 @@ module TZInfo
     end
 
     def period_for(tm)
-      # FIXME: maybe define TimeOrDateTime#utc as a synonym for #offset(0)?..
-      period_for_utc(TimeOrDateTime.wrap(tm, false).offset(0))
+      # FIXME: maybe define TimeOrDateTime#to_utc as a synonym for #to_offset(0)?..
+      period_for_utc(TimeOrDateTime.wrap(tm, false).to_offset(0))
     end
 
     # Converts a time in UTC to the local timezone. utc can either be

--- a/lib/tzinfo/timezone.rb
+++ b/lib/tzinfo/timezone.rb
@@ -419,18 +419,8 @@ module TZInfo
     end
 
     def period_for(tm)
-      tm = tm.to_orig if tm.is_a?(TimeOrDateTime)
-
-      utc = case tm
-      when Time
-        tm.getutc
-      when DateTime
-        tm.new_offset(0)
-      else
-        tm
-      end
-
-      period_for_utc(utc)
+      # FIXME: maybe define TimeOrDateTime#utc as a synonym for #offset(0)?..
+      period_for_utc(TimeOrDateTime.wrap(tm, false).offset(0))
     end
 
     # Converts a time in UTC to the local timezone. utc can either be

--- a/lib/tzinfo/timezone.rb
+++ b/lib/tzinfo/timezone.rb
@@ -418,12 +418,12 @@ module TZInfo
       end
     end
 
-    def period_for(tm, dst = Timezone.default_dst)
+    def period_for(tm)
       tm = tm.to_orig if tm.is_a?(TimeOrDateTime)
 
       utc = case tm
       when Time
-        tm.utc
+        tm.getutc
       when DateTime
         tm.new_offset(0)
       else

--- a/lib/tzinfo/timezone.rb
+++ b/lib/tzinfo/timezone.rb
@@ -428,6 +428,12 @@ module TZInfo
       }
     end
 
+    def to_local(date_or_time)
+      TimeOrDateTime.wrap(date_or_time, false) {|wrapped|
+        period_for(wrapped).to_local(wrapped)
+      }
+    end
+
     # Converts a time in the local timezone to UTC. local can either be
     # a DateTime, Time or timestamp (Time.to_i). The returned time has the same
     # type as local. Any timezone information in local is ignored (it is treated

--- a/lib/tzinfo/timezone.rb
+++ b/lib/tzinfo/timezone.rb
@@ -418,6 +418,21 @@ module TZInfo
       end
     end
 
+    def period_for(tm, dst = Timezone.default_dst)
+      tm = tm.to_orig if tm.is_a?(TimeOrDateTime)
+
+      utc = case tm
+      when Time
+        tm.utc
+      when DateTime
+        tm.new_offset(0)
+      else
+        tm
+      end
+
+      period_for_utc(utc)
+    end
+
     # Converts a time in UTC to the local timezone. utc can either be
     # a DateTime, Time or timestamp (Time.to_i). The returned time has the same
     # type as utc. Any timezone information in utc is ignored (it is treated as

--- a/lib/tzinfo/timezone.rb
+++ b/lib/tzinfo/timezone.rb
@@ -418,9 +418,14 @@ module TZInfo
       end
     end
 
-    def period_for(tm)
+    # Returns the TimezonePeriod for the given local time. local can either be
+    # a DateTime, Time or integer timestamp (Time.to_i). Unlike `period_for_local`,
+    # actually considers timezone information of local, thus eliminating
+    # all complexities about AmbiguousTime.
+    #
+    def period_for(local)
       # FIXME: maybe define TimeOrDateTime#to_utc as a synonym for #to_offset(0)?..
-      period_for_utc(TimeOrDateTime.wrap(tm, false).to_offset(0))
+      period_for_utc(TimeOrDateTime.wrap(local, false).to_offset(0))
     end
 
     # Converts a time in UTC to the local timezone. utc can either be
@@ -433,8 +438,12 @@ module TZInfo
       }
     end
 
-    def to_local(date_or_time)
-      TimeOrDateTime.wrap(date_or_time, false) {|wrapped|
+    # Converts a time in some local timezone to another local timezone.
+    # another_local can either be a DateTime, Time or timestamp (Time.to_i).
+    #
+    # Considers timezone of another_local.
+    def to_local(another_local)
+      TimeOrDateTime.wrap(another_local, false) {|wrapped|
         period_for(wrapped).to_local(wrapped)
       }
     end

--- a/lib/tzinfo/timezone_offset.rb
+++ b/lib/tzinfo/timezone_offset.rb
@@ -36,7 +36,6 @@ module TZInfo
     # the offset of this period.
     def to_local(utc)
       TimeOrDateTime.wrap(utc) {|wrapped|
-        #wrapped + @utc_total_offset
         wrapped.offset(@utc_total_offset)
       }
     end

--- a/lib/tzinfo/timezone_offset.rb
+++ b/lib/tzinfo/timezone_offset.rb
@@ -36,7 +36,8 @@ module TZInfo
     # the offset of this period.
     def to_local(utc)
       TimeOrDateTime.wrap(utc) {|wrapped|
-        wrapped + @utc_total_offset
+        #wrapped + @utc_total_offset
+        wrapped.offset(@utc_total_offset)
       }
     end
 

--- a/lib/tzinfo/timezone_offset.rb
+++ b/lib/tzinfo/timezone_offset.rb
@@ -36,7 +36,7 @@ module TZInfo
     # the offset of this period.
     def to_local(utc)
       TimeOrDateTime.wrap(utc) {|wrapped|
-        wrapped.offset(@utc_total_offset)
+        wrapped.to_offset(@utc_total_offset)
       }
     end
 

--- a/test/tc_time_or_datetime.rb
+++ b/test/tc_time_or_datetime.rb
@@ -103,6 +103,17 @@ class TCTimeOrDateTime < Minitest::Test
       TimeOrDateTime.new('1143214323').to_time)
   end
 
+  def test_to_time_preserve_offset
+    assert_equal(Time.new(2006, 3, 24, 15, 32, 3, '+03:00'),
+      TimeOrDateTime.new(Time.new(2006, 3, 24, 15, 32, 3, '+03:00'), false).to_time)
+    assert_equal(Time.new(2006, 3, 24, 15, 32, 3 + Rational(721123, 1000000), '+03:00'),
+      TimeOrDateTime.new(Time.new(2006, 3, 24, 15, 32, 3 + Rational(721123, 1000000), '+03:00'), false).to_time)
+    assert_equal(Time.new(2006, 3, 24, 15, 32, 3, '+03:00'),
+      TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3, '+3'), false).to_time)
+    assert_equal(Time.new(2006, 3, 24, 15, 32, 3 + Rational(721123, 1000000), '+03:00'),
+      TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721123, 1000000), '+3'), false).to_time)
+  end
+
   def test_to_time_trunc_to_usec
     assert_equal(Time.utc(2006, 3, 24, 15, 32, 3, 721123),
       TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(7211239, 10000000))).to_time)
@@ -121,6 +132,17 @@ class TCTimeOrDateTime < Minitest::Test
       TimeOrDateTime.new(1143214323).to_datetime)
     assert_equal(DateTime.new(2006, 3, 24, 15, 32, 3),
       TimeOrDateTime.new('1143214323').to_datetime)
+  end
+
+  def test_to_datetime_preserve_offset
+    assert_equal(DateTime.new(2006, 3, 24, 15, 32, 3, '+3'),
+      TimeOrDateTime.new(Time.new(2006, 3, 24, 15, 32, 3, '+03:00'), false).to_datetime)
+    assert_equal(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721123, 1000000), '+3'),
+      TimeOrDateTime.new(Time.new(2006, 3, 24, 15, 32, 3 + Rational(721123, 1000000), '+03:00'), false).to_datetime)
+    assert_equal(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721123, 1000000), '+3'),
+      TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721123, 1000000), '+3'), false).to_datetime)
+    assert_equal(DateTime.new(2006, 3, 24, 15, 32, 3, '+3'),
+      TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3, '+3'), false).to_datetime)
   end
 
   def test_to_datetime_ruby186_bug
@@ -232,6 +254,18 @@ class TCTimeOrDateTime < Minitest::Test
     assert_equal(0, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)).usec)
     assert_equal(721123, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721123,1000000))).usec)
     assert_equal(0, TimeOrDateTime.new(1143214323).usec)
+  end
+
+  def test_offset_ignored
+    assert_equal(0, TimeOrDateTime.new(Time.new(2006, 3, 24, 15, 32, 3, '+03:00')).offset)
+    assert_equal(0, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3, '+03:00')).offset)
+    assert_equal(0, TimeOrDateTime.new(1143214323).offset)
+  end
+
+  def test_offset_preserved
+    assert_equal(10800, TimeOrDateTime.new(Time.new(2006, 3, 24, 15, 32, 3, '+03:00'), false).offset)
+    assert_equal(10800, TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3, '+03:00'), false).offset)
+    assert_equal(0, TimeOrDateTime.new(1143214323, false).offset)
   end
 
   def test_usec_after_to_i
@@ -491,24 +525,24 @@ class TCTimeOrDateTime < Minitest::Test
     assert_equal(1143214324, (TimeOrDateTime.new(1143214323) - (-1)).to_orig)
   end
 
-  def test_offset
-    assert_equal(Time.utc(2006, 3, 24, 15, 32, 3), (TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)).offset(0)).to_orig)
-    assert_equal(Time.utc(2006, 3, 24, 15, 32, 3, 721000), (TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 721000)).offset(0)).to_orig)
-    assert_equal(DateTime.new(2006, 3, 24, 15, 32, 3), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)).offset(0)).to_orig)
-    assert_equal(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721, 1000)), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721, 1000))).offset(0)).to_orig)
-    assert_equal(1143214323, (TimeOrDateTime.new(1143214323).offset(0)).to_orig)
+  def test_to_offset
+    assert_equal(Time.utc(2006, 3, 24, 15, 32, 3), (TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)).to_offset(0)).to_orig)
+    assert_equal(Time.utc(2006, 3, 24, 15, 32, 3, 721000), (TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 721000)).to_offset(0)).to_orig)
+    assert_equal(DateTime.new(2006, 3, 24, 15, 32, 3), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)).to_offset(0)).to_orig)
+    assert_equal(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721, 1000)), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721, 1000))).to_offset(0)).to_orig)
+    assert_equal(1143214323, (TimeOrDateTime.new(1143214323).to_offset(0)).to_orig)
 
-    assert_equal(Time.new(2006, 3, 24, 18, 32, 3, '+03:00'), (TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)).offset(3600*3)).to_orig)
-    assert_equal(Time.new(2006, 3, 24, 18, 32, 3 + Rational(721, 1000), '+03:00'), (TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 721000)).offset(3600*3)).to_orig)
-    assert_equal(DateTime.new(2006, 3, 24, 18, 32, 3, '+3'), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)).offset(3600*3)).to_orig)
-    assert_equal(DateTime.new(2006, 3, 24, 18, 32, 3 + Rational(721, 1000), '+3'), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721, 1000))).offset(3600*3)).to_orig)
-    assert_equal(1143225123, (TimeOrDateTime.new(1143214323).offset(3600*3)).to_orig)
+    assert_equal(Time.new(2006, 3, 24, 18, 32, 3, '+03:00'), (TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)).to_offset(3600*3)).to_orig)
+    assert_equal(Time.new(2006, 3, 24, 18, 32, 3 + Rational(721, 1000), '+03:00'), (TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 721000)).to_offset(3600*3)).to_orig)
+    assert_equal(DateTime.new(2006, 3, 24, 18, 32, 3, '+3'), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)).to_offset(3600*3)).to_orig)
+    assert_equal(DateTime.new(2006, 3, 24, 18, 32, 3 + Rational(721, 1000), '+3'), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721, 1000))).to_offset(3600*3)).to_orig)
+    assert_equal(1143225123, (TimeOrDateTime.new(1143214323).to_offset(3600*3)).to_orig)
 
-    assert_equal(Time.new(2006, 3, 24, 16, 32, 3, '+03:00'), (TimeOrDateTime.new(Time.new(2006, 3, 24, 15, 32, 3, '+02:00'), false).offset(3600*3)).to_orig)
-    assert_equal(DateTime.new(2006, 3, 24, 16, 32, 3, '+3'), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3, '+2'), false).offset(3600*3)).to_orig)
+    assert_equal(Time.new(2006, 3, 24, 16, 32, 3, '+03:00'), (TimeOrDateTime.new(Time.new(2006, 3, 24, 15, 32, 3, '+02:00'), false).to_offset(3600*3)).to_orig)
+    assert_equal(DateTime.new(2006, 3, 24, 16, 32, 3, '+3'), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3, '+2'), false).to_offset(3600*3)).to_orig)
 
-    assert_equal(Time.utc(2006, 3, 24, 13, 32, 3), (TimeOrDateTime.new(Time.new(2006, 3, 24, 15, 32, 3, '+02:00'), false).offset(3600*3)).to_orig)
-    assert_equal(DateTime.new(2006, 3, 24, 13, 32, 3), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3, '+2'), false).offset(3600*3)).to_orig)
+    assert_equal(Time.utc(2006, 3, 24, 13, 32, 3), (TimeOrDateTime.new(Time.new(2006, 3, 24, 15, 32, 3, '+02:00'), false).to_offset(3600*3)).to_orig)
+    assert_equal(DateTime.new(2006, 3, 24, 13, 32, 3), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3, '+2'), false).to_offset(3600*3)).to_orig)
   end
 
   def test_wrap_time

--- a/test/tc_time_or_datetime.rb
+++ b/test/tc_time_or_datetime.rb
@@ -502,14 +502,13 @@ class TCTimeOrDateTime < Minitest::Test
     assert_equal(Time.new(2006, 3, 24, 18, 32, 3 + Rational(721, 1000), '+03:00'), (TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 721000)).offset(3600*3)).to_orig)
     assert_equal(DateTime.new(2006, 3, 24, 18, 32, 3, '+3'), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)).offset(3600*3)).to_orig)
     assert_equal(DateTime.new(2006, 3, 24, 18, 32, 3 + Rational(721, 1000), '+3'), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721, 1000))).offset(3600*3)).to_orig)
-    #assert_equal(1143214322, (TimeOrDateTime.new(1143214323).offset(3600*3)).to_orig)
-    #assert_equal(Time.utc(2006, 3, 24, 15, 32, 4), (TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)) - (-1)).to_orig)
-    #assert_equal(Time.utc(2006, 3, 24, 15, 32, 4, 721000), (TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 721000)) - (-1)).to_orig)
-    #assert_equal(DateTime.new(2006, 3, 24, 15, 32, 4), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)) - (-1)).to_orig)
-    #assert_equal(DateTime.new(2006, 3, 24, 15, 32, 4 + Rational(721, 1000)), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721, 1000))) - (-1)).to_orig)
-    #assert_equal(1143214324, (TimeOrDateTime.new(1143214323) - (-1)).to_orig)
+    assert_equal(1143225123, (TimeOrDateTime.new(1143214323).offset(3600*3)).to_orig)
 
-    # TODO: check what to do if orig is not UTC
+    assert_equal(Time.new(2006, 3, 24, 16, 32, 3, '+03:00'), (TimeOrDateTime.new(Time.new(2006, 3, 24, 15, 32, 3, '+02:00'), false).offset(3600*3)).to_orig)
+    assert_equal(DateTime.new(2006, 3, 24, 16, 32, 3, '+3'), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3, '+2'), false).offset(3600*3)).to_orig)
+
+    assert_equal(Time.utc(2006, 3, 24, 13, 32, 3), (TimeOrDateTime.new(Time.new(2006, 3, 24, 15, 32, 3, '+02:00'), false).offset(3600*3)).to_orig)
+    assert_equal(DateTime.new(2006, 3, 24, 13, 32, 3), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3, '+2'), false).offset(3600*3)).to_orig)
   end
 
   def test_wrap_time

--- a/test/tc_time_or_datetime.rb
+++ b/test/tc_time_or_datetime.rb
@@ -18,6 +18,15 @@ class TCTimeOrDateTime < Minitest::Test
     assert(tdt.to_orig.utc?)
   end
 
+  def test_initialize_time_local_preserve_offset
+    t = Time.new(2006, 3, 24, 15, 32, 3, '+03:00')
+    tdt = TimeOrDateTime.new(t, false)
+    assert_equal(t, tdt.to_time)
+    assert_equal(t, tdt.to_orig)
+    assert(!tdt.to_time.utc?)
+    assert(!tdt.to_orig.utc?)
+  end
+
   def test_intialize_time_local_usec
     tdt = TimeOrDateTime.new(Time.local(2006, 3, 24, 15, 32, 3, 721123))
     assert_equal(Time.utc(2006, 3, 24, 15, 32, 3, 721123), tdt.to_time)
@@ -480,6 +489,27 @@ class TCTimeOrDateTime < Minitest::Test
     assert_equal(DateTime.new(2006, 3, 24, 15, 32, 4), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)) - (-1)).to_orig)
     assert_equal(DateTime.new(2006, 3, 24, 15, 32, 4 + Rational(721, 1000)), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721, 1000))) - (-1)).to_orig)
     assert_equal(1143214324, (TimeOrDateTime.new(1143214323) - (-1)).to_orig)
+  end
+
+  def test_offset
+    assert_equal(Time.utc(2006, 3, 24, 15, 32, 3), (TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)).offset(0)).to_orig)
+    assert_equal(Time.utc(2006, 3, 24, 15, 32, 3, 721000), (TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 721000)).offset(0)).to_orig)
+    assert_equal(DateTime.new(2006, 3, 24, 15, 32, 3), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)).offset(0)).to_orig)
+    assert_equal(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721, 1000)), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721, 1000))).offset(0)).to_orig)
+    assert_equal(1143214323, (TimeOrDateTime.new(1143214323).offset(0)).to_orig)
+
+    assert_equal(Time.new(2006, 3, 24, 18, 32, 3, '+03:00'), (TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)).offset(3600*3)).to_orig)
+    assert_equal(Time.new(2006, 3, 24, 18, 32, 3 + Rational(721, 1000), '+03:00'), (TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 721000)).offset(3600*3)).to_orig)
+    assert_equal(DateTime.new(2006, 3, 24, 18, 32, 3, '+3'), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)).offset(3600*3)).to_orig)
+    assert_equal(DateTime.new(2006, 3, 24, 18, 32, 3 + Rational(721, 1000), '+3'), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721, 1000))).offset(3600*3)).to_orig)
+    #assert_equal(1143214322, (TimeOrDateTime.new(1143214323).offset(3600*3)).to_orig)
+    #assert_equal(Time.utc(2006, 3, 24, 15, 32, 4), (TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3)) - (-1)).to_orig)
+    #assert_equal(Time.utc(2006, 3, 24, 15, 32, 4, 721000), (TimeOrDateTime.new(Time.utc(2006, 3, 24, 15, 32, 3, 721000)) - (-1)).to_orig)
+    #assert_equal(DateTime.new(2006, 3, 24, 15, 32, 4), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3)) - (-1)).to_orig)
+    #assert_equal(DateTime.new(2006, 3, 24, 15, 32, 4 + Rational(721, 1000)), (TimeOrDateTime.new(DateTime.new(2006, 3, 24, 15, 32, 3 + Rational(721, 1000))) - (-1)).to_orig)
+    #assert_equal(1143214324, (TimeOrDateTime.new(1143214323) - (-1)).to_orig)
+
+    # TODO: check what to do if orig is not UTC
   end
 
   def test_wrap_time

--- a/test/tc_timezone.rb
+++ b/test/tc_timezone.rb
@@ -789,9 +789,9 @@ class TCTimezone < Minitest::Test
     assert_equal(DateTime.new(2005,6,18,17,24,23 + Rational(567,1000),'+1'), TestTimezone.new('Europe/London', period, [], dtu).to_local(dtu))
     assert_equal(DateTime.new(2005,6,18,14,24,23 + Rational(567,1000),'+1'), TestTimezone.new('Europe/London', period, [], dtu2).to_local(dtu2))
     assert_equal(Time.new(2005,6,18,17,24,23,'+01:00'), TestTimezone.new('Europe/London', period, [], t).to_local(t))
-    assert_equal(Time.new(2005,6,18,14,24,23,'+01:00'), TestTimezone.new('Europe/London', period, [], t2.utc).to_local(t2))
+    assert_equal(Time.new(2005,6,18,14,24,23,'+01:00'), TestTimezone.new('Europe/London', period, [], t2.getutc).to_local(t2))
     assert_equal(Time.new(2005,6,18,17,24,23+Rational(567,1000), '+01:00'), TestTimezone.new('Europe/London', period, [], tu).to_local(tu))
-    assert_equal(Time.new(2005,6,18,14,24,23+Rational(567,1000), '+01:00'), TestTimezone.new('Europe/London', period, [], tu2.utc).to_local(tu2))
+    assert_equal(Time.new(2005,6,18,14,24,23+Rational(567,1000), '+01:00'), TestTimezone.new('Europe/London', period, [], tu2.getutc).to_local(tu2))
     assert_equal(Time.utc(2005,6,18,17,24,23).to_i, TestTimezone.new('Europe/London', period, [], ts).utc_to_local(ts))
   end
 

--- a/test/tc_timezone.rb
+++ b/test/tc_timezone.rb
@@ -766,6 +766,35 @@ class TCTimezone < Minitest::Test
     assert(!TestTimezone.new('Europe/London', period, [], tu2).utc_to_local(tu2).utc?)
   end
 
+  def test_to_local
+    dt = DateTime.new(2005,6,18,16,24,23)
+    dt2 = DateTime.new(2005,6,18,16,24,23, '+3')
+    dtu = DateTime.new(2005,6,18,16,24,23 + Rational(567,1000))
+    dtu2 = DateTime.new(2005,6,18,16,24,23 + Rational(567,1000), '+3')
+    t = Time.utc(2005,6,18,16,24,23)
+    t2 = Time.new(2005,6,18,16,24,23, '+03:00')
+    tu = Time.utc(2005,6,18,16,24,23,567000)
+    tu2 = Time.new(2005,6,18,16,24,23 + Rational(567, 1000), '+03:00')
+    ts = t.to_i
+
+    o1 = TimezoneOffset.new(0, 0, :GMT)
+    o2 = TimezoneOffset.new(0, 3600, :BST)
+
+    period = TimezonePeriod.new(
+      TestTimezoneTransition.new(o2, o1, 1111885200),
+      TestTimezoneTransition.new(o1, o2, 1130634000))
+
+    assert_equal(DateTime.new(2005,6,18,17,24,23,'+1'), TestTimezone.new('Europe/London', period, [], dt).to_local(dt))
+    assert_equal(DateTime.new(2005,6,18,14,24,23,'+1'), TestTimezone.new('Europe/London', period, [], dt2).to_local(dt2))
+    assert_equal(DateTime.new(2005,6,18,17,24,23 + Rational(567,1000),'+1'), TestTimezone.new('Europe/London', period, [], dtu).to_local(dtu))
+    assert_equal(DateTime.new(2005,6,18,14,24,23 + Rational(567,1000),'+1'), TestTimezone.new('Europe/London', period, [], dtu2).to_local(dtu2))
+    assert_equal(Time.new(2005,6,18,17,24,23,'+01:00'), TestTimezone.new('Europe/London', period, [], t).to_local(t))
+    assert_equal(Time.new(2005,6,18,14,24,23,'+01:00'), TestTimezone.new('Europe/London', period, [], t2.utc).to_local(t2))
+    assert_equal(Time.new(2005,6,18,17,24,23+Rational(567,1000), '+01:00'), TestTimezone.new('Europe/London', period, [], tu).to_local(tu))
+    assert_equal(Time.new(2005,6,18,14,24,23+Rational(567,1000), '+01:00'), TestTimezone.new('Europe/London', period, [], tu2.utc).to_local(tu2))
+    assert_equal(Time.utc(2005,6,18,17,24,23).to_i, TestTimezone.new('Europe/London', period, [], ts).utc_to_local(ts))
+  end
+
   def test_local_to_utc
     dt = DateTime.new(2005,6,18,16,24,23)
     dt2 = DateTime.new(2005,6,18,16,24,23).new_offset(Rational(5, 24))

--- a/test/tc_timezone.rb
+++ b/test/tc_timezone.rb
@@ -752,10 +752,10 @@ class TCTimezone < Minitest::Test
       TestTimezoneTransition.new(o2, o1, 1111885200),
       TestTimezoneTransition.new(o1, o2, 1130634000))
 
-    assert_equal(1/24r, TestTimezone.new('Europe/London', period, [], dt).utc_to_local(dt).offset)
-    assert_equal(1/24r, TestTimezone.new('Europe/London', period, [], dt2).utc_to_local(dt2).offset)
-    assert_equal(1/24r, TestTimezone.new('Europe/London', period, [], dtu).utc_to_local(dtu).offset)
-    assert_equal(1/24r, TestTimezone.new('Europe/London', period, [], dtu2).utc_to_local(dtu2).offset)
+    assert_equal(Rational(1, 24), TestTimezone.new('Europe/London', period, [], dt).utc_to_local(dt).offset)
+    assert_equal(Rational(1, 24), TestTimezone.new('Europe/London', period, [], dt2).utc_to_local(dt2).offset)
+    assert_equal(Rational(1, 24), TestTimezone.new('Europe/London', period, [], dtu).utc_to_local(dtu).offset)
+    assert_equal(Rational(1, 24), TestTimezone.new('Europe/London', period, [], dtu2).utc_to_local(dtu2).offset)
     assert_equal(3600, TestTimezone.new('Europe/London', period, [], t).utc_to_local(t).utc_offset)
     assert(!TestTimezone.new('Europe/London', period, [], t).utc_to_local(t).utc?)
     assert_equal(3600, TestTimezone.new('Europe/London', period, [], t2).utc_to_local(t2).utc_offset)

--- a/test/tc_timezone.rb
+++ b/test/tc_timezone.rb
@@ -706,6 +706,31 @@ class TCTimezone < Minitest::Test
     end
   end
 
+  def test_period_for
+    dt = DateTime.new(2005,2,18,16,24,23,'+03:00')
+    t = Time.new(2005,2,18,16,24,23,'+03:00')
+    ts = t.to_i
+
+    dt_utc = TimeOrDateTime.wrap(dt, false).to_offset(0)
+    t_utc = TimeOrDateTime.wrap(t, false).to_offset(0)
+    ts_utc = TimeOrDateTime.wrap(ts, false).to_offset(0)
+
+    o1 = TimezoneOffset.new(0, 0, :GMT)
+    o2 = TimezoneOffset.new(0, 3600, :BST)
+
+    period = TimezonePeriod.new(
+      TestTimezoneTransition.new(o1, o2, 1099184400),
+      TestTimezoneTransition.new(o2, o1, 1111885200))
+
+    dt_period = TestTimezone.new('Europe/London', period, nil, dt_utc).period_for(dt)
+    t_period = TestTimezone.new('Europe/London', period, nil, t_utc).period_for(t)
+    ts_period = TestTimezone.new('Europe/London', period, nil, ts_utc).period_for(ts)
+
+    assert_equal(period, dt_period)
+    assert_equal(period, t_period)
+    assert_equal(period, ts_period)
+  end
+
   def test_utc_to_local
     dt = DateTime.new(2005,6,18,16,24,23)
     dt2 = DateTime.new(2005,6,18,16,24,23).new_offset(Rational(5,24))

--- a/test/tc_timezone.rb
+++ b/test/tc_timezone.rb
@@ -724,14 +724,14 @@ class TCTimezone < Minitest::Test
       TestTimezoneTransition.new(o2, o1, 1111885200),
       TestTimezoneTransition.new(o1, o2, 1130634000))
 
-    assert_equal(DateTime.new(2005,6,18,17,24,23), TestTimezone.new('Europe/London', period, [], dt).utc_to_local(dt))
-    assert_equal(DateTime.new(2005,6,18,17,24,23), TestTimezone.new('Europe/London', period, [], dt2).utc_to_local(dt2))
-    assert_equal(DateTime.new(2005,6,18,17,24,23 + Rational(567,1000)), TestTimezone.new('Europe/London', period, [], dtu).utc_to_local(dtu))
-    assert_equal(DateTime.new(2005,6,18,17,24,23 + Rational(567,1000)), TestTimezone.new('Europe/London', period, [], dtu2).utc_to_local(dtu2))
-    assert_equal(Time.utc(2005,6,18,17,24,23), TestTimezone.new('Europe/London', period, [], t).utc_to_local(t))
-    assert_equal(Time.utc(2005,6,18,17,24,23), TestTimezone.new('Europe/London', period, [], t2).utc_to_local(t2))
-    assert_equal(Time.utc(2005,6,18,17,24,23,567000), TestTimezone.new('Europe/London', period, [], tu).utc_to_local(tu))
-    assert_equal(Time.utc(2005,6,18,17,24,23,567000), TestTimezone.new('Europe/London', period, [], tu2).utc_to_local(tu2))
+    assert_equal(DateTime.new(2005,6,18,17,24,23,'+1'), TestTimezone.new('Europe/London', period, [], dt).utc_to_local(dt))
+    assert_equal(DateTime.new(2005,6,18,17,24,23,'+1'), TestTimezone.new('Europe/London', period, [], dt2).utc_to_local(dt2))
+    assert_equal(DateTime.new(2005,6,18,17,24,23 + Rational(567,1000),'+1'), TestTimezone.new('Europe/London', period, [], dtu).utc_to_local(dtu))
+    assert_equal(DateTime.new(2005,6,18,17,24,23 + Rational(567,1000),'+1'), TestTimezone.new('Europe/London', period, [], dtu2).utc_to_local(dtu2))
+    assert_equal(Time.new(2005,6,18,17,24,23,'+01:00'), TestTimezone.new('Europe/London', period, [], t).utc_to_local(t))
+    assert_equal(Time.new(2005,6,18,17,24,23,'+01:00'), TestTimezone.new('Europe/London', period, [], t2).utc_to_local(t2))
+    assert_equal(Time.new(2005,6,18,17,24,23+Rational(567,1000), '+01:00'), TestTimezone.new('Europe/London', period, [], tu).utc_to_local(tu))
+    assert_equal(Time.new(2005,6,18,17,24,23+Rational(567,1000), '+01:00'), TestTimezone.new('Europe/London', period, [], tu2).utc_to_local(tu2))
     assert_equal(Time.utc(2005,6,18,17,24,23).to_i, TestTimezone.new('Europe/London', period, [], ts).utc_to_local(ts))
   end
 
@@ -752,18 +752,18 @@ class TCTimezone < Minitest::Test
       TestTimezoneTransition.new(o2, o1, 1111885200),
       TestTimezoneTransition.new(o1, o2, 1130634000))
 
-    assert_equal(0, TestTimezone.new('Europe/London', period, [], dt).utc_to_local(dt).offset)
-    assert_equal(0, TestTimezone.new('Europe/London', period, [], dt2).utc_to_local(dt2).offset)
-    assert_equal(0, TestTimezone.new('Europe/London', period, [], dtu).utc_to_local(dtu).offset)
-    assert_equal(0, TestTimezone.new('Europe/London', period, [], dtu2).utc_to_local(dtu2).offset)
-    assert_equal(0, TestTimezone.new('Europe/London', period, [], t).utc_to_local(t).utc_offset)
-    assert(TestTimezone.new('Europe/London', period, [], t).utc_to_local(t).utc?)
-    assert_equal(0, TestTimezone.new('Europe/London', period, [], t2).utc_to_local(t2).utc_offset)
-    assert(TestTimezone.new('Europe/London', period, [], t2).utc_to_local(t2).utc?)
-    assert_equal(0, TestTimezone.new('Europe/London', period, [], tu).utc_to_local(tu).utc_offset)
-    assert(TestTimezone.new('Europe/London', period, [], tu).utc_to_local(tu).utc?)
-    assert_equal(0, TestTimezone.new('Europe/London', period, [], tu2).utc_to_local(tu2).utc_offset)
-    assert(TestTimezone.new('Europe/London', period, [], tu2).utc_to_local(tu2).utc?)
+    assert_equal(1/24r, TestTimezone.new('Europe/London', period, [], dt).utc_to_local(dt).offset)
+    assert_equal(1/24r, TestTimezone.new('Europe/London', period, [], dt2).utc_to_local(dt2).offset)
+    assert_equal(1/24r, TestTimezone.new('Europe/London', period, [], dtu).utc_to_local(dtu).offset)
+    assert_equal(1/24r, TestTimezone.new('Europe/London', period, [], dtu2).utc_to_local(dtu2).offset)
+    assert_equal(3600, TestTimezone.new('Europe/London', period, [], t).utc_to_local(t).utc_offset)
+    assert(!TestTimezone.new('Europe/London', period, [], t).utc_to_local(t).utc?)
+    assert_equal(3600, TestTimezone.new('Europe/London', period, [], t2).utc_to_local(t2).utc_offset)
+    assert(!TestTimezone.new('Europe/London', period, [], t2).utc_to_local(t2).utc?)
+    assert_equal(3600, TestTimezone.new('Europe/London', period, [], tu).utc_to_local(tu).utc_offset)
+    assert(!TestTimezone.new('Europe/London', period, [], tu).utc_to_local(tu).utc?)
+    assert_equal(3600, TestTimezone.new('Europe/London', period, [], tu2).utc_to_local(tu2).utc_offset)
+    assert(!TestTimezone.new('Europe/London', period, [], tu2).utc_to_local(tu2).utc?)
   end
 
   def test_local_to_utc

--- a/test/tc_timezone_london.rb
+++ b/test/tc_timezone_london.rb
@@ -11,8 +11,8 @@ class TCTimezoneLondon < Minitest::Test
 
     tz = Timezone.get('Europe/London')
     assert_equal(DateTime.new(2004,3,28,0,59,59), tz.utc_to_local(DateTime.new(2004,3,28,0,59,59)))
-    assert_equal(DateTime.new(2004,3,28,2,0,0), tz.utc_to_local(DateTime.new(2004,3,28,1,0,0)))
-    assert_equal(DateTime.new(2004,10,31,1,59,59), tz.utc_to_local(DateTime.new(2004,10,31,0,59,59)))
+    assert_equal(DateTime.new(2004,3,28,2,0,0,'+1'), tz.utc_to_local(DateTime.new(2004,3,28,1,0,0)))
+    assert_equal(DateTime.new(2004,10,31,1,59,59,'+1'), tz.utc_to_local(DateTime.new(2004,10,31,0,59,59)))
     assert_equal(DateTime.new(2004,10,31,1,0,0), tz.utc_to_local(DateTime.new(2004,10,31,1,0,0)))
 
     assert_equal(DateTime.new(2004,3,28,0,59,59), tz.local_to_utc(DateTime.new(2004,3,28,0,59,59)))
@@ -70,8 +70,8 @@ class TCTimezoneLondon < Minitest::Test
 
     tz = Timezone.get('Europe/London')
     assert_equal(DateTime.new(1961,3,26,1,59,59), tz.utc_to_local(DateTime.new(1961,3,26,1,59,59)))
-    assert_equal(DateTime.new(1961,3,26,3,0,0), tz.utc_to_local(DateTime.new(1961,3,26,2,0,0)))
-    assert_equal(DateTime.new(1961,10,29,2,59,59), tz.utc_to_local(DateTime.new(1961,10,29,1,59,59)))
+    assert_equal(DateTime.new(1961,3,26,3,0,0,'+1'), tz.utc_to_local(DateTime.new(1961,3,26,2,0,0)))
+    assert_equal(DateTime.new(1961,10,29,2,59,59,'+1'), tz.utc_to_local(DateTime.new(1961,10,29,1,59,59)))
     assert_equal(DateTime.new(1961,10,29,2,0,0), tz.utc_to_local(DateTime.new(1961,10,29,2,0,0)))
 
     assert_equal(DateTime.new(1961,3,26,1,59,59), tz.local_to_utc(DateTime.new(1961,3,26,1,59,59)))
@@ -127,9 +127,9 @@ class TCTimezoneLondon < Minitest::Test
     #Europe/London  Sun Oct 31 01:59:59 1971 UTC = Sun Oct 31 02:59:59 1971 GMT isdst=0 gmtoff=3600
 
     tz = Timezone.get('Europe/London')
-    assert_equal(DateTime.new(1970,1,1,1,0,0), tz.utc_to_local(DateTime.new(1970,1,1,0,0,0)))
+    assert_equal(DateTime.new(1970,1,1,1,0,0,'+1'), tz.utc_to_local(DateTime.new(1970,1,1,0,0,0)))
     assert_equal(DateTime.new(1970,1,1,0,0,0), tz.local_to_utc(DateTime.new(1970,1,1,1,0,0)))
-    assert_equal(Time.utc(1970,1,1,1,0,0), tz.utc_to_local(Time.utc(1970,1,1,0,0,0)))
+    assert_equal(Time.new(1970,1,1,1,0,0,'+01:00'), tz.utc_to_local(Time.utc(1970,1,1,0,0,0)))
     assert_equal(Time.utc(1970,1,1,0,0,0), tz.local_to_utc(Time.utc(1970,1,1,1,0,0)))
     assert_equal(3600, tz.utc_to_local(0))
     assert_equal(0, tz.local_to_utc(3600))

--- a/test/tc_timezone_melbourne.rb
+++ b/test/tc_timezone_melbourne.rb
@@ -10,10 +10,10 @@ class TCTimezoneMelbourne < Minitest::Test
     #Australia/Melbourne  Sat Oct 30 16:00:00 2004 UTC = Sun Oct 31 03:00:00 2004 AEDT isdst=1 gmtoff=39600
 
     tz = Timezone.get('Australia/Melbourne')
-    assert_equal(DateTime.new(2004,3,28,2,59,59), tz.utc_to_local(DateTime.new(2004,3,27,15,59,59)))
-    assert_equal(DateTime.new(2004,3,28,2,0,0), tz.utc_to_local(DateTime.new(2004,3,27,16,0,0)))
-    assert_equal(DateTime.new(2004,10,31,1,59,59), tz.utc_to_local(DateTime.new(2004,10,30,15,59,59)))
-    assert_equal(DateTime.new(2004,10,31,3,0,0), tz.utc_to_local(DateTime.new(2004,10,30,16,0,0)))
+    assert_equal(DateTime.new(2004,3,28,2,59,59,'+11'), tz.utc_to_local(DateTime.new(2004,3,27,15,59,59)))
+    assert_equal(DateTime.new(2004,3,28,2,0,0,'+10'), tz.utc_to_local(DateTime.new(2004,3,27,16,0,0)))
+    assert_equal(DateTime.new(2004,10,31,1,59,59,'+10'), tz.utc_to_local(DateTime.new(2004,10,30,15,59,59)))
+    assert_equal(DateTime.new(2004,10,31,3,0,0,'+11'), tz.utc_to_local(DateTime.new(2004,10,30,16,0,0)))
 
     assert_equal(DateTime.new(2004,3,27,15,59,59), tz.local_to_utc(DateTime.new(2004,3,28,2,59,59), true))
     assert_equal(DateTime.new(2004,3,27,16,59,59), tz.local_to_utc(DateTime.new(2004,3,28,2,59,59), false))
@@ -69,10 +69,10 @@ class TCTimezoneMelbourne < Minitest::Test
     #Australia/Melbourne  Sat Sep 26 16:00:00 1942 UTC = Sun Sep 27 03:00:00 1942 AEDT isdst=1 gmtoff=39600
 
     tz = Timezone.get('Australia/Melbourne')
-    assert_equal(DateTime.new(1942,3,29,1,59,59), tz.utc_to_local(DateTime.new(1942,3,28,14,59,59)))
-    assert_equal(DateTime.new(1942,3,29,1,0,0), tz.utc_to_local(DateTime.new(1942,3,28,15,0,0)))
-    assert_equal(DateTime.new(1942,9,27,1,59,59), tz.utc_to_local(DateTime.new(1942,9,26,15,59,59)))
-    assert_equal(DateTime.new(1942,9,27,3,0,0), tz.utc_to_local(DateTime.new(1942,9,26,16,0,0)))
+    assert_equal(DateTime.new(1942,3,29,1,59,59,'+11'), tz.utc_to_local(DateTime.new(1942,3,28,14,59,59)))
+    assert_equal(DateTime.new(1942,3,29,1,0,0,'+10'), tz.utc_to_local(DateTime.new(1942,3,28,15,0,0)))
+    assert_equal(DateTime.new(1942,9,27,1,59,59,'+10'), tz.utc_to_local(DateTime.new(1942,9,26,15,59,59)))
+    assert_equal(DateTime.new(1942,9,27,3,0,0,'+11'), tz.utc_to_local(DateTime.new(1942,9,26,16,0,0)))
 
     assert_equal(DateTime.new(1942,3,28,14,59,59), tz.local_to_utc(DateTime.new(1942,3,29,1,59,59), true))
     assert_equal(DateTime.new(1942,3,28,15,59,59), tz.local_to_utc(DateTime.new(1942,3,29,1,59,59), false))
@@ -126,9 +126,9 @@ class TCTimezoneMelbourne < Minitest::Test
     #Australia/Melbourne  Sat Oct 30 15:59:59 1971 UTC = Sun Oct 31 01:59:59 1971 AEST isdst=0 gmtoff=36000
 
     tz = Timezone.get('Australia/Melbourne')
-    assert_equal(DateTime.new(1970,1,1,10,0,0), tz.utc_to_local(DateTime.new(1970,1,1,0,0,0)))
+    assert_equal(DateTime.new(1970,1,1,10,0,0,'+10'), tz.utc_to_local(DateTime.new(1970,1,1,0,0,0)))
     assert_equal(DateTime.new(1970,1,1,0,0,0), tz.local_to_utc(DateTime.new(1970,1,1,10,0,0)))
-    assert_equal(Time.utc(1970,1,1,10,0,0), tz.utc_to_local(Time.utc(1970,1,1,0,0,0)))
+    assert_equal(Time.new(1970,1,1,10,0,0,'+10:00'), tz.utc_to_local(Time.utc(1970,1,1,0,0,0)))
     assert_equal(Time.utc(1970,1,1,0,0,0), tz.local_to_utc(Time.utc(1970,1,1,10,0,0)))
     assert_equal(36000, tz.utc_to_local(0))
     assert_equal(0, tz.local_to_utc(36000))

--- a/test/tc_timezone_new_york.rb
+++ b/test/tc_timezone_new_york.rb
@@ -10,10 +10,10 @@ class TCTimezoneNewYork < Minitest::Test
     #America/New_York  Sun Oct 31 06:00:00 2004 UTC = Sun Oct 31 01:00:00 2004 EST isdst=0 gmtoff=-18000
 
     tz = Timezone.get('America/New_York')
-    assert_equal(DateTime.new(2004,4,4,1,59,59), tz.utc_to_local(DateTime.new(2004,4,4,6,59,59)))
-    assert_equal(DateTime.new(2004,4,4,3,0,0), tz.utc_to_local(DateTime.new(2004,4,4,7,0,0)))
-    assert_equal(DateTime.new(2004,10,31,1,59,59), tz.utc_to_local(DateTime.new(2004,10,31,5,59,59)))
-    assert_equal(DateTime.new(2004,10,31,1,0,0), tz.utc_to_local(DateTime.new(2004,10,31,6,0,0)))
+    assert_equal(DateTime.new(2004,4,4,1,59,59,'-5'), tz.utc_to_local(DateTime.new(2004,4,4,6,59,59)))
+    assert_equal(DateTime.new(2004,4,4,3,0,0,'-4'), tz.utc_to_local(DateTime.new(2004,4,4,7,0,0)))
+    assert_equal(DateTime.new(2004,10,31,1,59,59,'-4'), tz.utc_to_local(DateTime.new(2004,10,31,5,59,59)))
+    assert_equal(DateTime.new(2004,10,31,1,0,0,'-5'), tz.utc_to_local(DateTime.new(2004,10,31,6,0,0)))
 
     assert_equal(DateTime.new(2004,4,4,6,59,59), tz.local_to_utc(DateTime.new(2004,4,4,1,59,59)))
     assert_equal(DateTime.new(2004,4,4,7,0,0), tz.local_to_utc(DateTime.new(2004,4,4,3,0,0)))
@@ -69,10 +69,10 @@ class TCTimezoneNewYork < Minitest::Test
     #America/New_York  Sun Oct 27 06:00:00 1957 UTC = Sun Oct 27 01:00:00 1957 EST isdst=0 gmtoff=-18000
 
     tz = Timezone.get('America/New_York')
-    assert_equal(DateTime.new(1957,4,28,1,59,59), tz.utc_to_local(DateTime.new(1957,4,28,6,59,59)))
-    assert_equal(DateTime.new(1957,4,28,3,0,0), tz.utc_to_local(DateTime.new(1957,4,28,7,0,0)))
-    assert_equal(DateTime.new(1957,10,27,1,59,59), tz.utc_to_local(DateTime.new(1957,10,27,5,59,59)))
-    assert_equal(DateTime.new(1957,10,27,1,0,0), tz.utc_to_local(DateTime.new(1957,10,27,6,0,0)))
+    assert_equal(DateTime.new(1957,4,28,1,59,59,'-5'), tz.utc_to_local(DateTime.new(1957,4,28,6,59,59)))
+    assert_equal(DateTime.new(1957,4,28,3,0,0,'-4'), tz.utc_to_local(DateTime.new(1957,4,28,7,0,0)))
+    assert_equal(DateTime.new(1957,10,27,1,59,59,'-4'), tz.utc_to_local(DateTime.new(1957,10,27,5,59,59)))
+    assert_equal(DateTime.new(1957,10,27,1,0,0,'-5'), tz.utc_to_local(DateTime.new(1957,10,27,6,0,0)))
 
     assert_equal(DateTime.new(1957,4,28,6,59,59), tz.local_to_utc(DateTime.new(1957,4,28,1,59,59)))
     assert_equal(DateTime.new(1957,4,28,7,0,0), tz.local_to_utc(DateTime.new(1957,4,28,3,0,0)))
@@ -126,9 +126,9 @@ class TCTimezoneNewYork < Minitest::Test
     #America/New_York  Sun Apr 26 06:59:59 1970 UTC = Sun Apr 26 01:59:59 1970 EST isdst=0 gmtoff=-18000
 
     tz = Timezone.get('America/New_York')
-    assert_equal(DateTime.new(1970,1,1,0,0,0), tz.utc_to_local(DateTime.new(1970,1,1,5,0,0)))
+    assert_equal(DateTime.new(1970,1,1,0,0,0,'-5'), tz.utc_to_local(DateTime.new(1970,1,1,5,0,0)))
     assert_equal(DateTime.new(1970,1,1,5,0,0), tz.local_to_utc(DateTime.new(1970,1,1,0,0,0)))
-    assert_equal(Time.utc(1970,1,1,0,0,0), tz.utc_to_local(Time.utc(1970,1,1,5,0,0)))
+    assert_equal(Time.new(1970,1,1,0,0,0,'-05:00'), tz.utc_to_local(Time.utc(1970,1,1,5,0,0)))
     assert_equal(Time.utc(1970,1,1,5,0,0), tz.local_to_utc(Time.utc(1970,1,1,0,0,0)))
     assert_equal(0, tz.utc_to_local(18000))
     assert_equal(18000, tz.local_to_utc(0))

--- a/test/tc_timezone_offset.rb
+++ b/test/tc_timezone_offset.rb
@@ -49,10 +49,10 @@ class TCTimezoneOffset < Minitest::Test
     o2 = TimezoneOffset.new(-3600, 3600, :TEST2)
 
     assert_equal(1148949080, o1.to_local(1148931080))
-    assert_equal(Time.utc(2006, 5, 30, 0, 31, 20), o1.to_local(Time.utc(2006, 5, 29, 19, 31, 20)))
-    assert_equal(Time.utc(2006, 5, 30, 0, 31, 20, 782000), o1.to_local(Time.utc(2006, 5, 29, 19, 31, 20, 782000)))
-    assert_equal(DateTime.new(2006, 5, 30, 0, 31, 20), o1.to_local(DateTime.new(2006, 5, 29, 19, 31, 20)))
-    assert_equal(DateTime.new(2006, 5, 30, 0, 31, 20 + Rational(782, 1000)), o1.to_local(DateTime.new(2006, 5, 29, 19, 31, 20 + Rational(782, 1000))))
+    assert_equal(Time.new(2006, 5, 30, 0, 31, 20, '+05:00'), o1.to_local(Time.utc(2006, 5, 29, 19, 31, 20)))
+    assert_equal(Time.new(2006, 5, 30, 0, 31, 20 + Rational(782, 1000), '+05:00'), o1.to_local(Time.utc(2006, 5, 29, 19, 31, 20, 782000)))
+    assert_equal(DateTime.new(2006, 5, 30, 0, 31, 20, '+5'), o1.to_local(DateTime.new(2006, 5, 29, 19, 31, 20)))
+    assert_equal(DateTime.new(2006, 5, 30, 0, 31, 20 + Rational(782, 1000), '+5'), o1.to_local(DateTime.new(2006, 5, 29, 19, 31, 20 + Rational(782, 1000))))
     assert_equal(1148949080, o1.to_local(1148931080))
     assert(TimeOrDateTime.new(1148949080).eql?(o1.to_local(TimeOrDateTime.new(1148931080))))
 

--- a/test/tc_timezone_period.rb
+++ b/test/tc_timezone_period.rb
@@ -376,10 +376,10 @@ class TCTimezonePeriod < Minitest::Test
     p2 = TimezonePeriod.new(nil, nil, TimezoneOffset.new(-14400, 0, :TEST))
     p3 = TimezonePeriod.new(nil, nil, TimezoneOffset.new(7200, 3600, :TEST))
 
-    assert_equal(DateTime.new(2005,1,19,22,0,0), p1.to_local(DateTime.new(2005,1,20,1,0,0)))
-    assert_equal(DateTime.new(2005,1,19,22,0,0 + Rational(512,1000)), p1.to_local(DateTime.new(2005,1,20,1,0,0 + Rational(512,1000))))
-    assert_equal(Time.utc(2005,1,19,21,0,0), p2.to_local(Time.utc(2005,1,20,1,0,0)))
-    assert_equal(Time.utc(2005,1,19,21,0,0,512000), p2.to_local(Time.utc(2005,1,20,1,0,0,512000)))
+    assert_equal(DateTime.new(2005,1,19,22,0,0, '-3'), p1.to_local(DateTime.new(2005,1,20,1,0,0)))
+    assert_equal(DateTime.new(2005,1,19,22,0,0 + Rational(512,1000), '-3'), p1.to_local(DateTime.new(2005,1,20,1,0,0 + Rational(512,1000))))
+    assert_equal(Time.new(2005,1,19,21,0,0, '-04:00'), p2.to_local(Time.utc(2005,1,20,1,0,0)))
+    assert_equal(Time.new(2005,1,19,21,0,0 + Rational(512,1000), '-04:00'), p2.to_local(Time.utc(2005,1,20,1,0,0,512000)))
     assert_equal(1106193600, p3.to_local(1106182800))
   end
 


### PR DESCRIPTION
Hey. This is an attempt to implement https://github.com/tzinfo/tzinfo/issues/49, as @philr described in https://github.com/tzinfo/tzinfo/issues/49#issuecomment-208077450.

What is done:
* `Timezone#utc_to_local` returns Time/DateTime with correct offsets;
* `Timezone#local_to_utc` is untouched (as discussed), it just ignores argument's offset;
* `Timezone#to_local` converts argument, considering its offset.

What is not done (and requires advises/discussions):
* <s>Implementations are somewhat naive and maybe not the most effective, to say the least;</s>
* `#to_local` may seem undertested (and `#period_for` is not tested at all);
* No documentation for new/changed functionality.

Currently, I'm expecting principal agreement (or disagreement) with my approaches, and optimization/code quality advises.