### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/tzinfo.gemspec
+++ b/tzinfo.gemspec
@@ -9,6 +9,15 @@ Gem::Specification.new do |s|
   s.email = 'phil.ross@gmail.com'
   s.homepage = 'https://tzinfo.github.io'
   s.license = 'MIT'
+  if s.respond_to? :metadata=
+    s.metadata = {
+      'bug_tracker_uri' => 'https://github.com/tzinfo/tzinfo/issues',
+      'changelog_uri' => 'https://github.com/tzinfo/tzinfo/blob/master/CHANGES.md',
+      'documentation_uri' => "https://rubydoc.info/gems/#{s.name}/#{s.version}",
+      'homepage_uri' => s.homepage,
+      'source_code_uri' => "https://github.com/tzinfo/tzinfo/tree/v#{s.version}"
+    }
+  end
   s.files = %w(CHANGES.md LICENSE README.md .yardopts) + Dir['lib/**/*.rb']
   s.platform = Gem::Platform::RUBY
   s.require_path = 'lib'


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `homepage_uri`, and `source_code_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/tzinfo), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.