### PR TITLE
Add support for loading zoneinfo from ENV['TZDIR']

### DIFF
--- a/lib/tzinfo/data_sources/zoneinfo_data_source.rb
+++ b/lib/tzinfo/data_sources/zoneinfo_data_source.rb
@@ -67,7 +67,12 @@ module TZInfo
     # inaccurate.
     class ZoneinfoDataSource < DataSource
       # The default value of {ZoneinfoDataSource.search_path}.
-      DEFAULT_SEARCH_PATH = ['/usr/share/zoneinfo', '/usr/share/lib/zoneinfo', '/etc/zoneinfo'].freeze
+      DEFAULT_SEARCH_PATH = [
+        ENV['TZDIR'],
+        '/usr/share/zoneinfo',
+        '/usr/share/lib/zoneinfo',
+        '/etc/zoneinfo'
+      ].compact.uniq.freeze
       private_constant :DEFAULT_SEARCH_PATH
 
       # The default value of {ZoneinfoDataSource.alternate_iso3166_tab_search_path}.


### PR DESCRIPTION
I ran into some issues running tzinfo in a nix install, where zoneinfo was installed to /nix/store/49c4bxmqq5y53y38v7amdcs05d061wvr-tzdata-2025b/share/zoneinfo and so not findable by tzinfo by default.

TZDIR seems to be a common convention for specifying the zoneinfo location - what about something along these lines?

I've not yet added tests... they're a little tricky if we stick with reading ENV as soon as zoneinfo_data_source is loaded.
An alternative might be something like this - 

```diff
 class ZoneInfoDataSource < DataSource
   class << self
     def search_path
-       @@search_path
+       ENV.fetch("TZDIR", @@search_path)
     end
```

which would allow tests to mess with ENV and check the results... but then `ZoneInfoDataSource.search_path= foo` has no effect if TZDIR is set. Maybe that's ok...?

Thought I'd open this to see if you have any thoughts before I go any further.