### PR TITLE
Define =~ method on Timezone identifier

### DIFF
--- a/lib/tzinfo/timezone.rb
+++ b/lib/tzinfo/timezone.rb
@@ -1119,6 +1119,14 @@ module TZInfo
       identifier.hash
     end
 
+    # @param regex [Regex] a `Regex` to match against the identifier of this
+    #  {Timezone}.
+    # @return [Integer, nil] `Integer` offset of the match on the identifier,
+    # otherwise `nil` if there is no match.
+    def =~(regex)
+      regex =~ identifier
+    end
+
     # Returns a serialized representation of this {Timezone}. This method is
     # called when using `Marshal.dump` with an instance of {Timezone}.
     #

--- a/test/tc_timezone.rb
+++ b/test/tc_timezone.rb
@@ -1700,6 +1700,12 @@ class TCTimezone < Minitest::Test
     assert_equal('America/New_York'.hash, TestTimezone.new('America/New_York').hash)
   end
 
+  define_method("test_=~_operator_matches_against_identifier") do
+    tz = TestTimezone.new('Europe/London')
+    assert_equal(0, tz  =~ /Europe\/London/)
+    assert_nil(tz =~ /America\/NewYork/)
+  end
+
   def test_marshal_data
     tz = Timezone.get('Europe/London')
     marshalled_tz = Marshal.load(Marshal.dump(tz))


### PR DESCRIPTION
It's useful to match agains a timezones identifier using regex.
e.g. this rails issue: https://github.com/rails/rails/issues/35973 this
commit overrides the =~ operator to the Timezone class so that clients
can match against its identifier.

