### PR TITLE
`$VERBOSE = false` won't be worked since `rb_warning` is changed to `rb_warn`

### DIFF
--- a/lib/tzinfo/ruby_core_support.rb
+++ b/lib/tzinfo/ruby_core_support.rb
@@ -156,21 +156,15 @@ module TZInfo
     # Object#untaint is a deprecated no-op in Ruby >= 2.7 and will be removed in
     # 3.0. Add a refinement to either silence the warning, or supply the method
     # if needed.
-    old_verbose = $VERBOSE
-    $VERBOSE = false
-    begin
-      o = Object.new
-      if [:taint, :untaint, :tainted?].none? {|m| o.respond_to?(m) } || !o.taint.tainted?
-        module UntaintExt
-          refine Object do
-            def untaint
-              self
-            end
+    o = Object.new
+    if [:taint, :untaint, :tainted?].none? {|m| o.respond_to?(m) } || RUBY_VERSION >= '2.7'
+      module UntaintExt
+        refine Object do
+          def untaint
+            self
           end
         end
       end
-    ensure
-      $VERBOSE = old_verbose
     end
   end
 end


### PR DESCRIPTION
Ref https://github.com/ruby/ruby/pull/2856.