### PR TITLE
fix SecurityError: Insecure operation - gem_original_require`

### DIFF
--- a/lib/tzinfo/data_sources/ruby_data_source.rb
+++ b/lib/tzinfo/data_sources/ruby_data_source.rb
@@ -48,7 +48,7 @@ module TZInfo
           data_file = File.join('', 'tzinfo', 'data.rb')
           path = $".reverse_each.detect {|p| p.end_with?(data_file) }
           if path
-            @base_path = File.join(File.dirname(path), 'data')
+            @base_path = File.join(File.dirname(path), 'data').untaint
           else
             @base_path = 'tzinfo/data'
           end


### PR DESCRIPTION
I noticed that test on Ruby 2.7 failed, because raised `SecurityError`.

https://travis-ci.org/tzinfo/tzinfo/jobs/526594506
```
  1) Error:
TCTimezone#test_get_tainted_and_frozen_not_previously_loaded:
SecurityError: Insecure operation - require
    /home/travis/build/tzinfo/tzinfo/lib/tzinfo/data_sources/ruby_data_source.rb:129:in `require'
    /home/travis/build/tzinfo/tzinfo/lib/tzinfo/data_sources/ruby_data_source.rb:129:in `require_data'
    /home/travis/build/tzinfo/tzinfo/lib/tzinfo/data_sources/ruby_data_source.rb:115:in `require_definition'
    /home/travis/build/tzinfo/tzinfo/lib/tzinfo/data_sources/ruby_data_source.rb:93:in `load_timezone_info'
    /home/travis/build/tzinfo/tzinfo/lib/tzinfo/data_source.rb:195:in `get_timezone_info'
    /home/travis/build/tzinfo/tzinfo/lib/tzinfo/timezone.rb:128:in `get'
    /home/travis/build/tzinfo/tzinfo/test/tc_timezone.rb:291:in `block in test_get_tainted_and_frozen_not_previously_loaded'
    /home/travis/build/tzinfo/tzinfo/test/test_utils.rb:311:in `block in safe_test'
```