### PR TITLE
Added TZInfo::Timezone#abbr

### DIFF
--- a/lib/tzinfo/timezone.rb
+++ b/lib/tzinfo/timezone.rb
@@ -1026,6 +1026,17 @@ module TZInfo
       to_local(time).strftime(format)
     end
 
+    # Returns the abbreviation of this {Timezone} at the given time.
+    #
+    # @param time [Object] a `Time`, `DateTime` or `Timestamp`.
+    # @return [String] the abbreviation of this {Timezone}.
+    # @raise [ArgumentError] if `format` or `time` is `nil`.
+    # @raise [ArgumentError] if `time` is a {Timestamp} with an unspecified UTC
+    #   offset.
+    def abbr(time = Time.now)
+      period_for(time).abbreviation
+    end
+
     # Compares this {Timezone} with another based on the {identifier}.
     #
     # @param tz [Object] an `Object` to compare this {Timezone} with.

--- a/test/tc_timezone.rb
+++ b/test/tc_timezone.rb
@@ -1804,6 +1804,15 @@ class TCTimezone < Minitest::Test
     assert_equal('#<TCTimezone::TestTimezone: Europe/London>', tz.inspect)
   end
 
+  def test_abbreviation
+    tz = Timezone.get('Europe/London')
+    assert_equal('GMT', tz.abbr(Time.utc(2017,1,15,15,50,0)))
+    assert_equal('BST', tz.abbr(Time.utc(2017,7,15,15,50,0)))
+    tz = Timezone.get('America/New_York')
+    assert_equal('EST', tz.abbr(Time.utc(2017,1,15,15,50,0)))
+    assert_equal('EDT', tz.abbr(Time.utc(2017,7,15,15,50,0)))
+  end
+
   private
 
   def assert_raises_unknown_timezone(&block)


### PR DESCRIPTION
I want to suggest `TZInfo::Timezone#abbr` which returns the abbreviation of the `Timezone` at the given time.

Currently, `TZInfo::Timezone` provides a way to get an abbreviated name as `tz.strftime("%Z")`, but it feels a roundabout route.