### PR TITLE
Fix Ruby 2.7 warnings for the 1.2 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ rvm:
   - 2.3.7
   - 2.4.4
   - 2.5.1
+  - 2.7.0
   - ruby-head
   - jruby-18mode
   - jruby-1.7.27

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source "https://rubygems.org"
 gemspec
 
 group :test do
-  gem 'rake', '~> 10.5'
+  gem 'rake', '~> 13.0'
   gem 'minitest', '~> 5.0'
 end

--- a/lib/tzinfo.rb
+++ b/lib/tzinfo.rb
@@ -1,5 +1,6 @@
 # Top level module for TZInfo.
 module TZInfo
+  TAINT_SUPPORT = RUBY_VERSION <= '2.7'
 end
 
 require 'tzinfo/ruby_core_support'

--- a/lib/tzinfo/ruby_core_support.rb
+++ b/lib/tzinfo/ruby_core_support.rb
@@ -138,8 +138,11 @@ module TZInfo
         File.open(file_name, mode, &block)
       end
     else
-      def self.open_file(file_name, mode, opts, &block)
-        File.open(file_name, mode, opts, &block)
+      class << self
+        def open_file(file_name, mode, opts, &block)
+          ::File.open(file_name, mode, opts, &block)
+        end
+        ruby2_keywords :open_file if respond_to?(:ruby2_keywords, true)
       end
     end
   end

--- a/lib/tzinfo/ruby_data_source.rb
+++ b/lib/tzinfo/ruby_data_source.rb
@@ -26,7 +26,7 @@ module TZInfo
       # Untaint identifier after it has been reassigned to a new string. We
       # don't want to modify the original identifier. identifier may also be 
       # frozen and therefore cannot be untainted.
-      identifier.untaint
+      identifier.untaint if TAINT_SUPPORT
       
       identifier = identifier.split('/')
       begin

--- a/lib/tzinfo/zoneinfo_data_source.rb
+++ b/lib/tzinfo/zoneinfo_data_source.rb
@@ -197,7 +197,7 @@ module TZInfo
           # Untaint path rather than identifier. We don't want to modify 
           # identifier. identifier may also be frozen and therefore cannot be
           # untainted.
-          path.untaint
+          path.untaint if TAINT_SUPPORT
           
           begin
             ZoneinfoTimezoneInfo.new(identifier, path)
@@ -364,7 +364,7 @@ module TZInfo
     def enum_timezones(dir, exclude = [], &block)
       Dir.foreach(dir ? File.join(@zoneinfo_dir, dir) : @zoneinfo_dir) do |entry|
         unless entry =~ /\./ || exclude.include?(entry)
-          entry.untaint
+          entry.untaint if TAINT_SUPPORT
           path = dir ? File.join(dir, entry) : entry
           full_path = File.join(@zoneinfo_dir, path)
  

--- a/lib/tzinfo/zoneinfo_timezone_info.rb
+++ b/lib/tzinfo/zoneinfo_timezone_info.rb
@@ -160,7 +160,7 @@ module TZInfo
           std_offset = 0
         end
 
-        offset index, utc_offset, std_offset, offset[:abbr].untaint.to_sym
+        offset index, utc_offset, std_offset, offset[:abbr].to_sym
       end
       
       # Parses a zoneinfo file and intializes the DataTimezoneInfo structures.

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -1,4 +1,7 @@
-TESTS_DIR = File.expand_path(File.dirname(__FILE__))
+test_dir = File.expand_path(File.dirname(__FILE__))
+test_dir.untaint if RUBY_VERSION <= '2.7'
+TESTS_DIR = test_dir
+
 TZINFO_LIB_DIR = File.expand_path(File.join(TESTS_DIR, '..', 'lib'))
 TZINFO_TEST_DATA_DIR = File.join(TESTS_DIR, 'tzinfo-data')
 TZINFO_TEST_ZONEINFO_DIR = File.join(TESTS_DIR, 'zoneinfo')

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -1,4 +1,4 @@
-TESTS_DIR = File.expand_path(File.dirname(__FILE__)).untaint
+TESTS_DIR = File.expand_path(File.dirname(__FILE__))
 TZINFO_LIB_DIR = File.expand_path(File.join(TESTS_DIR, '..', 'lib'))
 TZINFO_TEST_DATA_DIR = File.join(TESTS_DIR, 'tzinfo-data')
 TZINFO_TEST_ZONEINFO_DIR = File.join(TESTS_DIR, 'zoneinfo')
@@ -56,7 +56,7 @@ module Kernel
   
   def safe_test(options = {})
     # JRuby and Rubinus don't support SAFE levels.
-    available = !(defined?(RUBY_ENGINE) && %w(jruby rbx).include?(RUBY_ENGINE))
+    available = !(defined?(RUBY_ENGINE) && %w(jruby rbx).include?(RUBY_ENGINE)) && RUBY_VERSION < '2.7'
    
     if available || options[:unavailable] != :skip
       thread = Thread.new do


### PR DESCRIPTION
Most of these have been fixed on `master`, however they were only pusblish in the 2.0 release.

The issue is that I'm trying to fix warnings for the stable versions of Rails, so bumping tzinfo from a major version to another is complicated.

It would be much simpler if a `1.x` compatible with Ruby 2.7 was released.

cc @kamipo @rafaelfranca @Edouard-Chin