### PR TITLE
Fix taint warnings on Ruby master

### DIFF
--- a/lib/tzinfo.rb
+++ b/lib/tzinfo.rb
@@ -8,13 +8,9 @@ end
 # Object#untaint is a deprecated no-op in Ruby >= 2.7 and will be removed in
 # 3.0. Add a refinement to either silence the warning, or supply the method if
 # needed.
-old_verbose = $VERBOSE
-$VERBOSE = false
-begin
-  o = Object.new
-  require_relative 'tzinfo/untaint_ext' if [:taint, :untaint, :tainted?].none? {|m| o.respond_to?(m) } || !o.taint.tainted?
-ensure
-  $VERBOSE = old_verbose
+o = Object.new
+if [:taint, :untaint, :tainted?].none? {|m| o.respond_to?(m) } || RUBY_VERSION >= '2.7'
+  require_relative 'tzinfo/untaint_ext'
 end
 
 require_relative 'tzinfo/version'

--- a/test/tzinfo-data2/tzinfo/data.rb
+++ b/test/tzinfo-data2/tzinfo/data.rb
@@ -6,12 +6,8 @@ module TZInfo
   module Data
     location = File.dirname(File.dirname(__FILE__))
 
-    old_verbose = $VERBOSE
-    $VERBOSE = false
-    begin
-      location.untaint if location.respond_to?(:untaint)
-    ensure
-      $VERBOSE = old_verbose
+    if location.respond_to?(:untaint) && RUBY_VERSION < '2.7'
+      location.untaint
     end
 
     # The directory containing the TZInfo::Data files.


### PR DESCRIPTION
`$VERBOSE = false` won't be worked since `rb_warning` is changed to
`rb_warn`.

Ref https://github.com/ruby/ruby/pull/2856.