### PR TITLE
Fully initialize TZInfo::TimezoneTransitionDefinition object before freeze

### DIFF
--- a/lib/tzinfo/timezone_transition_definition.rb
+++ b/lib/tzinfo/timezone_transition_definition.rb
@@ -97,5 +97,10 @@ module TZInfo
     def hash
       @offset.hash ^ @previous_offset.hash ^ @numerator_or_time.hash ^ @denominator.hash
     end
+
+    def freeze
+      at # to fully initialize object before freeze
+      super
+    end
   end
 end

--- a/test/tc_timezone_transition_definition.rb
+++ b/test/tc_timezone_transition_definition.rb
@@ -281,4 +281,12 @@ class TCTimezoneTransitionDefinition < Minitest::Test
         t6.hash)
     end
   end
+
+  def test_freeze_when_not_fully_initialized
+    transition = TimezoneTransitionDefinition.new(TimezoneOffset.new(3600, 3600, :TDT),
+                                        TimezoneOffset.new(3600, 0, :TST), 1148949080)
+    transition.freeze
+
+    assert_nothing_raised { transition.at }
+  end
 end


### PR DESCRIPTION
`TZInfo::Timezone` objects could potentially be deep frozen before internal instances of `TZInfo::TimezoneTransitionDefinition` (which they may contain) will be fully initialized. If this happens then invoking `at` method will raise `RuntimeError: can't modify frozen TZInfo::TimezoneTransitionDefinition` exception (because of lazily computed `@at` instance variable).

Situation can be complicated with use of `ActiveSupport::TimeWithZone` instances (in Ruby on Rails projects for example) which can share cached `TZInfo::Timezone` instances internally - so deep freezing any `ActiveSupport::TimeWithZone` instance in one place of the code can cause mentioned exceptions to be raised in other, unrelated places.

The solution in this PR is similar to `activesupport` gem code, see [ActiveSupport::TimeWithZone#freeze](https://github.com/rails/rails/blob/v4.2.10/activesupport/lib/active_support/time_with_zone.rb#L351) for example.