### PR TITLE
Slight memory reduction

### DIFF
--- a/lib/tzinfo/zoneinfo_data_source.rb
+++ b/lib/tzinfo/zoneinfo_data_source.rb
@@ -432,7 +432,7 @@ module TZInfo
 
             file_is_5_column = true if column5
 
-            zone_tab << [codes.split(','), zone_identifier, latitude, longitude, column4, column5]
+            zone_tab << [codes.split(','.freeze), zone_identifier, latitude, longitude, column4, column5]
           end
         end
       end
@@ -480,7 +480,7 @@ module TZInfo
     def dms_to_rational(sign, degrees, minutes, seconds = nil)
       result = degrees.to_i + Rational(minutes.to_i, 60)
       result += Rational(seconds.to_i, 3600) if seconds
-      result = -result if sign == '-'
+      result = -result if sign == '-'.freeze
       result
     end
   end

--- a/lib/tzinfo/zoneinfo_timezone_info.rb
+++ b/lib/tzinfo/zoneinfo_timezone_info.rb
@@ -127,26 +127,26 @@ module TZInfo
         transitions = []
 
         if using_64bit
-          (0...timecnt).each do |i|
+          timecnt.times do |i|
             high, low = check_read(file, 8).unpack('NN'.freeze)
             transition_time = make_signed_int64(high, low)
             transitions << {:at => transition_time}
           end
         else
-          (0...timecnt).each do |i|
+          timecnt.times do |i|
             transition_time = make_signed_int32(check_read(file, 4).unpack('N'.freeze)[0])
             transitions << {:at => transition_time}
           end
         end
 
-        (0...timecnt).each do |i|
+        timecnt.times do |i|
           localtime_type = check_read(file, 1).unpack('C'.freeze)[0]
           transitions[i][:offset] = localtime_type
         end
 
         offsets = []
 
-        (0...typecnt).each do |i|
+        typecnt.times do |i|
           gmtoff, isdst, abbrind = check_read(file, 6).unpack('NCC'.freeze)
           gmtoff = make_signed_int32(gmtoff)
           isdst = isdst == 1

--- a/lib/tzinfo/zoneinfo_timezone_info.rb
+++ b/lib/tzinfo/zoneinfo_timezone_info.rb
@@ -128,26 +128,26 @@ module TZInfo
 
         if using_64bit
           (0...timecnt).each do |i|
-            high, low = check_read(file, 8).unpack('NN')
+            high, low = check_read(file, 8).unpack('NN'.freeze)
             transition_time = make_signed_int64(high, low)
             transitions << {:at => transition_time}
           end
         else
           (0...timecnt).each do |i|
-            transition_time = make_signed_int32(check_read(file, 4).unpack('N')[0])
+            transition_time = make_signed_int32(check_read(file, 4).unpack('N'.freeze)[0])
             transitions << {:at => transition_time}
           end
         end
 
         (0...timecnt).each do |i|
-          localtime_type = check_read(file, 1).unpack('C')[0]
+          localtime_type = check_read(file, 1).unpack('C'.freeze)[0]
           transitions[i][:offset] = localtime_type
         end
 
         offsets = []
 
         (0...typecnt).each do |i|
-          gmtoff, isdst, abbrind = check_read(file, 6).unpack('NCC')
+          gmtoff, isdst, abbrind = check_read(file, 6).unpack('NCC'.freeze)
           gmtoff = make_signed_int32(gmtoff)
           isdst = isdst == 1
           offset = {:utc_total_offset => gmtoff, :is_dst => isdst, :abbr_index => abbrind}


### PR DESCRIPTION
closes #54 

Doing a basic `get` showed a slight reduction in objects created.

Using:
```
require 'rubygems'
require 'memory_profiler'
require 'tzinfo'

MemoryProfiler.report(ignore_files: 'rubygems') {
  TZInfo::Timezone.get('America/New_York')
}.pretty_print
```

Before:
```
allocated memory by gem
-----------------------------------
   1294730  tzinfo
        40  concurrent-ruby-1.0.2
        40  other
```

After:
```
allocated memory by gem
-----------------------------------
   1225130  tzinfo
        40  concurrent-ruby-1.0.2
        40  other
```

5.38% lower memory usage