### PR TITLE
No-op `Object#untaint` to suppress deprecation warning in Ruby 2.7

### DIFF
--- a/lib/tzinfo/data_sources/zoneinfo_data_source.rb
+++ b/lib/tzinfo/data_sources/zoneinfo_data_source.rb
@@ -1,6 +1,11 @@
 # encoding: UTF-8
 # frozen_string_literal: true
 
+if RUBY_ENGINE == 'ruby' && RUBY_VERSION >= '2.7'
+  require 'tzinfo/untaint_ext'
+  using TZInfo::UntaintExt
+end
+
 module TZInfo
   module DataSources
     # An {InvalidZoneinfoDirectory} exception is raised if {ZoneinfoDataSource}

--- a/lib/tzinfo/data_sources/zoneinfo_reader.rb
+++ b/lib/tzinfo/data_sources/zoneinfo_reader.rb
@@ -1,6 +1,11 @@
 # encoding: UTF-8
 # frozen_string_literal: true
 
+if RUBY_ENGINE == 'ruby' && RUBY_VERSION >= '2.7'
+  require 'tzinfo/untaint_ext'
+  using TZInfo::UntaintExt
+end
+
 module TZInfo
   module DataSources
     # An {InvalidZoneinfoFile} exception is raised if an attempt is made to load

--- a/lib/tzinfo/untaint_ext.rb
+++ b/lib/tzinfo/untaint_ext.rb
@@ -1,0 +1,12 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+module TZInfo
+  module UntaintExt # :nodoc:
+    refine Object do
+      def untaint
+        self
+      end
+    end
+  end
+end

--- a/test/data_sources/tc_zoneinfo_reader.rb
+++ b/test/data_sources/tc_zoneinfo_reader.rb
@@ -1216,10 +1216,10 @@ module DataSources
       o0 = TimezoneOffset.new(-12094, 0, 'LT')
 
       tzif_test(offsets, []) do |path, format|
-        # Temp file path is tainted with Ruby >= 2.3.0. Untaint for this test.
-        path.untaint
-
         safe_test do
+          # Temp file path is tainted with Ruby >= 2.3.0. Untaint for this test.
+          path.untaint
+
           assert_equal(o0, @reader.read(path))
         end
       end
@@ -1229,10 +1229,10 @@ module DataSources
       offsets = [{gmtoff: -12094, isdst: false, abbrev: 'LT'}]
 
       tzif_test(offsets, []) do |path, format|
-        # Temp file path is only tainted with Ruby >= 2.3.0. Taint for this test.
-        path.taint
-
         safe_test(unavailable: :skip) do
+          # Temp file path is only tainted with Ruby >= 2.3.0. Taint for this test.
+          path.taint
+
           assert_raises(SecurityError) { @reader.read(path) }
         end
       end

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -289,8 +289,8 @@ module TestUtils
       # JRuby, Rubinius and TruffleRuby don't support SAFE levels.
       available = !%w(jruby rbx truffleruby).include?(RUBY_ENGINE)
 
-      if !available && options[:unavailable] == :skip
-        skip('JRuby, Rubinius and TruffleRuby don\'t support SAFE levels')
+      if !available && options[:unavailable] == :skip || RUBY_ENGINE == 'ruby' && RUBY_VERSION >= '2.7'
+        skip('Ruby >= 2.7, JRuby, Rubinius and TruffleRuby don\'t support SAFE levels')
       end
 
       thread = Thread.new do


### PR DESCRIPTION
The Ruby core team decided to deprecate the taint mechanism in Ruby 2.7
and will remove that in Ruby 3.

https://bugs.ruby-lang.org/issues/16131
https://github.com/ruby/ruby/pull/2476

This is an alternative of #108.