### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ TZInfo requires a source of time zone data. There are two options:
 By default, TZInfo will attempt to use TZInfo::Data. If TZInfo::Data is not
 available (i.e. if `require 'tzinfo/data'` fails), then TZInfo will search for a
 zoneinfo directory instead (using the search path specified by
-`TZInfo::ZoneinfoDataSource::DEFAULT_SEARCH_PATH`).
+`TZInfo::DataSources::ZoneinfoDataSource::search_path`).
 
 If no data source can be found, a `TZInfo::DataSourceNotFound` exception will be
 raised when TZInfo is used. Further information is available


### PR DESCRIPTION
## Description

The goal of this PR is to fix the command present in the README.md for showing the tzinfo search path. 

`TZInfo::ZoneinfoDataSource::DEFAULT_SEARCH_PATH` throws an uninitialized constant error