### PR TITLE
Remove dependency on concurrent-ruby

### DIFF
--- a/lib/tzinfo.rb
+++ b/lib/tzinfo.rb
@@ -8,7 +8,7 @@ class TZInfo::ConcurrentMap
     @mutex = Mutex.new
     @h = {}
   end
-  def [](k); @mutex.synchronize { @h[k] }; end
+  def [](k); @h[k]; end
   def []=(k, v); @mutex.synchronize { @h[k] = v } ; end
 end
 

--- a/lib/tzinfo.rb
+++ b/lib/tzinfo.rb
@@ -2,6 +2,17 @@
 module TZInfo
 end
 
+
+class TZInfo::ConcurrentMap
+  def initialize
+    @mutex = Mutex.new
+    @h = {}
+  end
+  def [](k); @mutex.synchronize { @h[k] }; end
+  def []=(k, v); @mutex.synchronize { @h[k] = v } ; end
+end
+
+
 require 'tzinfo/version'
 
 require 'tzinfo/offset_rationals'
@@ -38,3 +49,5 @@ require 'tzinfo/zoneinfo_country_info'
 
 require 'tzinfo/country'
 require 'tzinfo/country_timezone'
+
+

--- a/lib/tzinfo/country.rb
+++ b/lib/tzinfo/country.rb
@@ -1,4 +1,4 @@
-require 'concurrent/map'
+#require 'concurrent/map'
 
 module TZInfo
   # Raised by Country#get if the code given is not valid.
@@ -184,7 +184,7 @@ module TZInfo
 
       # Initializes @@countries.
       def self.init_countries
-        @@countries = Concurrent::Map.new
+        @@countries = TZInfo::ConcurrentMap.new
       end
       init_countries
 

--- a/lib/tzinfo/timezone.rb
+++ b/lib/tzinfo/timezone.rb
@@ -1,6 +1,6 @@
 require 'date'
 require 'set'
-require 'concurrent/map'
+#require 'concurrent/map'
 
 module TZInfo
   # AmbiguousTime is raised to indicates that a specified time in a local
@@ -702,7 +702,7 @@ module TZInfo
     private
       # Initializes @@loaded_zones.
       def self.init_loaded_zones
-        @@loaded_zones = Concurrent::Map.new
+        @@loaded_zones = TZInfo::ConcurrentMap.new
       end
       init_loaded_zones
 

--- a/tzinfo.gemspec
+++ b/tzinfo.gemspec
@@ -23,5 +23,4 @@ Gem::Specification.new do |s|
                     '--main' << 'README.md'
   s.extra_rdoc_files = ['README.md', 'CHANGES.md', 'LICENSE']
   s.required_ruby_version = '>= 1.9.3'
-  s.add_dependency 'concurrent-ruby', '~> 1.0'
 end


### PR DESCRIPTION
Concurrent-ruby weighs 129KB (234KB for the Java flavour). Tzinfo only uses its Concurrent::Map.

This commit implements a tiny TZInfo::ConcurrentMap for @@countries and @@loaded_zones

Makes TZInfo lean.

Many thanks for TZInfo.