### PR TITLE
Implement TZInfo.eager_load!

### DIFF
--- a/lib/tzinfo.rb
+++ b/lib/tzinfo.rb
@@ -3,6 +3,15 @@
 
 # The top level module for TZInfo.
 module TZInfo
+  class << self
+    # Force all timezone data to be loaded immediately. This is desirable in
+    # production environments to improve Copy-on-Write performance and to
+    # avoid flushing the constant cache every time a new timezone is accessed.
+    def eager_load!
+      Timezone.all.each(&:eager_load!)
+      nil
+    end
+  end
 end
 
 # Object#untaint is a deprecated no-op in Ruby >= 2.7 and will be removed in

--- a/lib/tzinfo/timezone_proxy.rb
+++ b/lib/tzinfo/timezone_proxy.rb
@@ -72,6 +72,11 @@ module TZInfo
       TimezoneProxy.new(data)
     end
 
+    def eager_load!
+      real_timezone
+      nil
+    end
+
     private
 
     # Returns the real {Timezone} instance being proxied.


### PR DESCRIPTION
We recently instrumented our application to locate the source of the constant cache bumps we were seeing, and tzinfo came up as one of the sources.

In production environment, it's detrimental for performance to use lazy loading. It's much better to load everything upfront as part of boot.