### PR TITLE
Revert back to requiring only `concurrent/map`

### DIFF
--- a/lib/tzinfo/data_source.rb
+++ b/lib/tzinfo/data_source.rb
@@ -1,7 +1,7 @@
 # encoding: UTF-8
 # frozen_string_literal: true
 
-require 'concurrent'
+require 'concurrent/map'
 require 'thread'
 
 module TZInfo

--- a/lib/tzinfo/string_deduper.rb
+++ b/lib/tzinfo/string_deduper.rb
@@ -1,7 +1,7 @@
 # encoding: UTF-8
 # frozen_string_literal: true
 
-require 'concurrent'
+require 'concurrent/map'
 
 module TZInfo
   # Maintains a pool of `String` instances. The {#dedupe} method will return

--- a/test/tc_string_deduper.rb
+++ b/test/tc_string_deduper.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require_relative 'test_utils'
-require 'concurrent'
+require 'concurrent/map'
 
 class TCStringDeduper < Minitest::Test
   include TZInfo


### PR DESCRIPTION
Ref https://github.com/rails/rails/issues/56824

This reverts commit f24b78fedc1fe83db37ee4685e8b85e47eb3b192.

concurrent-ruby now [explicitly][1] supports requiring individual components, so we can greatly reduce the footprint of tzinfo's requires by only requring concurrent/map. The current `require` is ~6% of time running `bin/rails app:update` in a fresh Rails application.

[1]: https://github.com/ruby-concurrency/concurrent-ruby/issues/934