### PR TITLE
The taint mechanism will be deprecated in Ruby 2.7

### DIFF
--- a/lib/tzinfo/data_sources/zoneinfo_data_source.rb
+++ b/lib/tzinfo/data_sources/zoneinfo_data_source.rb
@@ -421,7 +421,6 @@ module TZInfo
           end
 
           unless entry =~ /\./ || exclude.include?(entry)
-            entry.untaint
             path = dir + [entry]
             full_path = File.join(@zoneinfo_dir, *path)
 

--- a/lib/tzinfo/data_sources/zoneinfo_reader.rb
+++ b/lib/tzinfo/data_sources/zoneinfo_reader.rb
@@ -253,7 +253,7 @@ module TZInfo
           abbrev_end = abbrev.index("\0", abbrev_start)
           raise InvalidZoneinfoFile, "Missing abbreviation null terminator in file '#{file.path}'." unless abbrev_end
 
-          abbr = @string_deduper.dedupe(abbrev[abbrev_start...abbrev_end].force_encoding(Encoding::UTF_8).untaint)
+          abbr = @string_deduper.dedupe(abbrev[abbrev_start...abbrev_end].force_encoding(Encoding::UTF_8))
 
           TimezoneOffset.new(base_utc_offset, std_offset, abbr)
         end

--- a/test/data_sources/tc_ruby_data_source.rb
+++ b/test/data_sources/tc_ruby_data_source.rb
@@ -117,19 +117,9 @@ module DataSources
       assert_equal('Etc/GMT-1', info.identifier)
     end
 
-    def test_load_timezone_info_tainted
+    def test_load_timezone_info_frozen
       safe_test do
-        identifier = 'Europe/Amsterdam'.dup.taint
-        assert(identifier.tainted?)
-        info = @data_source.send(:load_timezone_info, identifier)
-        assert_equal('Europe/Amsterdam', info.identifier)
-        assert(identifier.tainted?)
-      end
-    end
-
-    def test_load_timezone_info_tainted_and_frozen
-      safe_test do
-        info = @data_source.send(:load_timezone_info, 'Europe/Amsterdam'.dup.taint.freeze)
+        info = @data_source.send(:load_timezone_info, 'Europe/Amsterdam'.dup.freeze)
         assert_equal('Europe/Amsterdam', info.identifier)
       end
     end
@@ -226,19 +216,9 @@ module DataSources
       assert_match(/\bgb\b/, error.message)
     end
 
-    def test_load_country_info_tainted
+    def test_load_country_info_frozen
       safe_test do
-        code = 'NL'.dup.taint
-        assert(code.tainted?)
-        info = @data_source.send(:load_country_info, code)
-        assert_equal('NL', info.code)
-        assert(code.tainted?)
-      end
-    end
-
-    def test_load_country_info_tainted_and_frozen
-      safe_test do
-        info = @data_source.send(:load_country_info, 'NL'.dup.taint.freeze)
+        info = @data_source.send(:load_country_info, 'NL'.dup.freeze)
         assert_equal('NL', info.code)
       end
     end

--- a/test/data_sources/tc_zoneinfo_data_source.rb
+++ b/test/data_sources/tc_zoneinfo_data_source.rb
@@ -10,7 +10,7 @@ include TZInfo
 
 module DataSources
   class TCZoneinfoDataSource < Minitest::Test
-    ZONEINFO_DIR = File.expand_path(File.join(File.dirname(__FILE__), '..', 'zoneinfo')).untaint
+    ZONEINFO_DIR = File.expand_path(File.join(File.dirname(__FILE__), '..', 'zoneinfo'))
 
     def setup
       @orig_search_path = ZoneinfoDataSource.search_path.clone
@@ -777,36 +777,11 @@ module DataSources
       end
     end
 
-    def test_load_timezone_info_tainted
+    def test_load_timezone_info_frozen
       safe_test do
-        identifier = 'Europe/Amsterdam'.dup.taint
-        assert(identifier.tainted?)
-        info = @data_source.send(:load_timezone_info, identifier)
-        assert_equal('Europe/Amsterdam', info.identifier)
-        assert(identifier.tainted?)
-      end
-    end
-
-    def test_load_timezone_info_tainted_and_frozen
-      safe_test do
-        info = @data_source.send(:load_timezone_info, 'Europe/Amsterdam'.dup.taint.freeze)
+        info = @data_source.send(:load_timezone_info, 'Europe/Amsterdam'.dup.freeze)
         assert_equal('Europe/Amsterdam', info.identifier)
       end
-    end
-
-    def test_load_timezone_info_tainted_zoneinfo_dir_safe_mode
-      safe_test(unavailable: :skip) do
-        assert_raises(SecurityError) do
-          ZoneinfoDataSource.new(@data_source.zoneinfo_dir.dup.taint)
-        end
-      end
-    end
-
-    def test_load_timezone_info_tainted_zoneinfo_dir
-      data_source = ZoneinfoDataSource.new(@data_source.zoneinfo_dir.dup.taint)
-      info = data_source.send(:load_timezone_info, 'Europe/London')
-      assert_kind_of(TransitionsDataTimezoneInfo, info)
-      assert_equal('Europe/London', info.identifier)
     end
 
     def test_load_timezone_info_returned_identifier_frozen
@@ -839,7 +814,6 @@ module DataSources
       entries = Dir.glob(File.join(directory, '**', '*'))
 
       entries = entries.select do |file|
-        file.untaint
         File.file?(file)
       end
 
@@ -1117,16 +1091,6 @@ module DataSources
       end
 
       assert_match(/\bgb\b/, error.message)
-    end
-
-    def test_load_country_info_tainted
-      safe_test do
-        code = 'NL'.dup.taint
-        assert(code.tainted?)
-        info = @data_source.send(:load_country_info, code)
-        assert_equal('NL', info.code)
-        assert(code.tainted?)
-      end
     end
 
     def test_load_country_info_returned_strings_frozen

--- a/test/data_sources/tc_zoneinfo_reader.rb
+++ b/test/data_sources/tc_zoneinfo_reader.rb
@@ -1210,34 +1210,6 @@ module DataSources
       end
     end
 
-    def test_read_untainted_in_safe_mode
-      offsets = [{gmtoff: -12094, isdst: false, abbrev: 'LT'}]
-
-      o0 = TimezoneOffset.new(-12094, 0, 'LT')
-
-      tzif_test(offsets, []) do |path, format|
-        # Temp file path is tainted with Ruby >= 2.3.0. Untaint for this test.
-        path.untaint
-
-        safe_test do
-          assert_equal(o0, @reader.read(path))
-        end
-      end
-    end
-
-    def test_read_tainted_in_safe_mode
-      offsets = [{gmtoff: -12094, isdst: false, abbrev: 'LT'}]
-
-      tzif_test(offsets, []) do |path, format|
-        # Temp file path is only tainted with Ruby >= 2.3.0. Taint for this test.
-        path.taint
-
-        safe_test(unavailable: :skip) do
-          assert_raises(SecurityError) { @reader.read(path) }
-        end
-      end
-    end
-
     def test_read_encoding
       # tzfile.5 doesn't specify an encoding, but the source data is in ASCII.
       # ZoneinfoTimezoneInfo will load as UTF-8 (a superset of ASCII).

--- a/test/tc_country.rb
+++ b/test/tc_country.rb
@@ -43,40 +43,18 @@ class TCCountry < Minitest::Test
     assert_match(/\bnil\b/, error.message)
   end
 
-  def test_get_tainted_loaded
+  def test_get_frozen_loaded
     Country.get('GB')
 
     safe_test do
-      code = 'GB'.dup.taint
-      assert(code.tainted?)
-      country = Country.get(code)
-      assert_equal('GB', country.code)
-      assert(code.tainted?)
-    end
-  end
-
-  def test_get_tainted_and_frozen_loaded
-    Country.get('GB')
-
-    safe_test do
-      country = Country.get('GB'.dup.taint.freeze)
+      country = Country.get('GB'.dup.freeze)
       assert_equal('GB', country.code)
     end
   end
 
-  def test_get_tainted_not_previously_loaded
+  def test_get_frozen_not_previously_loaded
     safe_test do
-      code = 'GB'.dup.taint
-      assert(code.tainted?)
-      country = Country.get(code)
-      assert_equal('GB', country.code)
-      assert(code.tainted?)
-    end
-  end
-
-  def test_get_tainted_and_frozen_not_previously_loaded
-    safe_test do
-      country = Country.get('GB'.dup.taint.freeze)
+      country = Country.get('GB'.dup.freeze)
       assert_equal('GB', country.code)
     end
   end

--- a/test/tc_timezone.rb
+++ b/test/tc_timezone.rb
@@ -255,40 +255,18 @@ class TCTimezone < Minitest::Test
     end
   end
 
-  def test_get_tainted_loaded
+  def test_get_frozen_loaded
     Timezone.get('Europe/Andorra')
 
     safe_test do
-      identifier = 'Europe/Andorra'.dup.taint
-      assert(identifier.tainted?)
-      tz = Timezone.get(identifier)
-      assert_equal('Europe/Andorra', tz.identifier)
-      assert(identifier.tainted?)
-    end
-  end
-
-  def test_get_tainted_and_frozen_loaded
-    Timezone.get('Europe/Andorra')
-
-    safe_test do
-      tz = Timezone.get('Europe/Andorra'.dup.taint.freeze)
+      tz = Timezone.get('Europe/Andorra'.dup.freeze)
       assert_equal('Europe/Andorra', tz.identifier)
     end
   end
 
-  def test_get_tainted_not_previously_loaded
+  def test_get_frozen_not_previously_loaded
     safe_test do
-      identifier = 'Europe/Andorra'.dup.taint
-      assert(identifier.tainted?)
-      tz = Timezone.get(identifier)
-      assert_equal('Europe/Andorra', tz.identifier)
-      assert(identifier.tainted?)
-    end
-  end
-
-  def test_get_tainted_and_frozen_not_previously_loaded
-    safe_test do
-      tz = Timezone.get('Europe/Amsterdam'.dup.taint.freeze)
+      tz = Timezone.get('Europe/Amsterdam'.dup.freeze)
       assert_equal('Europe/Amsterdam', tz.identifier)
     end
   end

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -49,7 +49,7 @@ if COVERAGE_ENABLED && defined?(COVERAGE_TYPE)
   end
 end
 
-TESTS_DIR = File.expand_path(File.dirname(__FILE__)).untaint
+TESTS_DIR = File.expand_path(File.dirname(__FILE__))
 TZINFO_TEST_ZONEINFO_DIR = File.join(TESTS_DIR, 'zoneinfo')
 
 unless defined? TZINFO_TEST_DATA_DIR
@@ -286,8 +286,8 @@ module TestUtils
 
     # Runs a test with safe mode enabled ($SAFE = 1).
     def safe_test(options = {})
-      # JRuby, Rubinius and TruffleRuby don't support SAFE levels.
-      available = !%w(jruby rbx truffleruby).include?(RUBY_ENGINE)
+      # Ruby >= 2.7, JRuby, Rubinius and TruffleRuby don't support SAFE levels.
+      available = !%w(ruby jruby rbx truffleruby).include?(RUBY_ENGINE)
 
       if !available && options[:unavailable] == :skip
         skip('JRuby, Rubinius and TruffleRuby don\'t support SAFE levels')

--- a/test/ts_all_zoneinfo.rb
+++ b/test/ts_all_zoneinfo.rb
@@ -7,6 +7,6 @@ require_relative 'test_utils'
 
 # Use a zoneinfo directory containing files needed by the tests.
 # The symlinks in this directory are set up in test_utils.rb.
-TZInfo::DataSource.set(:zoneinfo, File.join(File.expand_path(File.dirname(__FILE__)), 'zoneinfo').untaint)
+TZInfo::DataSource.set(:zoneinfo, File.join(File.expand_path(File.dirname(__FILE__)), 'zoneinfo'))
 
 require_relative 'ts_all'

--- a/test/tzinfo-data2/tzinfo/data.rb
+++ b/test/tzinfo-data2/tzinfo/data.rb
@@ -5,7 +5,7 @@ module TZInfo
   # Top level module for TZInfo::Data.
   module Data
     # The directory containing the TZInfo::Data files.
-    LOCATION = File.dirname(File.dirname(__FILE__)).untaint.freeze
+    LOCATION = File.dirname(File.dirname(__FILE__)).freeze
   end
 end
 

--- a/tzinfo.gemspec
+++ b/tzinfo.gemspec
@@ -1,4 +1,4 @@
-require File.join(File.expand_path(File.dirname(__FILE__)), 'lib', 'tzinfo', 'version').untaint
+require File.join(File.expand_path(File.dirname(__FILE__)), 'lib', 'tzinfo', 'version')
 
 Gem::Specification.new do |s|
   s.name = 'tzinfo'


### PR DESCRIPTION
The Ruby core team decided to deprecate the taint mechanism in Ruby 2.7
and will remove that in Ruby 3.

https://bugs.ruby-lang.org/issues/16131
https://github.com/ruby/ruby/pull/2476

In Ruby 2.7, `Object#{taint,untaint,trust,untrust}` and related
functions in the C-API no longer have an effect (all objects are always
considered untainted), and are now warned deprecation message.

https://buildkite.com/rails/rails/builds/65069#dddcc2a1-a23c-4bc2-9eaf-351295244d1f/991-993